### PR TITLE
fix: preserve allow_replace_deleted on HNSW reload + guard scoring matmul against non-finite embeddings

### DIFF
--- a/src/iai_mcp/hippo/_db.py
+++ b/src/iai_mcp/hippo/_db.py
@@ -397,7 +397,7 @@ class HippoDB:
             if candidate.exists():
                 try:
                     idx = hnswlib.Index(space="cosine", dim=self._embed_dim)
-                    idx.load_index(str(candidate), max_elements=cap)
+                    idx.load_index(str(candidate), max_elements=cap, allow_replace_deleted=True)
                     idx.set_ef(max(HNSW_EF, RECALL_INDEX_EF))
                     idx.set_num_threads(1)
                     self._hnsw: hnswlib.Index = idx

--- a/src/iai_mcp/pipeline.py
+++ b/src/iai_mcp/pipeline.py
@@ -240,6 +240,7 @@ def _community_gate_max_node(
         return []
 
     mat = np.stack(rows).astype(np.float32, copy=False)
+    mat = np.nan_to_num(mat, nan=0.0, posinf=0.0, neginf=0.0)
     norms = np.linalg.norm(mat, axis=1)
     norms[norms == 0.0] = 1.0
     mat = mat / norms[:, None]
@@ -528,7 +529,11 @@ def _recall_core(
     if cnorm > 0.0:
         cue_vec = cue_vec / cnorm
     if pool_embs.size:
-        shared_cos = np.matmul(pool_embs, cue_vec).astype(np.float32)
+        _pe = np.nan_to_num(pool_embs, nan=0.0, posinf=0.0, neginf=0.0)
+        _pe_norms = np.linalg.norm(_pe, axis=1)
+        _pe_norms[_pe_norms == 0.0] = 1.0
+        _pe = _pe / _pe_norms[:, None]
+        shared_cos = np.matmul(_pe, cue_vec).astype(np.float32)
     else:
         shared_cos = np.empty(0, dtype=np.float32)
     if shared_cos.size:


### PR DESCRIPTION
## Summary

After several days of steady-state, multi-channel use (~1.5k records) on macOS, the nightly sleep cycle started looping on `KNOB_TUNE` (`crisis_mode`, sustained >100% CPU) and recall ranking collapsed. Root cause is two independent bugs surfacing during consolidation and recall.

## 1. HNSW reload drops `allow_replace_deleted` → `hippo_hnsw_rebuild_failed`

Every `init_index()` in `hippo/_db.py` sets `allow_replace_deleted=True`, and steady-state rebuilds rely on `add_items(..., replace_deleted=True)`. But the boot reload path called `load_index()` **without** the flag, and hnswlib resets it to `False` on load. After the first standby buffer swap, the reloaded index becomes the standby and the next consolidation raises:

```
hippo_hnsw_rebuild_failed: RuntimeError: Replacement of deleted elements is disabled in constructor
```

which fails the sleep cycle and retries indefinitely (observed: `KNOB_TUNE` re-entered 279× in one night vs 8 completions, `crisis_mode: true`).

Isolated repro (hnswlib 0.8.0): `init_index(allow_replace_deleted=True)` → `save_index` → `load_index(...)` (no flag) → `add_items(..., replace_deleted=True)` reproduces the error; passing `allow_replace_deleted=True` to `load_index` fixes it.

## 2. Non-finite embeddings poison scoring matmuls → broken recall

`_collect_graph_pool()` returns raw, unnormalized embeddings, fed directly to `shared_cos = np.matmul(pool_embs, cue_vec)`. A single null/non-finite embedding makes the whole `shared_cos` vector `NaN`/`inf`:

```
RuntimeWarning: divide by zero / overflow / invalid value encountered in matmul
```

`np.argsort(-shared_cos)` on NaN then produces a meaningless ranking (results collapse to a uniform score, real memories buried under noise). Same exposure for `member_scores = mat @ cue_vec` in `_community_gate_max_node` (the existing `norms[norms==0]=1` guard does not catch NaN rows).

**Fix:** sanitize with `np.nan_to_num` + L2-normalize with a zero-norm guard before both products, mirroring the guard already applied to `mat`/`cue_vec`. No-op for healthy (already L2-normalized) vectors; only neutralizes pathological ones.

## Verification

- Isolated hnswlib 0.8.0 repro confirms both the reload flag loss and the fix.
- After patching: `maintenance sleep-cycle` completes in ~1.7s (was looping), `crisis_mode` clears, no new `hnsw_rebuild_failed`.
- Recall stops emitting matmul warnings and returns relevant results again.

## Scope

Minimal and defensive: 7 insertions, 2 deletions across 2 files. No change to scoring semantics for healthy data; capture path untouched.
