### PR TITLE
Fix episodic capture timestamp matcher and duplicate-capture race

### DIFF
--- a/bench/capture_dedup_lock.py
+++ b/bench/capture_dedup_lock.py
@@ -1,0 +1,134 @@
+"""Capture dedup-lock overhead: capture_turn() solo latency and concurrent throughput.
+
+Quantifies the cost of _CAPTURE_DEDUP_LOCK (the fix for the daemon's
+concurrent-thread capture_turn() dedup race -- see capture.py). All
+captures used here have distinct content, so every call falls through to
+an actual insert; the question this bench answers is how much serializing
+the dedup-check-through-insert critical section costs, both with zero
+contention (solo) and under real thread contention (concurrent).
+"""
+from __future__ import annotations
+
+import argparse
+import statistics
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+from uuid import uuid4
+
+_SRC_PATH = str(Path(__file__).resolve().parent.parent / "src")
+if _SRC_PATH not in sys.path:
+    sys.path.insert(0, _SRC_PATH)
+
+import os
+if not os.environ.get("IAI_MCP_CRYPTO_PASSPHRASE"):
+    os.environ["IAI_MCP_CRYPTO_PASSPHRASE"] = (
+        "iai-mcp-bench-falsifiability-deterministic-2026"
+    )
+
+from iai_mcp.capture import capture_turn
+from iai_mcp.store import MemoryStore
+
+SESSION_ID = "bench-capture-dedup-lock"
+MIN_TEXT = (
+    "with enough length to clear the MIN_CAPTURE_LEN floor for a realistic capture"
+)
+
+
+def _solo_latency(store: MemoryStore, n: int) -> dict:
+    samples_ms: list[float] = []
+    for i in range(n):
+        t0 = time.perf_counter()
+        capture_turn(
+            store,
+            cue=f"bench solo turn {i}",
+            text=f"Capture dedup-lock bench solo turn {i} {MIN_TEXT}.",
+            tier="episodic",
+            session_id=SESSION_ID,
+            role="user",
+            source_uuid=str(uuid4()),
+        )
+        samples_ms.append((time.perf_counter() - t0) * 1000.0)
+    samples_ms.sort()
+    return {
+        "n": n,
+        "p50_ms": statistics.median(samples_ms),
+        "mean_ms": statistics.mean(samples_ms),
+        "p95_ms": samples_ms[max(0, int(round(0.95 * (n - 1))))],
+    }
+
+
+def _concurrent_throughput(store: MemoryStore, n_threads: int, per_thread: int) -> dict:
+    def worker(thread_idx: int) -> None:
+        for i in range(per_thread):
+            capture_turn(
+                store,
+                cue=f"bench concurrent t{thread_idx} turn {i}",
+                text=(
+                    f"Capture dedup-lock bench concurrent thread {thread_idx} "
+                    f"turn {i} {MIN_TEXT}."
+                ),
+                tier="episodic",
+                session_id=SESSION_ID,
+                role="user",
+                source_uuid=str(uuid4()),
+            )
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n_threads)]
+    t0 = time.perf_counter()
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    elapsed = time.perf_counter() - t0
+    total = n_threads * per_thread
+    return {
+        "n_threads": n_threads,
+        "per_thread": per_thread,
+        "total_captures": total,
+        "elapsed_s": elapsed,
+        "throughput_per_s": (total / elapsed) if elapsed > 0 else float("inf"),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--solo-n", type=int, default=60,
+        help="Number of single-threaded distinct captures (default: 60).",
+    )
+    parser.add_argument(
+        "--threads", type=int, default=8,
+        help="Concurrent threads for the throughput phase (default: 8).",
+    )
+    parser.add_argument(
+        "--per-thread", type=int, default=20,
+        help="Distinct captures per thread (default: 20).",
+    )
+    args = parser.parse_args()
+
+    with tempfile.TemporaryDirectory() as td:
+        store = MemoryStore(path=Path(td))
+
+        solo = _solo_latency(store, args.solo_n)
+        print(
+            f"solo capture_turn latency (n={solo['n']}, distinct content, "
+            f"zero lock contention): "
+            f"p50={solo['p50_ms']:.2f}ms mean={solo['mean_ms']:.2f}ms "
+            f"p95={solo['p95_ms']:.2f}ms"
+        )
+
+        conc = _concurrent_throughput(store, args.threads, args.per_thread)
+        print(
+            f"concurrent throughput ({conc['n_threads']} threads x "
+            f"{conc['per_thread']} distinct captures each): "
+            f"{conc['throughput_per_s']:.1f} captures/sec "
+            f"({conc['total_captures']} total in {conc['elapsed_s']:.2f}s)"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/iai_mcp/capture.py
+++ b/src/iai_mcp/capture.py
@@ -7,6 +7,7 @@ import logging
 import os
 import re
 import shutil
+import threading
 import time
 from collections import deque
 from datetime import datetime, timezone
@@ -32,6 +33,13 @@ log = logging.getLogger(__name__)
 DEDUP_COS_THRESHOLD = 0.95
 MIN_CAPTURE_LEN = 12
 MAX_CAPTURE_LEN = 8000
+
+# Daemon RPC dispatch runs each request on its own thread (asyncio.to_thread),
+# so concurrent capture_turn() calls (e.g. several sessions/forks draining
+# deferred captures at once) can race the dedup check-then-insert sequence.
+# This serializes that sequence so a tag can never be checked-as-absent by
+# two threads before either has inserted it.
+_CAPTURE_DEDUP_LOCK = threading.Lock()
 
 FAILED_MAX_ATTEMPTS: int = 3
 FAILED_BACKOFF_BASE_SEC: float = 60.0
@@ -284,94 +292,95 @@ def capture_turn(
         raise NativeError(f"capture encode failed: {exc}") from exc
     embedding = list(emb)
 
-    if _is_episodic_conversational(tier, role):
-        ts_iso = now.isoformat()
-        idem_t = _idem_tag(session_id, role, ts_iso, text, source_uuid=source_uuid)
-        existing_id = store.find_record_by_tag(idem_t)
-        if existing_id is not None:
-            try:
-                store.reinforce_record(existing_id)
-            except (ValueError, IOError) as exc:
-                log.warning(
-                    "capture_dedup_reinforce_failed",
-                    extra={
-                        "err_type": type(exc).__name__,
-                        "record_id": str(existing_id),
-                    },
-                )
-            return {
-                "status": "reinforced",
-                "record_id": str(existing_id),
-                "reason": "exact-key re-drain",
-            }
-    else:
-        try:
-            neighbours = store.query_similar(embedding, k=3, tier=tier)
-        except (ValueError, IOError) as exc:
-            log.warning(
-                "capture_dedup_query_failed",
-                extra={"err_type": type(exc).__name__, "err": str(exc)[:120]},
-            )
-            neighbours = []
-
-        for record, score in neighbours:
-            if score >= DEDUP_COS_THRESHOLD:
+    with _CAPTURE_DEDUP_LOCK:
+        if _is_episodic_conversational(tier, role):
+            ts_iso = now.isoformat()
+            idem_t = _idem_tag(session_id, role, ts_iso, text, source_uuid=source_uuid)
+            existing_id = store.find_record_by_tag(idem_t)
+            if existing_id is not None:
                 try:
-                    store.reinforce_record(record.id)
+                    store.reinforce_record(existing_id)
                 except (ValueError, IOError) as exc:
                     log.warning(
                         "capture_dedup_reinforce_failed",
                         extra={
                             "err_type": type(exc).__name__,
-                            "record_id": str(record.id),
+                            "record_id": str(existing_id),
                         },
                     )
                 return {
                     "status": "reinforced",
-                    "record_id": str(record.id),
-                    "reason": f"cos={score:.3f} >= {DEDUP_COS_THRESHOLD}",
+                    "record_id": str(existing_id),
+                    "reason": "exact-key re-drain",
                 }
+        else:
+            try:
+                neighbours = store.query_similar(embedding, k=3, tier=tier)
+            except (ValueError, IOError) as exc:
+                log.warning(
+                    "capture_dedup_query_failed",
+                    extra={"err_type": type(exc).__name__, "err": str(exc)[:120]},
+                )
+                neighbours = []
 
-    tags = ["capture", f"role:{role}"]
-    if verdict == "FLAG_FOR_REVIEW":
-        tags.append("shield:flagged")
-        tags.extend(f"shield:{t}" for t in shield_tags[:3])
+            for record, score in neighbours:
+                if score >= DEDUP_COS_THRESHOLD:
+                    try:
+                        store.reinforce_record(record.id)
+                    except (ValueError, IOError) as exc:
+                        log.warning(
+                            "capture_dedup_reinforce_failed",
+                            extra={
+                                "err_type": type(exc).__name__,
+                                "record_id": str(record.id),
+                            },
+                        )
+                    return {
+                        "status": "reinforced",
+                        "record_id": str(record.id),
+                        "reason": f"cos={score:.3f} >= {DEDUP_COS_THRESHOLD}",
+                    }
 
-    if _is_episodic_conversational(tier, role):
-        ts_iso = now.isoformat()
-        tags.append(_idem_tag(session_id, role, ts_iso, text, source_uuid=source_uuid))
+        tags = ["capture", f"role:{role}"]
+        if verdict == "FLAG_FOR_REVIEW":
+            tags.append("shield:flagged")
+            tags.extend(f"shield:{t}" for t in shield_tags[:3])
 
-    rec = MemoryRecord(
-        id=uuid4(),
-        tier=tier,
-        literal_surface=text,
-        aaak_index="",
-        embedding=embedding,
-        community_id=None,
-        centrality=0.0,
-        detail_level=2,
-        pinned=False,
-        stability=0.0,
-        difficulty=0.0,
-        last_reviewed=None,
-        never_decay=False,
-        never_merge=False,
-        provenance=[{"ts": now.isoformat(), "cue": cue or "(auto-capture)",
-                     "session_id": session_id, "role": role}],
-        created_at=now,
-        updated_at=now,
-        tags=tags,
-        language="en",
-        s5_trust_score=0.5,
-        profile_modulation_gain={},
-        schema_version=SCHEMA_VERSION_CURRENT,
-    )
+        if _is_episodic_conversational(tier, role):
+            ts_iso = now.isoformat()
+            tags.append(_idem_tag(session_id, role, ts_iso, text, source_uuid=source_uuid))
 
-    try:
-        store.insert(rec)
-    except Exception as e:
-        log.exception("capture_turn insert failed")
-        return {"status": "skipped", "record_id": None, "reason": f"insert-failed: {type(e).__name__}"}
+        rec = MemoryRecord(
+            id=uuid4(),
+            tier=tier,
+            literal_surface=text,
+            aaak_index="",
+            embedding=embedding,
+            community_id=None,
+            centrality=0.0,
+            detail_level=2,
+            pinned=False,
+            stability=0.0,
+            difficulty=0.0,
+            last_reviewed=None,
+            never_decay=False,
+            never_merge=False,
+            provenance=[{"ts": now.isoformat(), "cue": cue or "(auto-capture)",
+                         "session_id": session_id, "role": role}],
+            created_at=now,
+            updated_at=now,
+            tags=tags,
+            language="en",
+            s5_trust_score=0.5,
+            profile_modulation_gain={},
+            schema_version=SCHEMA_VERSION_CURRENT,
+        )
+
+        try:
+            store.insert(rec)
+        except Exception as e:
+            log.exception("capture_turn insert failed")
+            return {"status": "skipped", "record_id": None, "reason": f"insert-failed: {type(e).__name__}"}
 
     try:
         from iai_mcp.peri_event_buffer import get_buffer

--- a/src/iai_mcp/cli/__init__.py
+++ b/src/iai_mcp/cli/__init__.py
@@ -380,6 +380,16 @@ def _build_parser() -> argparse.ArgumentParser:
             "are left unchanged."
         ),
     )
+    m.add_argument(
+        "--dedupe-episodic",
+        action="store_true",
+        help=(
+            "Tombstone duplicate episodic records sharing an idem-tag (cleanup "
+            "for the capture_turn() check-then-insert race, fixed separately). "
+            "One-time operation; idempotent. Soft-delete only -- literal_surface, "
+            "provenance, and embeddings are never touched."
+        ),
+    )
     m.set_defaults(func=cmd_migrate)
 
     c = sub.add_parser(

--- a/src/iai_mcp/cli/_analytics.py
+++ b/src/iai_mcp/cli/_analytics.py
@@ -121,6 +121,17 @@ def cmd_migrate(args: argparse.Namespace) -> int:
         )
         return 0
 
+    if bool(getattr(args, "dedupe_episodic", False)):
+        from iai_mcp.migrate import migrate_dedupe_episodic_captures
+        dry_run = bool(getattr(args, "dry_run", False))
+        result = migrate_dedupe_episodic_captures(store, dry_run=dry_run)
+        prefix = "[dry-run] would tombstone" if dry_run else "tombstoned"
+        print(
+            f"{prefix} {result['tombstoned']} duplicate records "
+            f"across {result['groups']} group(s)"
+        )
+        return 0
+
     from_v = int(getattr(args, "from_", 1))
     to_v = int(getattr(args, "to", 2))
     dry_run = bool(getattr(args, "dry_run", False))

--- a/src/iai_mcp/doctor/_storage_checks.py
+++ b/src/iai_mcp/doctor/_storage_checks.py
@@ -212,7 +212,8 @@ def check_x_no_collapsed_timestamps() -> CheckResult:
     try:
         conn = sqlite3.connect(str(db_path), timeout=2.0)
         rows = conn.execute(
-            "SELECT created_at, COUNT(*) AS n FROM records WHERE tier = 'episodic'"
+            "SELECT created_at, COUNT(*) AS n FROM records"
+            " WHERE tier = 'episodic' AND tombstoned_at IS NULL"
             " GROUP BY created_at HAVING n >= 5 ORDER BY n DESC LIMIT 20"
         ).fetchall()
     except sqlite3.Error as exc:

--- a/src/iai_mcp/migrate/__init__.py
+++ b/src/iai_mcp/migrate/__init__.py
@@ -154,6 +154,7 @@ from iai_mcp.migrate._timestamps import (  # noqa: E402
     migrate_rederive_collapsed_timestamps,
     _find_transcript_ts,
 )
+from iai_mcp.migrate._dedupe import migrate_dedupe_episodic_captures  # noqa: E402
 
 
 __all__ = [
@@ -172,4 +173,5 @@ __all__ = [
     "migrate_codec_metadata_v4_to_v5",
     "cleanup_schema_duplicates",
     "migrate_rederive_collapsed_timestamps",
+    "migrate_dedupe_episodic_captures",
 ]

--- a/src/iai_mcp/migrate/_dedupe.py
+++ b/src/iai_mcp/migrate/_dedupe.py
@@ -1,0 +1,99 @@
+"""Episodic capture de-duplication.
+
+Tombstones duplicate episodic records produced by the capture_turn()
+check-then-insert race (fixed by _CAPTURE_DEDUP_LOCK in capture.py):
+concurrent daemon RPC threads draining overlapping Stop-hook full-transcript
+replays could each see a tag as absent and insert their own copy before the
+fix landed. This is the one-off cleanup for records inserted before then.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from uuid import UUID
+
+from iai_mcp.events import write_event
+from iai_mcp.store import MemoryStore
+
+log = logging.getLogger(__name__)
+
+
+def migrate_dedupe_episodic_captures(
+    store: "MemoryStore",
+    *,
+    dry_run: bool = False,
+) -> dict:
+    """Tombstone duplicate episodic records that share an idem-tag.
+
+    Groups non-tombstoned episodic records by their ``idem:<hash>`` tag --
+    the same identity key capture_turn() checks before inserting -- and
+    keeps exactly one record per group. Duplicates are soft-deleted via
+    ``tombstoned_at`` (the same column the erasure-agent sleep step uses),
+    never hard-deleted: literal_surface, provenance, and embeddings are
+    left untouched on every record.
+
+    Safe to call multiple times (idempotent): once a group has one survivor,
+    re-running finds no group with more than one non-tombstoned member.
+    """
+    from iai_mcp.hippo import HippoDB
+
+    db = store.db
+    if not isinstance(db, HippoDB):
+        return {"groups": 0, "tombstoned": 0, "dry_run": dry_run}
+
+    with db._conn_lock:
+        rows = db._conn.execute(
+            "SELECT id FROM records"
+            " WHERE tier = 'episodic' AND tombstoned_at IS NULL"
+        ).fetchall()
+    record_ids = [row[0] for row in rows]
+
+    groups: dict[str, list[str]] = {}
+    for rid_str in record_ids:
+        try:
+            rec = store.get(UUID(rid_str))
+        except (ValueError, TypeError):
+            continue
+        if rec is None:
+            continue
+        idem_tag = next(
+            (t for t in (rec.tags or []) if t.startswith("idem:")), None
+        )
+        if idem_tag is None:
+            continue
+        groups.setdefault(idem_tag, []).append(rid_str)
+
+    dup_groups = {tag: ids for tag, ids in groups.items() if len(ids) > 1}
+
+    to_tombstone: list[str] = []
+    for ids in dup_groups.values():
+        # Keep the lexicographically-smallest id as the canonical survivor --
+        # deterministic and idempotent across re-runs. created_at is
+        # identical within a group (they all resolve to the same true
+        # transcript turn), so it can't break ties meaningfully.
+        ids_sorted = sorted(ids)
+        to_tombstone.extend(ids_sorted[1:])
+
+    if not dry_run and to_tombstone:
+        now = datetime.now(timezone.utc)
+        with db._conn_lock:
+            db._conn.executemany(
+                "UPDATE records SET tombstoned_at = ? WHERE id = ?",
+                [(now, rid) for rid in to_tombstone],
+            )
+        try:
+            write_event(
+                store,
+                "migration_dedupe_episodic_captures",
+                {"groups": len(dup_groups), "tombstoned": len(to_tombstone)},
+            )
+        except (OSError, ValueError, RuntimeError) as exc:
+            log.error(
+                "migration_dedupe_episodic_captures event write failed: %s", exc
+            )
+
+    return {
+        "groups": len(dup_groups),
+        "tombstoned": len(to_tombstone),
+        "dry_run": dry_run,
+    }

--- a/src/iai_mcp/migrate/_timestamps.py
+++ b/src/iai_mcp/migrate/_timestamps.py
@@ -32,7 +32,7 @@ def _find_transcript_ts(
     Fast path: match by source_uuid. Fallback: match by content hash of literal_surface
     against the transcript line text field.
     """
-    from iai_mcp.capture import _resolve_ts
+    from iai_mcp.capture import MAX_CAPTURE_LEN, _resolve_ts
 
     # Validate session_id to prevent path traversal.
     if not session_id or "/" in session_id or ".." in session_id:
@@ -64,21 +64,23 @@ def _find_transcript_ts(
                     # Fast path: uuid match.
                     if source_uuid and obj.get("uuid") == source_uuid:
                         return _resolve_ts(ts_str)
-                    # Content-hash fallback: compare against message text fields.
-                    text_candidate = (
-                        obj.get("text")
-                        or obj.get("content")
-                        or ""
-                    )
-                    if isinstance(text_candidate, list):
-                        # Content is sometimes a list of blocks.
+                    # Content-hash fallback: real transcript lines nest the
+                    # text under message.content, not at the top level — mirror
+                    # the extraction capture_transcript_into_episodic() uses so
+                    # the hash matches what was actually stored as literal_surface.
+                    msg = obj.get("message")
+                    msg = msg if isinstance(msg, dict) else obj
+                    content = msg.get("content", "")
+                    if isinstance(content, list):
                         parts = []
-                        for block in text_candidate:
-                            if isinstance(block, dict):
+                        for block in content:
+                            if isinstance(block, dict) and block.get("type") == "text":
                                 parts.append(block.get("text") or "")
-                            elif isinstance(block, str):
-                                parts.append(block)
-                        text_candidate = "".join(parts)
+                        text_candidate = "\n".join(parts).strip()
+                    else:
+                        text_candidate = str(content or "").strip()
+                    if len(text_candidate) > MAX_CAPTURE_LEN:
+                        text_candidate = text_candidate[:MAX_CAPTURE_LEN]
                     if text_candidate:
                         candidate_hash = hashlib.sha256(
                             text_candidate.encode("utf-8")

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -169,3 +169,76 @@ def test_capture_idempotent_after_cap_raise(iai_home, tmp_path):
         f"Second pass must reinforce all {_N_TURNS} turns (not re-insert). "
         f"counts_second={counts_second!r}"
     )
+
+
+def test_capture_turn_concurrent_drains_do_not_duplicate(iai_home, tmp_path):
+    """Concurrent capture_turn() calls for the same turn (simulating the daemon
+    draining several Stop-hook full-transcript replays on separate
+    asyncio.to_thread workers at once) must serialize the dedup
+    check-then-insert and produce exactly one record."""
+    import threading
+    import time as _time
+
+    from iai_mcp import capture as capture_mod
+
+    store = _open_store()
+    text = "Duplicate turn raced by concurrent drains for race regression test"
+    source_uuid = str(uuid.uuid4())
+    ts = "2026-07-01T00:00:00Z"
+
+    n_threads = 6
+    state_lock = threading.Lock()
+    in_flight = 0
+    max_in_flight = 0
+    original_find = store.find_record_by_tag
+
+    def tracking_find(tag):
+        nonlocal in_flight, max_in_flight
+        with state_lock:
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+        _time.sleep(0.05)  # widen the race window the bug needed
+        try:
+            return original_find(tag)
+        finally:
+            with state_lock:
+                in_flight -= 1
+
+    store.find_record_by_tag = tracking_find
+
+    results: list[dict] = []
+    results_lock = threading.Lock()
+
+    def worker():
+        r = capture_mod.capture_turn(
+            store,
+            cue="race test",
+            text=text,
+            tier="episodic",
+            session_id=SESSION_ID,
+            role="user",
+            ts=ts,
+            source_uuid=source_uuid,
+        )
+        with results_lock:
+            results.append(r)
+
+    threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert len(results) == n_threads, f"Not all threads completed: {results!r}"
+    assert max_in_flight == 1, (
+        f"max_in_flight={max_in_flight}; dedup check-then-insert is not serialized "
+        f"across threads -- this is the race that produced duplicate episodic records"
+    )
+
+    inserted = [r for r in results if r["status"] == "inserted"]
+    reinforced = [r for r in results if r["status"] == "reinforced"]
+    assert len(inserted) == 1, f"Expected exactly 1 insert, got {len(inserted)}: {results!r}"
+    assert len(reinforced) == n_threads - 1, f"results={results!r}"
+
+    count = _count_episodic_records(store)
+    assert count == 1, f"Expected exactly 1 episodic record in the store, found {count}"

--- a/tests/test_doctor_hippo_rows.py
+++ b/tests/test_doctor_hippo_rows.py
@@ -288,7 +288,7 @@ def _build_records_table(db_path: Path) -> None:
     conn = sqlite3.connect(str(db_path))
     conn.execute(
         "CREATE TABLE IF NOT EXISTS records "
-        "(id TEXT PRIMARY KEY, tier TEXT, created_at TEXT)"
+        "(id TEXT PRIMARY KEY, tier TEXT, created_at TEXT, tombstoned_at TEXT)"
     )
     conn.commit()
     conn.close()
@@ -319,6 +319,32 @@ def test_check_x_collapsed_timestamps_warns(tmp_path, monkeypatch):
     assert result.status == "WARN"
     assert "7" in result.detail
     assert "iai-mcp migrate --rederive-timestamps" in result.detail
+
+
+def test_check_x_collapsed_timestamps_ignores_tombstoned(tmp_path, monkeypatch):
+    """Tombstoned duplicates must not count toward the >=5 collapsed-group threshold."""
+    monkeypatch.setenv("IAI_MCP_STORE", str(tmp_path))
+    hippo = tmp_path / "hippo"
+    hippo.mkdir()
+    db_path = hippo / "brain.sqlite3"
+
+    _build_records_table(db_path)
+    collapsed_ts = "2024-01-01T00:00:00+00:00"
+    conn = sqlite3.connect(str(db_path))
+    for i in range(7):
+        tombstoned = "2024-06-01T00:00:00+00:00" if i < 3 else None
+        conn.execute(
+            "INSERT INTO records (id, tier, created_at, tombstoned_at) VALUES (?, ?, ?, ?)",
+            (f"r-{i}", "episodic", collapsed_ts, tombstoned),
+        )
+    conn.commit()
+    conn.close()
+
+    from iai_mcp.doctor import check_x_no_collapsed_timestamps
+
+    result = check_x_no_collapsed_timestamps()
+    assert result.passed is True, result.detail
+    assert result.status != "WARN"
 
 
 def test_check_x_collapsed_timestamps_pass(tmp_path, monkeypatch):

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -475,6 +475,60 @@ def test_migrate_rederive_skips_missing_transcript(tmp_path):
         assert after.created_at == collapsed_ts
 
 
+def test_migrate_rederive_content_hash_fallback_matches_nested_message(tmp_path):
+    """Records without source_uuid fall back to content-hash matching against
+    the transcript's nested message.content — the real Claude Code shape."""
+    from iai_mcp.migrate import migrate_rederive_collapsed_timestamps
+    from iai_mcp.store import MemoryStore
+
+    store = MemoryStore(path=tmp_path)
+    session_id = "sess-content-hash"
+    transcript_root = tmp_path / "transcripts"
+
+    collapsed_ts = datetime(2026, 7, 1, 0, 0, 0, tzinfo=timezone.utc)
+    texts = [f"User turn content-hash {i}" for i in range(3)]
+    real_ts_strs = [
+        "2026-07-01T05:00:00Z",
+        "2026-07-01T05:01:00Z",
+        "2026-07-01T05:02:00Z",
+    ]
+
+    # No source_uuid recorded in provenance — forces the content-hash fallback.
+    records = [
+        _make_episodic_record(texts[i], session_id, "", collapsed_ts)
+        for i in range(3)
+    ]
+    for r in records:
+        store.insert(r)
+
+    # Real transcript lines nest text under message.content, not at the top level.
+    transcript_entries = [
+        {
+            "type": "user",
+            "timestamp": real_ts_strs[i],
+            "sessionId": session_id,
+            "uuid": str(uuid4()),
+            "message": {"role": "user", "content": texts[i]},
+        }
+        for i in range(3)
+    ]
+    # One entry uses the list-of-content-blocks shape too.
+    transcript_entries[0]["message"]["content"] = [
+        {"type": "text", "text": texts[0]}
+    ]
+    _write_fake_transcript(transcript_root, session_id, transcript_entries)
+
+    result = migrate_rederive_collapsed_timestamps(store, transcript_root=transcript_root)
+
+    assert result["records_updated"] == 3
+    assert result["skipped_no_match"] == 0
+
+    fetched_ts = {r.id: store.get(r.id).created_at for r in records}
+    assert len(set(fetched_ts.values())) == 3
+    for ts in fetched_ts.values():
+        assert ts != collapsed_ts
+
+
 def test_migrate_rederive_writes_event(tmp_path):
     """A migration_rederive_timestamps event is written after a non-dry run."""
     from iai_mcp.events import query_events

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -566,3 +566,172 @@ def test_migrate_rederive_writes_event(tmp_path):
     events = query_events(store, kind="migration_rederive_timestamps")
     assert len(events) >= 1
     assert "records_updated" in events[0]["data"]
+
+
+# ---------------------------------------------------------------------------
+# Episodic capture de-duplication tests
+# ---------------------------------------------------------------------------
+
+
+def _make_episodic_record_with_idem_tag(
+    text: str,
+    session_id: str,
+    idem_tag: str,
+    created_at: datetime,
+) -> MemoryRecord:
+    """Build an episodic MemoryRecord carrying a fixed idem-tag, simulating
+    what capture_turn() produces for two captures of the same logical turn."""
+    return MemoryRecord(
+        id=uuid4(),
+        tier="episodic",
+        literal_surface=text,
+        aaak_index="",
+        embedding=[0.1] * EMBED_DIM,
+        community_id=None,
+        centrality=0.0,
+        detail_level=2,
+        pinned=False,
+        stability=0.0,
+        difficulty=0.0,
+        last_reviewed=None,
+        never_decay=False,
+        never_merge=False,
+        provenance=[{"session_id": session_id, "role": "user"}],
+        created_at=created_at,
+        updated_at=created_at,
+        tags=["capture", "role:user", idem_tag],
+        language="en",
+        schema_version=5,
+    )
+
+
+def _tombstoned_at(store, record_id) -> str | None:
+    with store.db._conn_lock:
+        row = store.db._conn.execute(
+            "SELECT tombstoned_at FROM records WHERE id = ?", (str(record_id),)
+        ).fetchone()
+    return row[0] if row else None
+
+
+def test_migrate_dedupe_episodic_captures_tombstones_extras(tmp_path):
+    """Records sharing an idem-tag are reduced to one survivor; extras are
+    tombstoned (soft-deleted), never hard-deleted."""
+    from iai_mcp.migrate import migrate_dedupe_episodic_captures
+    from iai_mcp.store import MemoryStore
+
+    store = MemoryStore(path=tmp_path)
+    session_id = "sess-dedupe"
+    same_ts = datetime(2026, 6, 16, 12, 30, 21, tzinfo=timezone.utc)
+    idem_tag = "idem:" + "a" * 64
+
+    dup_records = [
+        _make_episodic_record_with_idem_tag(
+            "/ide-index-mcp turn, raced by concurrent drains", session_id, idem_tag, same_ts
+        )
+        for _ in range(3)
+    ]
+    for r in dup_records:
+        store.insert(r)
+
+    # An unrelated record must be left alone.
+    unrelated = _make_episodic_record_with_idem_tag(
+        "unrelated turn", session_id, "idem:" + "b" * 64, same_ts
+    )
+    store.insert(unrelated)
+
+    result = migrate_dedupe_episodic_captures(store)
+    assert result["groups"] == 1
+    assert result["tombstoned"] == 2
+    assert result["dry_run"] is False
+
+    tombstoned_count = sum(
+        1 for r in dup_records if _tombstoned_at(store, r.id) is not None
+    )
+    assert tombstoned_count == 2
+
+    survivors = [r for r in dup_records if _tombstoned_at(store, r.id) is None]
+    assert len(survivors) == 1
+
+    # Untouched: unrelated record, and every duplicate's actual content.
+    assert _tombstoned_at(store, unrelated.id) is None
+    for r in dup_records:
+        fetched = store.get(r.id)
+        assert fetched.literal_surface == r.literal_surface
+
+
+def test_migrate_dedupe_episodic_captures_idempotent(tmp_path):
+    """Running the dedupe migration twice tombstones zero records the second time."""
+    from iai_mcp.migrate import migrate_dedupe_episodic_captures
+    from iai_mcp.store import MemoryStore
+
+    store = MemoryStore(path=tmp_path)
+    session_id = "sess-dedupe-idem"
+    same_ts = datetime(2026, 6, 16, 12, 30, 21, tzinfo=timezone.utc)
+    idem_tag = "idem:" + "c" * 64
+
+    for _ in range(4):
+        store.insert(
+            _make_episodic_record_with_idem_tag(
+                "repeated turn", session_id, idem_tag, same_ts
+            )
+        )
+
+    first = migrate_dedupe_episodic_captures(store)
+    assert first["tombstoned"] == 3
+
+    second = migrate_dedupe_episodic_captures(store)
+    assert second["tombstoned"] == 0
+    assert second["groups"] == 0
+
+
+def test_migrate_dedupe_episodic_captures_dry_run(tmp_path):
+    """dry_run=True reports what would happen but tombstones nothing."""
+    from iai_mcp.migrate import migrate_dedupe_episodic_captures
+    from iai_mcp.store import MemoryStore
+
+    store = MemoryStore(path=tmp_path)
+    session_id = "sess-dedupe-dry"
+    same_ts = datetime(2026, 6, 16, 12, 30, 21, tzinfo=timezone.utc)
+    idem_tag = "idem:" + "d" * 64
+
+    records = [
+        _make_episodic_record_with_idem_tag(
+            "dry run turn", session_id, idem_tag, same_ts
+        )
+        for _ in range(3)
+    ]
+    for r in records:
+        store.insert(r)
+
+    result = migrate_dedupe_episodic_captures(store, dry_run=True)
+    assert result["dry_run"] is True
+    assert result["groups"] == 1
+    assert result["tombstoned"] == 2
+
+    for r in records:
+        assert _tombstoned_at(store, r.id) is None
+
+
+def test_migrate_dedupe_episodic_captures_writes_event(tmp_path):
+    """A migration_dedupe_episodic_captures event is written after a non-dry run."""
+    from iai_mcp.events import query_events
+    from iai_mcp.migrate import migrate_dedupe_episodic_captures
+    from iai_mcp.store import MemoryStore
+
+    store = MemoryStore(path=tmp_path)
+    session_id = "sess-dedupe-event"
+    same_ts = datetime(2026, 6, 16, 12, 30, 21, tzinfo=timezone.utc)
+    idem_tag = "idem:" + "e" * 64
+
+    for _ in range(2):
+        store.insert(
+            _make_episodic_record_with_idem_tag(
+                "event turn", session_id, idem_tag, same_ts
+            )
+        )
+
+    migrate_dedupe_episodic_captures(store)
+
+    events = query_events(store, kind="migration_dedupe_episodic_captures")
+    assert len(events) >= 1
+    assert "tombstoned" in events[0]["data"]


### PR DESCRIPTION
  ## Summary
  - Fixes `_find_transcript_ts`'s content-hash fallback, which compared a record's `literal_surface` against `obj.get("text")`/`obj.get("content")` at the top level of each transcript JSON line — but real Claude Code transcript entries nest the turn text under `message.content`. Any
  record without a stored `source_uuid` could never be matched, leaving its `created_at` stuck at the collapsed value no matter how many times the repair migration ran.
  - Fixes a race in `capture_turn()`'s dedup: the daemon's RPC dispatch runs each request on its own thread (`asyncio.to_thread`), and Stop-hook captures replay the full transcript on every firing with no incremental offset tracking. A session with many sub-agent/fork completions can
  fire its Stop hook a dozen+ times in under an hour, queueing near-identical deferred-capture files; concurrent drains of those files could both see an idem tag as absent and both insert, producing true duplicate episodic records. Confirmed live: one session fired Stop 16 times in 45
  minutes and produced 2-3x duplicates for several turns.
  - Adds `iai-mcp migrate --dedupe-episodic`, a one-off cleanup migration that groups existing records by idem tag and tombstones every duplicate but the first (soft-delete only — `literal_surface`/`provenance`/embeddings untouched).
  - Fixes `doctor`'s collapsed-timestamp check, which was missing the `tombstoned_at IS NULL` filter the migration's own candidate query already had.
  - Adds `bench.capture_dedup_lock`, a new bench harness for the lock fix's overhead.

  Four atomic commits, one logical change each.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / tooling

## Affected areas

- [x] Capture path
- [ ] Recall / retrieval
- [ ] Consolidation / sleep cycles
- [ ] Daemon lifecycle / FSM
- [ ] Storage / encryption at rest
- [ ] MCP wrapper (TypeScript)
- [x] Bench harness
- [x] CLI / doctor
- [ ] Other: ___

## Testing

- [x] `pytest` passes locally
- [x] `ruff check src/ tests/` clean
- [x] New tests added for changed behaviour, or rationale below for why not

### Runs
- [x] `pytest tests/test_migrate.py tests/test_capture.py tests/test_doctor_hippo_rows.py` — 44 pass, including new regression tests for the matcher fix, the concurrency race (verified it fails without the lock: `max_in_flight=6`), and the dedupe migration
  (insert/idempotent/dry-run/event).
- [x] Full repo suite: 3458 passed / 125 skipped / 1 xfailed / 3 failed. All 3 failures pre-existing and unrelated: 2 are the documented test-pollution-sensitive flakes (pass on rerun, per CONTRIBUTING.md), 1 is an HNSW recall-parity test that reproduces identically on a clean
  `upstream/main` checkout.
- [x] `ruff check` on every changed/added file: zero new violations (diffed against a clean `upstream/main` baseline — all pre-existing hits are unchanged; the new bench file's `E402`s match the same sys.path-then-import pattern already present in every other `bench/*.py`).
- [x] Applied against a live store: 1007 duplicate records across 168 groups tombstoned; `iai doctor`'s collapsed-timestamp check now passes clean.

## Benchmarks

  This touches `capture` (the `_CAPTURE_DEDUP_LOCK` addition), so per the template:

  - Bench command run: `python -m bench.capture_dedup_lock`
  - Before (no lock, 3 rounds, median): solo capture_turn p50=158.95ms / mean=162.12ms / p95=164.31ms; concurrent throughput (8 threads × 20 distinct captures) = 16.7 captures/sec
  - After (with lock, 3 rounds, median): solo capture_turn p50=158.27ms / mean=160.11ms / p95=163.62ms; concurrent throughput = 17.1 captures/sec

  Solo latency is unchanged (zero lock contention by construction). Concurrent throughput shows no regression — the ~2% delta is within run-to-run noise, since the embedding call (the actual bottleneck, ~158ms) sits outside the lock; only the cheap dedup-check + insert is now
  serialized, which was already largely serialized by the existing `_conn_lock` and the synchronous wait on the async write queue.

  This PR doesn't touch retrieval, ranking, or embedding code, so the retrieval-side benches aren't expected to move. Ran them anyway as a sanity check:
  - `bench.tokens --wake-depth minimal` (real store, read-only, post-`--dedupe-episodic`): `fresh=392 warm=[16,16,16] steady_ok=true fresh_ok=true`
  - `bench.verbatim` (isolated store, n=20): `accuracy=1.0 passed=true`
  - `bench.neural_map --n 100 --iterations 5` (isolated store, reduced scale): `p50=61.4ms p95=66.3ms passed=true`, well under the 100ms gate

  Skipped `bench.longmemeval_blind` (the 500-question full run) — it has no code-path overlap with this PR and is disproportionately heavy for a write-path-only change.

