### PR TITLE
fix: capture Codex event transcript rows

### DIFF
--- a/src/iai_mcp/capture.py
+++ b/src/iai_mcp/capture.py
@@ -35,7 +35,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 # R3 deviation [Rule 3 - blocking import cost]: `iai_mcp.embed` pulls
 # in transformers + torch (~2.9s cold import). Loading capture.py for the
@@ -80,6 +80,47 @@ def _run_shield(text: str) -> tuple[str, list[str]]:
         return verdict, tags
     except Exception:
         return "OK", []
+
+
+def _content_to_text(content: Any) -> str:
+    """Extract plain text from Claude and Codex content block shapes."""
+    if isinstance(content, list):
+        text_parts = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") in {"text", "input_text", "output_text"}:
+                text_parts.append(str(block.get("text", "")))
+        return "\n".join(text_parts).strip()
+    return str(content).strip()
+
+
+def _extract_transcript_turn(obj: dict[str, Any]) -> tuple[str, str] | None:
+    """Return (role, text) for supported Claude Code and Codex transcript rows."""
+    payload = obj.get("payload") if isinstance(obj.get("payload"), dict) else {}
+    obj_type = obj.get("type")
+
+    if obj_type == "response_item":
+        # Codex response_item message rows can include injected context and
+        # duplicate cleaner event_msg rows. Capture only event_msg turns.
+        return None
+
+    if obj_type == "event_msg":
+        payload_type = payload.get("type")
+        if payload_type == "user_message":
+            text = _content_to_text(payload.get("message", ""))
+            return ("user", text) if text else None
+        if payload_type == "agent_message":
+            text = _content_to_text(payload.get("message", ""))
+            return ("assistant", text) if text else None
+        return None
+
+    msg = obj.get("message") if isinstance(obj.get("message"), dict) else obj
+    role = obj_type if obj_type in {"user", "assistant"} else str(msg.get("role", ""))
+    if role not in {"user", "assistant"}:
+        return None
+    text = _content_to_text(msg.get("content", ""))
+    return (role, text) if text else None
 
 
 def capture_turn(
@@ -229,22 +270,10 @@ def capture_transcript(
             except Exception:
                 counts["errors"] += 1
                 continue
-            msg = obj.get("message") if isinstance(obj.get("message"), dict) else obj
-            role = obj.get("type") or msg.get("role", "")
-            if role not in {"user", "assistant"}:
+            turn = _extract_transcript_turn(obj)
+            if turn is None:
                 continue
-            content = msg.get("content", "")
-            if isinstance(content, list):
-                # Claude Code messages use block format; collect text blocks
-                text_parts = []
-                for block in content:
-                    if isinstance(block, dict) and block.get("type") == "text":
-                        text_parts.append(block.get("text", ""))
-                text = "\n".join(text_parts).strip()
-            else:
-                text = str(content).strip()
-            if not text:
-                continue
+            role, text = turn
             result = capture_turn(
                 store,
                 cue=f"session {session_id} turn {seen}",
@@ -340,22 +369,10 @@ def write_deferred_captures(
                     obj = json.loads(line)
                 except Exception:
                     continue
-                msg = obj.get("message") if isinstance(obj.get("message"), dict) else obj
-                role = obj.get("type") or msg.get("role", "")
-                if role not in {"user", "assistant"}:
+                turn = _extract_transcript_turn(obj)
+                if turn is None:
                     continue
-                content = msg.get("content", "")
-                if isinstance(content, list):
-                    text_parts = [
-                        b.get("text", "")
-                        for b in content
-                        if isinstance(b, dict) and b.get("type") == "text"
-                    ]
-                    text = "\n".join(text_parts).strip()
-                else:
-                    text = str(content).strip()
-                if not text:
-                    continue
+                role, text = turn
                 event = {
                     "text": text,
                     "cue": f"session {session_id} turn {seen}",

--- a/tests/test_capture_transcript_no_spawn_defer.py
+++ b/tests/test_capture_transcript_no_spawn_defer.py
@@ -111,6 +111,35 @@ def _make_transcript(tmp_path: Path) -> Path:
     return transcript_path
 
 
+def _make_codex_transcript(tmp_path: Path) -> Path:
+    turns = [
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": "noisy injected instructions should not be captured",
+                    }
+                ],
+            },
+        },
+        {
+            "type": "event_msg",
+            "payload": {"type": "user_message", "message": "codex event user turn"},
+        },
+        {
+            "type": "event_msg",
+            "payload": {"type": "agent_message", "message": "codex assistant turn"},
+        },
+    ]
+    transcript_path = tmp_path / "codex-transcript.jsonl"
+    transcript_path.write_text("\n".join(json.dumps(t) for t in turns) + "\n")
+    return transcript_path
+
+
 def _run_no_spawn(env: dict[str, str], transcript_path: Path) -> subprocess.CompletedProcess:
     """Invoke `iai-mcp capture-transcript --no-spawn <transcript>` via
     `python -m iai_mcp.cli`. 5s wall-clock budget — comfortably above the 2s
@@ -230,6 +259,26 @@ def test_no_spawn_unreachable_still_defers(tmp_path):
 
     files = sorted(deferred_dir.glob("*.jsonl"))
     assert len(files) == 1, f"expected 1 deferred file, got {files}"
+
+
+def test_no_spawn_extracts_codex_transcript_turns(tmp_path):
+    env, deferred_dir, _sock_path = _isolated_env(tmp_path)
+    transcript = _make_codex_transcript(tmp_path)
+
+    proc = _run_no_spawn(env, transcript)
+
+    assert proc.returncode == 0, f"stderr={proc.stderr!r} stdout={proc.stdout!r}"
+    payload = json.loads(proc.stdout.strip())
+    assert payload.get("status") == "deferred", payload
+
+    files = sorted(deferred_dir.glob("*.jsonl"))
+    assert len(files) == 1, f"expected 1 deferred file, got {files}"
+    events = [json.loads(line) for line in files[0].read_text().splitlines()[1:]]
+    assert [event["role"] for event in events] == ["user", "assistant"]
+    assert [event["text"] for event in events] == [
+        "codex event user turn",
+        "codex assistant turn",
+    ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Codex transcripts include `response_item` message rows that can contain injected context such as AGENTS/system/developer instructions. Treating those rows as conversation turns can store prompt context instead of the actual user/assistant exchange.

## Root cause

The transcript parser handled generic message rows but did not distinguish Codex's noisy `response_item` rows from cleaner `event_msg` conversation rows.

## Fix

Adds a shared transcript-turn extractor used by both inline capture and no-spawn deferred capture.

For Codex transcripts, it skips `response_item` rows and captures:

- `event_msg` + `payload.type=user_message` as `user`
- `event_msg` + `payload.type=agent_message` as `assistant`

Existing Claude Code transcript parsing stays unchanged.

## Validation

- `uv run --python 3.12 --with pytest --with pytest-rerunfailures pytest tests/test_capture_transcript_no_spawn_defer.py tests/test_capture_hooks_codex.py -q`
- `uv run --python 3.12 --with 'ruff>=0.5,<0.6' ruff check src/iai_mcp/capture.py tests/test_capture_transcript_no_spawn_defer.py`
- `git diff --check`

Closes #3.
