### PR TITLE
feat: add Codex capture hook installer support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Unreleased
+
+- Add Codex as an optional `capture-hooks` target for ambient Stop-hook capture.
+- Document Claude Code and Codex setup paths for capture hooks and MCP wiring.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ I built this for myself. It worked. I've been running it daily for months, and n
 - macOS (Apple Silicon tested)
 - Python 3.11 or 3.12
 - Node.js 18+
-- [Claude Code](https://docs.claude.com/en/docs/claude-code/overview) as the MCP host
+- [Claude Code](https://docs.claude.com/en/docs/claude-code/overview) or Codex CLI as the MCP host
 - ~500 MB free disk
 
 Windows and Linux not supported yet but I'm working on it.
@@ -82,9 +82,35 @@ export PATH="$HOME/.local/bin:$PATH"  # add to ~/.zshrc or ~/.bashrc
 iai-mcp --version
 ```
 
-### Install the Stop hook
+### Install the capture hook
 
 This is what makes capture ambient. Without it you'd have to save memories by hand.
+
+Claude Code is the default target:
+
+```bash
+iai-mcp capture-hooks install
+```
+
+For Codex:
+
+```bash
+iai-mcp capture-hooks install --target codex
+```
+
+To install both:
+
+```bash
+iai-mcp capture-hooks install --target all
+```
+
+Check status with:
+
+```bash
+iai-mcp capture-hooks status --target all
+```
+
+Manual Claude Code setup is equivalent to:
 
 ```bash
 mkdir -p ~/.claude/hooks
@@ -112,7 +138,9 @@ Register in `~/.claude/settings.json`:
 }
 ```
 
-### Connect Claude
+### Connect your MCP host
+
+Claude Code:
 
 ```bash
 claude mcp add iai-mcp -- node "$(pwd)/mcp-wrapper/dist/index.js"
@@ -134,6 +162,24 @@ Or edit `~/.claude.json` directly:
 Use the absolute path. `~` and `$HOME` won't expand here.
 
 For Claude Desktop (untested), edit `~/Library/Application Support/Claude/claude_desktop_config.json`.
+
+Codex CLI:
+
+```toml
+[mcp_servers.iai-mcp]
+command = "node"
+args = ["/absolute/path/to/iai-mcp/mcp-wrapper/dist/index.js"]
+
+[mcp_servers.iai-mcp.env]
+IAI_MCP_PYTHON = "/absolute/path/to/iai-mcp/.venv/bin/python"
+IAI_MCP_STORE = "/Users/you/.iai-mcp"
+TRANSFORMERS_VERBOSITY = "error"
+TOKENIZERS_PARALLELISM = "false"
+```
+
+Codex hooks are stable in current Codex CLI builds. If hooks are disabled by
+local policy or an older install, enable `[features].hooks = true` in
+`~/.codex/config.toml`.
 
 ### Verify
 
@@ -300,6 +346,8 @@ Limitations worth knowing about:
 Claude Code is the primary host, validated in daily use.
 
 Claude Desktop should work (uses `claude_desktop_config.json` instead of `~/.claude.json`) but hasn't been tested end to end.
+
+Codex CLI supports the MCP wrapper and ambient capture through a `Stop` hook.
 
 Other MCP-over-stdio hosts speak the same protocol and should work in principle. Not tested.
 

--- a/deploy/hooks/iai-mcp-codex-session-capture.sh
+++ b/deploy/hooks/iai-mcp-codex-session-capture.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# IAI-MCP Codex Stop hook — ambient WRITE-side capture.
+#
+# Reads Codex's Stop-hook JSON payload from stdin, extracts the active
+# transcript path, and defers capture through `iai-mcp capture-transcript
+# --no-spawn`. Fail-safe by design: any error exits 0 so session teardown is
+# never blocked.
+
+set -u  # no -e: the hook must not block session teardown
+input=$(cat 2>/dev/null || true)
+
+extract() {
+  local key=$1
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$input" | jq -r ".${key} // empty" 2>/dev/null
+  else
+    printf '%s' "$input" | /usr/bin/python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(d.get('${key}', '') or '')
+except Exception:
+    print('')
+" 2>/dev/null
+  fi
+}
+
+session_id=$(extract "session_id")
+transcript_path=$(extract "transcript_path")
+if [[ -z "$transcript_path" ]]; then
+  transcript_path=$(extract "transcriptPath")
+fi
+cwd=$(extract "cwd")
+stop_hook_active=$(extract "stop_hook_active")
+
+if [[ -z "$transcript_path" && -n "$session_id" ]]; then
+  sessions_dir="$HOME/.codex/sessions"
+  if [[ -d "$sessions_dir" ]]; then
+    transcript_path=$(
+      find "$sessions_dir" -type f \( -name "${session_id}.jsonl" -o -name "*${session_id}*.jsonl" \) \
+        -print 2>/dev/null | head -n 1
+    )
+  fi
+fi
+
+mkdir -p "$HOME/.iai-mcp/logs" 2>/dev/null || true
+log="$HOME/.iai-mcp/logs/codex-capture-$(date -u +%Y-%m-%d).log"
+ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+{
+  echo "---"
+  echo "$ts session=$session_id cwd=$cwd transcript=$transcript_path"
+} >> "$log" 2>/dev/null
+
+if [[ "$stop_hook_active" == "true" || "$stop_hook_active" == "1" ]]; then
+  echo "$ts skipped: stop hook already active" >> "$log" 2>/dev/null
+  exit 0
+fi
+
+if [[ -z "$transcript_path" || ! -f "$transcript_path" ]]; then
+  echo "$ts skipped: no transcript found" >> "$log" 2>/dev/null
+  exit 0
+fi
+
+cli_cache="$HOME/.iai-mcp/.cli-path"
+iai_cli=""
+if [[ -f "$cli_cache" ]]; then
+  cached=$(cat "$cli_cache" 2>/dev/null || true)
+  [[ -x "$cached" ]] && iai_cli="$cached"
+fi
+if [[ -z "$iai_cli" ]]; then
+  path_cli="$(command -v iai-mcp 2>/dev/null || true)"
+  if [[ -n "$path_cli" && -x "$path_cli" ]]; then
+    iai_cli="$path_cli"
+  else
+    for candidate in \
+      "$HOME/.local/bin/iai-mcp" \
+      "$HOME/iai-mcp/.venv/bin/iai-mcp" \
+      "$HOME/IAI-MCP/.venv/bin/iai-mcp" \
+      "/usr/local/bin/iai-mcp" \
+      "/opt/homebrew/bin/iai-mcp"; do
+      if [[ -x "$candidate" ]]; then
+        iai_cli="$candidate"
+        break
+      fi
+    done
+  fi
+  if [[ -n "$iai_cli" ]]; then
+    printf '%s' "$iai_cli" > "$cli_cache" 2>/dev/null || true
+  fi
+fi
+
+if [[ -z "$iai_cli" ]]; then
+  echo "$ts skipped: iai-mcp CLI not found" >> "$log" 2>/dev/null
+  exit 0
+fi
+
+if command -v timeout >/dev/null 2>&1; then
+  result=$(timeout 30 "$iai_cli" capture-transcript --no-spawn \
+    --session-id "${session_id:-codex}" \
+    --max-turns 200 \
+    "$transcript_path" 2>&1)
+elif command -v gtimeout >/dev/null 2>&1; then
+  result=$(gtimeout 30 "$iai_cli" capture-transcript --no-spawn \
+    --session-id "${session_id:-codex}" \
+    --max-turns 200 \
+    "$transcript_path" 2>&1)
+else
+  result=$("$iai_cli" capture-transcript --no-spawn \
+    --session-id "${session_id:-codex}" \
+    --max-turns 200 \
+    "$transcript_path" 2>&1)
+fi
+rc=$?
+
+{
+  echo "$ts rc=$rc result=$result"
+} >> "$log" 2>/dev/null
+
+exit 0

--- a/src/iai_mcp/cli.py
+++ b/src/iai_mcp/cli.py
@@ -726,12 +726,26 @@ def _capture_hook_paths() -> tuple[Path, Path, Path]:
     """Return (hook_src_in_repo, hook_dst_in_home, settings_path)."""
     from pathlib import Path as _P
     import iai_mcp
+
     pkg_dir = _P(iai_mcp.__file__).resolve().parent
     # repo layout: <repo>/src/iai_mcp/cli.py -> <repo>/deploy/hooks/...
     repo_root = pkg_dir.parent.parent
     src = repo_root / "deploy" / "hooks" / "iai-mcp-session-capture.sh"
     dst = _P.home() / ".claude" / "hooks" / "iai-mcp-session-capture.sh"
     settings = _P.home() / ".claude" / "settings.json"
+    return src, dst, settings
+
+
+def _codex_capture_hook_paths() -> tuple[Path, Path, Path]:
+    """Return (hook_src_in_repo, hook_dst_in_home, codex_hooks_json)."""
+    from pathlib import Path as _P
+    import iai_mcp
+
+    pkg_dir = _P(iai_mcp.__file__).resolve().parent
+    repo_root = pkg_dir.parent.parent
+    src = repo_root / "deploy" / "hooks" / "iai-mcp-codex-session-capture.sh"
+    dst = _P.home() / ".codex" / "hooks" / "iai-mcp-codex-session-capture.sh"
+    settings = _P.home() / ".codex" / "hooks.json"
     return src, dst, settings
 
 
@@ -817,7 +831,7 @@ def _patch_claude_desktop_config(action: str) -> str:
             servers.pop("iai-mcp", None)
             cfg_path.write_text(_json.dumps(data, indent=2))
             return f"Claude Desktop: removed iai-mcp from {cfg_path}"
-        return f"Claude Desktop: iai-mcp not in config — no change"
+        return "Claude Desktop: iai-mcp not in config — no change"
 
     # install
     new_entry = _build_iai_mcp_server_entry(repo_root)
@@ -829,6 +843,7 @@ def _patch_claude_desktop_config(action: str) -> str:
 
 
 _CAPTURE_HOOK_MARKER = "iai-mcp-session-capture.sh"
+_CODEX_CAPTURE_HOOK_MARKER = "iai-mcp-codex-session-capture.sh"
 
 
 def _load_settings(path):
@@ -841,14 +856,123 @@ def _load_settings(path):
         return {}
 
 
+def _target_from_args(args: argparse.Namespace) -> str:
+    return str(getattr(args, "target", "claude") or "claude")
+
+
+def _target_includes(target: str, name: str) -> bool:
+    return target == "all" or target == name
+
+
+def _patch_codex_hooks_config(action: str, command: str | None = None) -> str:
+    """Install/uninstall the Codex Stop hook in ~/.codex/hooks.json."""
+    import json as _json
+
+    _, dst, settings = _codex_capture_hook_paths()
+    data = _load_settings(settings)
+    if not isinstance(data, dict):
+        data = {}
+    hooks = data.setdefault("hooks", {})
+    stop_list = hooks.setdefault("Stop", [])
+
+    def has_marker(entry: dict) -> bool:
+        return any(
+            _CODEX_CAPTURE_HOOK_MARKER in (h.get("command") or "")
+            for h in (entry.get("hooks") or [])
+        )
+
+    if action == "uninstall":
+        kept = [entry for entry in stop_list if not has_marker(entry)]
+        if len(kept) == len(stop_list):
+            return f"Codex: no Stop entry to remove in {settings}"
+        if kept:
+            hooks["Stop"] = kept
+        else:
+            hooks.pop("Stop", None)
+        if not hooks:
+            data.pop("hooks", None)
+        settings.write_text(_json.dumps(data, indent=2))
+        return f"Codex: patched {settings} (Stop hook removed)"
+
+    if any(has_marker(entry) for entry in stop_list):
+        return f"Codex: {settings} already has Stop hook - no change"
+
+    stop_list.append({
+        "matcher": "",
+        "hooks": [{
+            "type": "command",
+            "command": command or f"bash {dst}",
+            "timeout": 35,
+        }],
+    })
+    settings.parent.mkdir(parents=True, exist_ok=True)
+    settings.write_text(_json.dumps(data, indent=2))
+    return f"Codex: patched {settings} (Stop hook registered)"
+
+
+def _install_codex_capture_hook() -> int:
+    """Install the Codex Stop hook without touching Claude config."""
+    import shlex
+    import shutil
+    import stat
+
+    src, dst, _settings = _codex_capture_hook_paths()
+    if not src.exists():
+        print(f"ERROR: hook template missing in repo: {src}", file=sys.stderr)
+        return 1
+
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dst)
+    dst.chmod(dst.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP)
+    print(f"Codex: installed {dst}")
+    print(_patch_codex_hooks_config("install", f"bash {shlex.quote(str(dst))}"))
+    return 0
+
+
+def _uninstall_codex_capture_hook() -> int:
+    """Remove the Codex Stop hook script and config entry."""
+    _, dst, _settings = _codex_capture_hook_paths()
+    if dst.exists():
+        dst.unlink()
+        print(f"Codex: removed {dst}")
+    else:
+        print(f"Codex: not present {dst}")
+    print(_patch_codex_hooks_config("uninstall"))
+    return 0
+
+
+def _codex_capture_hook_status() -> bool:
+    """Print and return whether the Codex Stop hook is installed and wired."""
+    src, dst, settings = _codex_capture_hook_paths()
+    print(f"Codex template: {src}  {'PRESENT' if src.exists() else 'MISSING'}")
+    print(f"Codex installed: {dst}  {'PRESENT' if dst.exists() else 'MISSING'}")
+    data = _load_settings(settings)
+    stop_list = data.get("hooks", {}).get("Stop", [])
+    wired = any(
+        any(_CODEX_CAPTURE_HOOK_MARKER in (h.get("command") or "")
+            for h in (entry.get("hooks") or []))
+        for entry in stop_list
+    )
+    print(f"Codex hooks.json: {settings}  {'WIRED' if wired else 'NOT WIRED'}")
+    return dst.exists() and wired
+
+
 def cmd_capture_hooks_install(args: argparse.Namespace) -> int:
     """Copy the Stop hook into ~/.claude/hooks/ and register it in settings.json."""
     import json as _json
     import shutil
     import stat
 
-    src, dst, settings = _capture_hook_paths()
+    target = _target_from_args(args)
+    if _target_includes(target, "codex") and _install_codex_capture_hook() != 0:
+        return 1
+    if not _target_includes(target, "claude"):
+        print("\nNext: restart Codex so it picks up the hook registration.")
+        print("If hooks are disabled by policy, enable [features].hooks = true.")
+        print("Verify: iai-mcp capture-hooks status --target codex")
+        return 0
 
+    src, dst, settings = _capture_hook_paths()
     if not src.exists():
         print(f"ERROR: hook template missing in repo: {src}", file=sys.stderr)
         return 1
@@ -871,7 +995,7 @@ def cmd_capture_hooks_install(args: argparse.Namespace) -> int:
         for entry in stop_list
     )
     if already:
-        print(f"settings.json already has Stop hook — no change")
+        print("settings.json already has Stop hook — no change")
     else:
         stop_list.append({"hooks": [{"type": "command", "command": hook_cmd, "timeout": 35}]})
         settings.write_text(_json.dumps(data, indent=2))
@@ -882,8 +1006,12 @@ def cmd_capture_hooks_install(args: argparse.Namespace) -> int:
     desktop_msg = _patch_claude_desktop_config("install")
     print(desktop_msg)
 
-    print("\nNext: fully quit + relaunch Claude Code AND Claude Desktop")
-    print("      so both pick up the registration (macOS: `killall Claude`).")
+    if _target_includes(target, "codex"):
+        print("\nNext: restart Codex, Claude Code, and Claude Desktop.")
+        print("If Codex hooks are disabled by policy, enable [features].hooks = true.")
+    else:
+        print("\nNext: fully quit + relaunch Claude Code AND Claude Desktop")
+        print("      so both pick up the registration (macOS: `killall Claude`).")
     print("Verify: iai-mcp capture-hooks status")
     return 0
 
@@ -892,8 +1020,13 @@ def cmd_capture_hooks_uninstall(args: argparse.Namespace) -> int:
     """Remove the Stop hook script and its settings.json entry (idempotent)."""
     import json as _json
 
-    _, dst, settings = _capture_hook_paths()
+    target = _target_from_args(args)
+    if _target_includes(target, "codex"):
+        _uninstall_codex_capture_hook()
+    if not _target_includes(target, "claude"):
+        return 0
 
+    _, dst, settings = _capture_hook_paths()
     if dst.exists():
         dst.unlink()
         print(f"removed: {dst}")
@@ -928,8 +1061,19 @@ def cmd_capture_hooks_uninstall(args: argparse.Namespace) -> int:
 def cmd_capture_hooks_status(args: argparse.Namespace) -> int:
     """Show whether the Stop hook is installed and active on both surfaces."""
     import json as _json
-    src, dst, settings = _capture_hook_paths()
 
+    target = _target_from_args(args)
+    codex_ok = True
+    if _target_includes(target, "codex"):
+        codex_ok = _codex_capture_hook_status()
+        if not _target_includes(target, "claude"):
+            if codex_ok:
+                print("\nstatus: ACTIVE - Codex ambient capture will fire on Stop")
+                return 0
+            print("\nstatus: INACTIVE - Codex not fully wired. Run: iai-mcp capture-hooks install --target codex")
+            return 1
+
+    src, dst, settings = _capture_hook_paths()
     print(f"repo template: {src}  {'PRESENT' if src.exists() else 'MISSING'}")
     print(f"installed at:  {dst}  {'PRESENT' if dst.exists() else 'MISSING'}")
 
@@ -966,13 +1110,15 @@ def cmd_capture_hooks_status(args: argparse.Namespace) -> int:
     # Desktop IS installed but not wired.
     desktop_problem = desktop_cfg is not None and desktop_cfg.exists() and not desktop_wired
 
-    if ok and not desktop_problem:
-        print(f"\nstatus: ACTIVE — ambient capture will fire on every SessionEnd "
+    if ok and not desktop_problem and codex_ok:
+        print(f"\nstatus: ACTIVE — ambient capture will fire on every Stop event "
               f"(Claude Code{'; Desktop also wired' if desktop_wired else ''})")
         return 0
     msg = []
     if not ok:
         msg.append("Claude Code not fully wired")
+    if not codex_ok:
+        msg.append("Codex not fully wired")
     if desktop_problem:
         msg.append("Claude Desktop present but iai-mcp not registered")
     print(f"\nstatus: INACTIVE — {'; '.join(msg)}. Run: iai-mcp capture-hooks install")
@@ -2257,8 +2403,6 @@ def cmd_maintenance_sleep_cycle(args: argparse.Namespace) -> int:
     runs CLI-only in — daemon coexistence is the Phase
     10.4/10.5 wiring concern.
     """
-    from datetime import timezone as _tz
-
     from iai_mcp.lifecycle_event_log import LifecycleEventLog
     from iai_mcp.lifecycle_state import LIFECYCLE_STATE_PATH
     from iai_mcp.sleep_pipeline import SleepPipeline, SleepStep
@@ -2549,25 +2693,29 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     cap.set_defaults(func=cmd_capture_transcript)
 
-    # Plan 06 ambient-capture installer: drops the Stop hook into
-    # ~/.claude/hooks/ and patches ~/.claude/settings.json. Makes a fresh
+    # Plan 06 ambient-capture installer: drops the Stop hook into Claude Code
+    # or Codex hook config. Makes a fresh
     # install of iai-mcp on another machine a two-step flow:
     #   pip install -e ".[dev,compress]"
     #   iai-mcp capture-hooks install
     ch = sub.add_parser(
         "capture-hooks",
-        help="install/uninstall/status the Claude Code Stop hook for ambient session capture",
+        help="install/uninstall/status Stop hooks for ambient session capture",
     )
     ch_sub = ch.add_subparsers(dest="capture_hooks_cmd", required=True)
-    ch_sub.add_parser("install",
-                      help="copy Stop hook to ~/.claude/hooks/ and register in settings.json"
-                      ).set_defaults(func=cmd_capture_hooks_install)
-    ch_sub.add_parser("uninstall",
-                      help="remove the Stop hook and its settings.json entry"
-                      ).set_defaults(func=cmd_capture_hooks_uninstall)
-    ch_sub.add_parser("status",
-                      help="show whether the Stop hook is installed and active"
-                      ).set_defaults(func=cmd_capture_hooks_status)
+    for name, helptext, func in (
+        ("install", "copy and register the Stop hook", cmd_capture_hooks_install),
+        ("uninstall", "remove the Stop hook and config entry", cmd_capture_hooks_uninstall),
+        ("status", "show whether the Stop hook is installed and active", cmd_capture_hooks_status),
+    ):
+        hook_cmd = ch_sub.add_parser(name, help=helptext)
+        hook_cmd.add_argument(
+            "--target",
+            choices=["claude", "codex", "all"],
+            default="claude",
+            help="hook target to manage (default: claude)",
+        )
+        hook_cmd.set_defaults(func=func)
 
     # audit subcommand + sub-subcommands.
     a = sub.add_parser(

--- a/tests/test_capture_hooks_codex.py
+++ b/tests/test_capture_hooks_codex.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+
+
+def _args(target: str = "codex") -> argparse.Namespace:
+    return argparse.Namespace(target=target)
+
+
+def test_codex_capture_hook_install_status_uninstall(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    from iai_mcp.cli import (
+        cmd_capture_hooks_install,
+        cmd_capture_hooks_status,
+        cmd_capture_hooks_uninstall,
+    )
+
+    assert cmd_capture_hooks_install(_args()) == 0
+    out = capsys.readouterr().out
+    assert "Codex: installed" in out
+
+    hook_path = tmp_path / ".codex" / "hooks" / "iai-mcp-codex-session-capture.sh"
+    hooks_json = tmp_path / ".codex" / "hooks.json"
+    assert hook_path.exists()
+
+    data = json.loads(hooks_json.read_text())
+    stop_entries = data["hooks"]["Stop"]
+    commands = [
+        hook["command"] for entry in stop_entries for hook in entry.get("hooks", [])
+    ]
+    assert any("iai-mcp-codex-session-capture.sh" in command for command in commands)
+    assert "codex_hooks" not in hooks_json.read_text()
+
+    assert cmd_capture_hooks_status(_args()) == 0
+    assert "status: ACTIVE" in capsys.readouterr().out
+
+    assert cmd_capture_hooks_uninstall(_args()) == 0
+    assert not hook_path.exists()
+    data = json.loads(hooks_json.read_text())
+    assert "Stop" not in data.get("hooks", {})
+
+
+def test_codex_capture_hook_uninstall_preserves_unrelated_stop_hooks(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    hooks_json = tmp_path / ".codex" / "hooks.json"
+    hooks_json.parent.mkdir(parents=True)
+    hooks_json.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "Stop": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "bash ~/.codex/hooks/keep.sh",
+                                }
+                            ]
+                        },
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "bash ~/.codex/hooks/iai-mcp-codex-session-capture.sh",
+                                }
+                            ]
+                        },
+                    ]
+                }
+            }
+        )
+    )
+
+    from iai_mcp.cli import cmd_capture_hooks_uninstall
+
+    assert cmd_capture_hooks_uninstall(_args()) == 0
+    data = json.loads(hooks_json.read_text())
+    stop_entries = data["hooks"]["Stop"]
+    commands = [
+        hook["command"] for entry in stop_entries for hook in entry.get("hooks", [])
+    ]
+    assert commands == ["bash ~/.codex/hooks/keep.sh"]
+
+
+def test_codex_stop_hook_stdout_is_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    from iai_mcp.cli import cmd_capture_hooks_install
+
+    assert cmd_capture_hooks_install(_args()) == 0
+    hook_path = tmp_path / ".codex" / "hooks" / "iai-mcp-codex-session-capture.sh"
+
+    payload = {
+        "cwd": str(tmp_path),
+        "hook_event_name": "Stop",
+        "last_assistant_message": None,
+        "model": "gpt-test",
+        "permission_mode": "default",
+        "session_id": "test-session",
+        "stop_hook_active": False,
+        "transcript_path": None,
+        "turn_id": "turn-1",
+    }
+    proc = subprocess.run(
+        ["bash", str(hook_path)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=5,
+    )
+
+    assert proc.returncode == 0
+    assert proc.stdout == ""


### PR DESCRIPTION
## Summary
Adds Codex as an optional `capture-hooks` target while keeping Claude as the default.

The Codex Stop hook reads Codex hook JSON from stdin, captures the transcript with `iai-mcp capture-transcript --no-spawn`, exits 0, and stays silent on stdout when skipping capture. The installer patches `~/.codex/hooks.json`, preserves unrelated hooks, and status/uninstall handle Codex separately.

Closes #1

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [x] Documentation
- [ ] Build / tooling

## Affected areas
- [x] Capture path
- [ ] Recall / retrieval
- [ ] Consolidation / sleep cycles
- [ ] Daemon lifecycle
- [ ] Storage / encryption at rest
- [ ] MCP wrapper
- [ ] Bench harness
- [x] CLI / doctor
- [x] Documentation
- [ ] Other: ___

## Testing
- [x] New tests added for changed behaviour
- [x] `uv run --python 3.12 --with pytest --with pytest-rerunfailures pytest tests/test_capture_hooks_codex.py tests/test_capture_transcript_no_spawn_defer.py -q`
- [x] `uv run --python 3.12 --with 'ruff>=0.5,<0.6' ruff check src/iai_mcp/cli.py tests/test_capture_hooks_codex.py`
- [x] `bash -n deploy/hooks/iai-mcp-codex-session-capture.sh`
- [x] `git diff --check`

## Benchmarks
Not run. This is hook installer and documentation work; it does not change retrieval ranking, consolidation, embedding, or capture parsing semantics.

## Notes for reviewers
This PR intentionally limits Codex support to ambient Stop-hook capture. It does not change iai-mcp recall mechanics.

Docs use `[features].hooks = true` only as troubleshooting for disabled or older installs; modern Codex hooks are stable/default-enabled.
