### PR TITLE
fix(capture): embed message content, not the positional cue label

### DIFF
--- a/src/iai_mcp/capture.py
+++ b/src/iai_mcp/capture.py
@@ -277,7 +277,11 @@ def capture_turn(
     from iai_mcp.events import TELEMETRY_EMBED_NATIVE_FAILURE, write_event
 
     try:
-        emb = embedder_for_store(store).embed(cue or text)
+        # Embed the CONTENT, never the cue. capture_transcript / deferred-drain pass
+        # a positional cue ("session <id> turn <n>"); embedding that collapsed every
+        # stored vector onto near-identical label embeddings, destroying graph
+        # structure and semantic recall. The cue stays a provenance label only.
+        emb = embedder_for_store(store).embed(text)
     except Exception as exc:
         write_event(
             store,

--- a/tests/test_bench_worktree_resolution.py
+++ b/tests/test_bench_worktree_resolution.py
@@ -13,6 +13,7 @@ BENCH_DIR = WORKTREE_ROOT / "bench"
 
 BENCH_SCRIPTS_NEEDING_SHIM = [
     "_night_runner.py",
+    "capture_dedup_lock.py",
     "community_pipeline_perf.py",
     "consolidation_rss_peak.py",
     "contradiction_longitudinal_claude.py",

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -242,3 +242,50 @@ def test_capture_turn_concurrent_drains_do_not_duplicate(iai_home, tmp_path):
 
     count = _count_episodic_records(store)
     assert count == 1, f"Expected exactly 1 episodic record in the store, found {count}"
+
+
+def test_capture_turn_embeds_content_not_cue(iai_home, monkeypatch):
+    """Regression: capture_turn() must embed the message CONTENT, not the cue label.
+
+    capture_transcript() passes a positional cue ("session <id> turn <n>") and
+    capture_turn() used to embed ``cue or text``, so every episodic capture's
+    vector was the embedding of a near-identical positional label instead of the
+    message body. That collapsed the stored embedding space (unrelated turns at
+    cosine ~0.9+) and broke the similarity graph and semantic recall.
+    """
+    import iai_mcp.embed as embed_mod
+    from iai_mcp import capture as capture_mod
+
+    seen: dict[str, str] = {}
+
+    class _RecordingEmbedder:
+        DIM = 384
+
+        def embed(self, text: str) -> list[float]:
+            seen["text"] = text
+            vec = [0.0] * 384
+            vec[0] = 1.0  # valid unit vector; avoids zero-norm edge cases downstream
+            return vec
+
+    # capture_turn imports embedder_for_store from iai_mcp.embed at call time.
+    monkeypatch.setattr(
+        embed_mod, "embedder_for_store", lambda store: _RecordingEmbedder()
+    )
+
+    store = _open_store()
+    cue = f"session {SESSION_ID} turn 7"
+    content = "Le constat d'état des lieux a été réalisé dans l'appartement."
+    capture_mod.capture_turn(
+        store,
+        cue=cue,
+        text=content,
+        tier="episodic",
+        session_id=SESSION_ID,
+        role="user",
+    )
+
+    assert seen.get("text") == content, (
+        "capture_turn embedded the wrong string -- it must embed the message "
+        f"content, not the cue. Got: {seen.get('text')!r}"
+    )
+    assert seen["text"] != cue


### PR DESCRIPTION
## Problem

`capture_transcript()` calls `capture_turn(cue=f"session {session_id} turn {seen}", text=<message>)`, and `capture_turn()` embedded `cue or text`. Because the cue is always a truthy positional label, **every episodic capture's vector is the embedding of `"session <uuid> turn <n>"`, not the message content**. `literal_surface` still stores the real text (no data loss), but the vector index does not represent the content.

### Impact (measured on a real ~2400-record store)
- Stored vectors collapse: cosine between *random, unrelated* captures ≈ **0.91** (vs ≈ **0.69** when the same texts are embedded fresh), because every vector is the embedding of a near-identical label. Across 200 sampled records: `cos(stored_vector, embed(cue)) = 1.000` vs `cos(stored_vector, embed(literal_surface)) ≈ 0.60`.
- The pattern-separation gate only links neighbours within the band `[link_threshold, near_dup_threshold)` = `[0.70, 0.92)`; with almost everything ≥ 0.92 (treated as near-dup), virtually no edges form → near-edgeless similarity graph → 1 trivial community → degraded `rich_club`/topology → `crisis_mode`.
- Semantic recall returns flat / off-topic hits regardless of the query (it cannot rely on the collapsed vector space).

This affects **all users** (the cue is a positional id, not semantic), and is especially visible for non-English content.

## Fix

Embed `text` (the content) in `capture_turn()`. The cue stays a provenance label only. Fixing this single chokepoint covers the transcript, deferred-drain and recovery paths at once.

Re-embedding existing records from their intact `literal_surface` (e.g. via the reembed migration) restores the vector space: random-pair cosine drops 0.91 → 0.69 and recall returns relevant results again.

## Test

`test_capture_turn_embeds_content_not_cue` monkeypatches the embedder to record its input and asserts `capture_turn()` embeds the message text, never the cue. It fails on the pre-fix code, locking the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
