### PR TITLE
Lint: Remove unused 'os' import in longmemeval.py

### DIFF
--- a/bench/adapters/longmemeval.py
+++ b/bench/adapters/longmemeval.py
@@ -47,7 +47,6 @@ reports session-level R@k using the dataset's native session_id gold.
 """
 from __future__ import annotations
 
-import os
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone


### PR DESCRIPTION
## Background

During a linting check, it was identified that the `os` module was imported in `bench/adapters/longmemeval.py` but never used anywhere in the file. Unused imports can clutter the code, reduce readability, and may trigger lint warnings. Removing them aligns with code quality best practices.

## Changes

- Removed the unused `import os` statement from the file, as it has no impact on functionality.

## Verification

- Verified that the code behavior remains unchanged by ensuring all existing tests pass.
- Ran lint tools (e.g., flake8, pylint) to confirm no new issues are introduced and the unused import warning is resolved.