### PR TITLE
Fix stale SessionStart cache during active WAKE sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ Thumbs.db
 *.lancedb
 lancedb/
 runtime_*.json
+
+# Local backups (montées chirurgicales iai-pme)
+.venv-pkg-bak-*/
+*.bak-*

--- a/src/iai_mcp/_deploy/hooks/iai-mcp-session-recall.sh
+++ b/src/iai_mcp/_deploy/hooks/iai-mcp-session-recall.sh
@@ -43,10 +43,23 @@ ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 } >> "$log" 2>/dev/null
 
 # precache for SessionStart hook
-# Read the daemon-written cache whenever it is non-empty (no age cap).
+# Read the daemon-written cache whenever it is non-empty AND younger than the
+# max-age safety net. Default: 43200s (12h). Set
+# IAI_MCP_SESSION_CACHE_MAX_AGE_SEC=0 to disable the cap (legacy behaviour:
+# serve the cache regardless of age). Unset / non-numeric → 43200s.
+#
+# Rationale: if the daemon is down, crashed, or its regeneration path is
+# silently failing, we MUST NOT re-inject a multi-day-old prefix into every
+# new Claude/Codex session. The TTL is a back-stop; the primary defence is
+# `daemon._maybe_refresh_session_start_cache`, which refreshes the cache on
+# WAKE whenever new records land.
 # Each branch writes a contract log marker. Falls through to the live CLI path
 # on any miss.
 cache_path="$HOME/.iai-mcp/.session-start-payload.cached.md"
+cache_max_age="${IAI_MCP_SESSION_CACHE_MAX_AGE_SEC-43200}"
+case "$cache_max_age" in
+  ''|*[!0-9]*) cache_max_age=43200 ;;
+esac
 if [ -s "$cache_path" ]; then
   # Cross-platform mtime: try GNU stat, then BSD stat.
   cache_mtime=$(stat -c %Y "$cache_path" 2>/dev/null || stat -f %m "$cache_path" 2>/dev/null || echo 0)
@@ -55,13 +68,17 @@ if [ -s "$cache_path" ]; then
   else
     now_epoch=$(date +%s)
     age=$(( now_epoch - cache_mtime ))
-    cache_out=$(head -c 10000 "$cache_path" 2>/dev/null || true)
-    if [ -n "$cache_out" ]; then
-      printf '%s' "$cache_out"
-      echo "$ts cache-hit age=${age}s bytes=${#cache_out}" >> "$log" 2>/dev/null
-      exit 0
+    if [ "$cache_max_age" -gt 0 ] && [ "$age" -gt "$cache_max_age" ]; then
+      echo "$ts cache-stale age=${age}s max=${cache_max_age}s -> live-cli" >> "$log" 2>/dev/null
+    else
+      cache_out=$(head -c 10000 "$cache_path" 2>/dev/null || true)
+      if [ -n "$cache_out" ]; then
+        printf '%s' "$cache_out"
+        echo "$ts cache-hit age=${age}s bytes=${#cache_out}" >> "$log" 2>/dev/null
+        exit 0
+      fi
+      echo "$ts cache-miss empty (file existed but read returned 0 bytes)" >> "$log" 2>/dev/null
     fi
-    echo "$ts cache-miss empty (file existed but read returned 0 bytes)" >> "$log" 2>/dev/null
   fi
 elif [ -e "$cache_path" ]; then
   echo "$ts cache-miss empty (zero-byte file)" >> "$log" 2>/dev/null

--- a/src/iai_mcp/capture.py
+++ b/src/iai_mcp/capture.py
@@ -690,11 +690,19 @@ def capture_transcript(
                 text = str(content).strip()
             if not text:
                 continue
+            normalized = _normalize_ambient_capture_event(text)
+            if normalized is None:
+                counts["skipped"] += 1
+                continue
+            text, tier, cue_tag = normalized
+            cue = f"session {session_id} turn {seen}"
+            if cue_tag:
+                cue = f"{cue} {cue_tag}"
             result = capture_turn(
                 store,
-                cue=f"session {session_id} turn {seen}",
+                cue=cue,
                 text=text,
-                tier="episodic",
+                tier=tier,
                 session_id=session_id,
                 role=role,
                 ts=obj.get("timestamp"),
@@ -714,10 +722,18 @@ _NOISE_PATTERNS: tuple[tuple[str, str], ...] = (
     ("startswith", "<command-name>"),
     ("startswith", "Base directory for this skill:"),
     ("startswith", "<task-notification>"),
+    ("startswith", "Contexte éventuel donné par Loïc :"),
+    ("startswith", "Contexte eventuel donne par Loic :"),
     ("equals",     "[Request interrupted by user]"),
 )
 
-
+_DURABLE_MEMORY_RE = re.compile(
+    r"(?im)^(?:Mémoire durable pour IAE|Mémoire durable IAE|Memoire durable IAE)\s*:"
+)
+_DURABLE_NOTHING_RE = re.compile(
+    r"(?i)^(?:Mémoire durable pour IAE|Mémoire durable IAE|Memoire durable IAE)\s*:\s*"
+    r"(?:rien\s+[àa]\s+capturer|nothing\s+to\s+capture)\.?\s*$"
+)
 def _is_noise(text: str) -> bool:
     for match_type, pattern in _NOISE_PATTERNS:
         if match_type == "startswith":
@@ -727,6 +743,78 @@ def _is_noise(text: str) -> bool:
             if text == pattern:
                 return True
     return False
+
+
+def _extract_durable_memory_block(text: str) -> str | None:
+    match = _DURABLE_MEMORY_RE.search(text)
+    if not match:
+        return None
+
+    tail = text[match.start():].splitlines()
+    if not tail:
+        return None
+
+    heading = tail[0].strip()
+    if _DURABLE_NOTHING_RE.match(heading):
+        return None
+
+    bullets: list[str] = []
+    for line in tail[1:]:
+        stripped = line.strip()
+        if not stripped:
+            if bullets:
+                break
+            continue
+        if stripped.startswith(("- ", "* ")):
+            bullets.append(stripped)
+            if len(bullets) >= 8:
+                break
+            continue
+        if bullets:
+            break
+
+    if not bullets:
+        return None
+    return "\n".join([heading, *bullets])[:MAX_CAPTURE_LEN]
+
+
+def _is_journalise_scaffold(text: str) -> bool:
+    lowered = text.lower()
+    return (
+        "contexte éventuel donné par loïc" in lowered
+        or "contexte eventuel donne par loic" in lowered
+        or (
+            "résume la session" in lowered
+            and "journal/" in lowered
+            and "mémoire durable" in lowered
+        )
+        or (
+            "resume la session" in lowered
+            and "journal/" in lowered
+            and "memoire durable" in lowered
+        )
+    )
+
+
+def _normalize_ambient_capture_event(
+    text: str,
+    *,
+    tier: str = "episodic",
+) -> tuple[str, str, str | None] | None:
+    stripped = (text or "").strip()
+    if not stripped or _is_noise(stripped):
+        return None
+
+    durable = _extract_durable_memory_block(stripped)
+    if durable is not None:
+        return durable, "semantic", "memoire-durable-iae"
+    if _DURABLE_MEMORY_RE.search(stripped):
+        return None
+
+    if _is_journalise_scaffold(stripped):
+        return None
+
+    return stripped, tier, None
 
 
 def _parse_transcript_line(
@@ -750,10 +838,10 @@ def _parse_transcript_line(
         text = "\n".join(parts).strip()
     else:
         text = str(content).strip()
-    if not text:
+    normalized = _normalize_ambient_capture_event(text)
+    if normalized is None:
         return None
-    if _is_noise(text):
-        return None
+    text, _tier, _cue_tag = normalized
     return role, text, obj.get("uuid"), obj.get("timestamp")
 
 
@@ -766,6 +854,7 @@ def write_deferred_event(
     ts: str | None = None,
     source_uuid: str | None = None,
 ) -> Path:
+    normalized = _normalize_ambient_capture_event(text)
     deferred_dir = Path.home() / ".iai-mcp" / ".deferred-captures"
     deferred_dir.mkdir(parents=True, exist_ok=True)
     path = deferred_dir / f"{session_id}.live.jsonl"
@@ -779,10 +868,16 @@ def write_deferred_event(
                 "cwd": cwd or os.getcwd(),
             }
             fh.write(json.dumps(header, ensure_ascii=False) + "\n")
+        if normalized is None:
+            return path
+        text, tier, cue_tag = normalized
+        cue = f"session {session_id} turn"
+        if cue_tag:
+            cue = f"{cue} {cue_tag}"
         event = {
             "text": text,
-            "cue": f"session {session_id} turn",
-            "tier": "episodic",
+            "cue": cue,
+            "tier": tier,
             "role": role,
             "ts": ts if ts else datetime.now(timezone.utc).isoformat(),
         }
@@ -935,10 +1030,17 @@ def write_deferred_captures(
                         text = str(content).strip()
                     if not text:
                         continue
+                    normalized = _normalize_ambient_capture_event(text)
+                    if normalized is None:
+                        continue
+                    text, tier, cue_tag = normalized
+                    cue = f"session {session_id} turn {seen}"
+                    if cue_tag:
+                        cue = f"{cue} {cue_tag}"
                     event = {
                         "text": text,
-                        "cue": f"session {session_id} turn {seen}",
-                        "tier": "episodic",
+                        "cue": cue,
+                        "tier": tier,
                         "role": role,
                         "ts": obj.get("timestamp") or datetime.now(timezone.utc).isoformat(),
                     }
@@ -1163,6 +1265,17 @@ def _drain_deferred_captures_locked(
                 ev = json.loads(ln)
                 tier = ev.get("tier", "episodic")
                 role = ev.get("role", "user")
+                raw_text = ev.get("text", "")
+                normalized = _normalize_ambient_capture_event(raw_text, tier=tier)
+                if normalized is None:
+                    counts["events_skipped"] += 1
+                    total_events_processed += 1
+                    processed_in_file += 1
+                    continue
+                text, tier, cue_tag = normalized
+                cue = ev.get("cue", "")
+                if cue_tag and cue_tag not in cue:
+                    cue = f"{cue} {cue_tag}".strip()
 
                 # Pre-embed idem skip for conversational episodic events. The tag
                 # is reproduced exactly as capture_turn computes it (stripped,
@@ -1171,7 +1284,7 @@ def _drain_deferred_captures_locked(
                 # embedding), so it can never match a stored tag — leave those to
                 # fall through to capture_turn's own "too short" skip.
                 if _is_episodic_conversational(tier, role):
-                    norm_text = (ev.get("text", "") or "").strip()
+                    norm_text = text
                     if MIN_CAPTURE_LEN <= len(norm_text):
                         if len(norm_text) > MAX_CAPTURE_LEN:
                             norm_text = norm_text[:MAX_CAPTURE_LEN]
@@ -1226,8 +1339,8 @@ def _drain_deferred_captures_locked(
                 # is dedup-findable by tag and verbatim-recallable immediately.
                 result = _drain_write_pending(
                     store,
-                    cue=ev.get("cue", ""),
-                    text=ev.get("text", ""),
+                    cue=cue,
+                    text=text,
                     tier=tier,
                     session_id=session_id,
                     role=role,
@@ -1475,14 +1588,20 @@ def drain_permanent_failed_files(
                         continue
                     text = (ev.get("text") or "").strip()
                     role = ev.get("role", "user")
-                    if not text or _is_noise(text):
+                    tier = ev.get("tier", "episodic")
+                    normalized = _normalize_ambient_capture_event(text, tier=tier)
+                    if normalized is None:
                         file_dropped += 1
                         continue
+                    text, tier, cue_tag = normalized
+                    cue = ev.get("cue") or "recovered turn"
+                    if cue_tag and cue_tag not in cue:
+                        cue = f"{cue} {cue_tag}".strip()
                     result = capture_turn(
                         store,
-                        cue=ev.get("cue") or "recovered turn",
+                        cue=cue,
                         text=text,
-                        tier=ev.get("tier", "episodic"),
+                        tier=tier,
                         session_id=session_id,
                         role=role,
                         ts=ev.get("ts"),
@@ -1506,11 +1625,19 @@ def drain_permanent_failed_files(
                         file_dropped += 1
                         continue
                     role, text, src_uuid, src_ts = parsed
+                    normalized = _normalize_ambient_capture_event(text)
+                    if normalized is None:
+                        file_dropped += 1
+                        continue
+                    text, tier, cue_tag = normalized
+                    cue = "recovered turn"
+                    if cue_tag:
+                        cue = f"{cue} {cue_tag}"
                     result = capture_turn(
                         store,
-                        cue="recovered turn",
+                        cue=cue,
                         text=text,
-                        tier="episodic",
+                        tier=tier,
                         session_id=raw_session_id,
                         role=role,
                         ts=src_ts,
@@ -1629,11 +1756,21 @@ def _drain_active_live_captures_impl(
                 new_offset += 1
                 counts["events_skipped"] += 1
                 continue
+            tier = ev.get("tier", "episodic")
+            normalized = _normalize_ambient_capture_event(ev.get("text", ""), tier=tier)
+            if normalized is None:
+                new_offset += 1
+                counts["events_skipped"] += 1
+                continue
+            text, tier, cue_tag = normalized
+            cue = ev.get("cue", "")
+            if cue_tag and cue_tag not in cue:
+                cue = f"{cue} {cue_tag}".strip()
             result = capture_turn(
                 store,
-                cue=ev.get("cue", ""),
-                text=ev.get("text", ""),
-                tier=ev.get("tier", "episodic"),
+                cue=cue,
+                text=text,
+                tier=tier,
                 session_id=file_session_id,
                 role=ev.get("role", "user"),
                 ts=ev.get("ts"),

--- a/src/iai_mcp/cli/__init__.py
+++ b/src/iai_mcp/cli/__init__.py
@@ -130,8 +130,8 @@ def _send_jsonrpc_request(
         finally:
             try:
                 writer.close()
-                await writer.wait_closed()
-            except OSError:
+                await asyncio.wait_for(writer.wait_closed(), timeout=0.25)
+            except (OSError, asyncio.TimeoutError):
                 pass
 
     try:
@@ -162,8 +162,8 @@ def _send_socket_request(req: dict, *, timeout: float = 30.0) -> dict | None:
         finally:
             try:
                 writer.close()
-                await writer.wait_closed()
-            except OSError:
+                await asyncio.wait_for(writer.wait_closed(), timeout=0.25)
+            except (OSError, asyncio.TimeoutError):
                 pass
 
     return asyncio.run(_runner())

--- a/src/iai_mcp/core/__init__.py
+++ b/src/iai_mcp/core/__init__.py
@@ -240,7 +240,7 @@ def dispatch(store: MemoryStore, method: str, params: dict) -> dict:
                         _global_edges_hebb = store.incident_edges(
                             _all_cand_ids,
                             edge_types=["hebbian"],
-                            top_k=None,
+                            top_k=20,
                         )
                         graph._global_degree = {
                             str(_cid): len(_nbrs)
@@ -266,7 +266,7 @@ def dispatch(store: MemoryStore, method: str, params: dict) -> dict:
                         _contr_edges = store.incident_edges(
                             _all_candidate_ids,
                             edge_types=["contradicts"],
-                            top_k=None,
+                            top_k=10,
                         )
                         _contr_dst_ids = []
                         for _src_id, _edges in _contr_edges.items():
@@ -801,7 +801,8 @@ def dispatch(store: MemoryStore, method: str, params: dict) -> dict:
                 total_dynamic_tokens=1000,
             )
             return _payload_to_json(empty)
-        _graph, assignment, rc = retrieve.build_runtime_graph(store)
+        from iai_mcp import runtime_graph_cache as _rgc
+        assignment, rc, _max_degree, _source = _rgc.load_recall_structural(store)
         payload = assemble_session_start(
             store, assignment, rc,
             session_id=sid,
@@ -1119,8 +1120,8 @@ def _first_turn_recall_hook(
         if not warm_hit_ids and str(session_id) not in _CORE_CASCADE_FIRED_PER_SESSION:
             try:
                 from iai_mcp.hippea_cascade import compute_core_side_warm_snapshot
-                from iai_mcp import retrieve as _retrieve
-                _graph, assignment, _rc = _retrieve.build_runtime_graph(store)
+                from iai_mcp import runtime_graph_cache as _rgc
+                assignment, _rc, _max_degree, _source = _rgc.load_recall_structural(store)
                 warm_ids = compute_core_side_warm_snapshot(
                     store, assignment, top_k=3, max_records=50,
                 )

--- a/src/iai_mcp/core/__init__.py
+++ b/src/iai_mcp/core/__init__.py
@@ -240,7 +240,7 @@ def dispatch(store: MemoryStore, method: str, params: dict) -> dict:
                         _global_edges_hebb = store.incident_edges(
                             _all_cand_ids,
                             edge_types=["hebbian"],
-                            top_k=20,
+                            top_k=None,
                         )
                         graph._global_degree = {
                             str(_cid): len(_nbrs)
@@ -266,7 +266,7 @@ def dispatch(store: MemoryStore, method: str, params: dict) -> dict:
                         _contr_edges = store.incident_edges(
                             _all_candidate_ids,
                             edge_types=["contradicts"],
-                            top_k=10,
+                            top_k=None,
                         )
                         _contr_dst_ids = []
                         for _src_id, _edges in _contr_edges.items():

--- a/src/iai_mcp/core/__init__.py
+++ b/src/iai_mcp/core/__init__.py
@@ -240,6 +240,9 @@ def dispatch(store: MemoryStore, method: str, params: dict) -> dict:
                         _global_edges_hebb = store.incident_edges(
                             _all_cand_ids,
                             edge_types=["hebbian"],
+                            # Keep the full degree signal: capping here makes
+                            # hubs with very different connectivity
+                            # indistinguishable in the ranking blend.
                             top_k=None,
                         )
                         graph._global_degree = {
@@ -266,6 +269,9 @@ def dispatch(store: MemoryStore, method: str, params: dict) -> dict:
                         _contr_edges = store.incident_edges(
                             _all_candidate_ids,
                             edge_types=["contradicts"],
+                            # Contradictions are correctness signals, not
+                            # neighbourhood garnish; do not hide low-weight
+                            # contradicts behind an arbitrary cap.
                             top_k=None,
                         )
                         _contr_dst_ids = []

--- a/src/iai_mcp/daemon/__init__.py
+++ b/src/iai_mcp/daemon/__init__.py
@@ -64,6 +64,8 @@ TICK_INTERVAL_SEC: int = 30
 STARTUP_DEFERRED_DRAIN_GRACE_SEC: float = float(
     os.environ.get("IAI_MCP_STARTUP_DEFERRED_DRAIN_GRACE_SEC", "20.0")
 )
+CAPTURE_QUEUE_RETRY_PENDING_KEY: str = "_capture_queue_drain_retry_pending"
+CAPTURE_QUEUE_LAST_RETRY_KEY: str = "_capture_queue_drain_last_retry_at"
 
 DEFAULT_CYCLE_COUNT: int = 4
 
@@ -169,6 +171,89 @@ def _mcp_recent_activity(mcp_socket, *, window_sec: float) -> bool:
         return (time.monotonic() - float(mcp_socket.last_activity_ts)) < window_sec
     except Exception:  # noqa: BLE001 -- activity probe must never crash scheduling
         return False
+
+
+def _capture_queue_pending_count(capture_queue) -> int | None:
+    try:
+        return int(capture_queue.pending_count())
+    except Exception:  # noqa: BLE001 -- telemetry only
+        return None
+
+
+def _set_capture_queue_retry_state(
+    state: dict,
+    *,
+    pending: bool,
+    pending_count: int | None = None,
+) -> None:
+    state[CAPTURE_QUEUE_RETRY_PENDING_KEY] = bool(pending)
+    state[CAPTURE_QUEUE_LAST_RETRY_KEY] = datetime.now(timezone.utc).isoformat()
+    if pending_count is not None:
+        state["_capture_queue_pending_count"] = pending_count
+
+
+def _drain_capture_queue_once(store, capture_queue, capture_handler, *, phase: str) -> dict:
+    ingested = int(capture_queue.ingest_pending(capture_handler))
+    pending_count = _capture_queue_pending_count(capture_queue)
+    payload = {"phase": phase, "ingested": ingested}
+    if pending_count is not None:
+        payload["pending_count"] = pending_count
+    if ingested > 0:
+        write_event(store, "capture_queue_drained", payload, severity="info")
+    return {
+        "ingested": ingested,
+        "pending_count": pending_count,
+        "pending": bool(pending_count) if pending_count is not None else False,
+    }
+
+
+async def _retry_capture_queue_drain_if_due(
+    store: MemoryStore,
+    state: dict,
+    *,
+    capture_queue=None,
+    capture_handler: Callable[[dict], None] | None = None,
+    mcp_socket: SocketServer | None = None,
+) -> None:
+    if (
+        capture_queue is None
+        or capture_handler is None
+        or not state.get(CAPTURE_QUEUE_RETRY_PENDING_KEY)
+    ):
+        return
+    if _mcp_recent_activity(mcp_socket, window_sec=STARTUP_DEFERRED_DRAIN_GRACE_SEC):
+        return
+    try:
+        result = await asyncio.to_thread(
+            _drain_capture_queue_once,
+            store,
+            capture_queue,
+            capture_handler,
+            phase="tick_retry",
+        )
+        _set_capture_queue_retry_state(
+            state,
+            pending=bool(result.get("pending")),
+            pending_count=result.get("pending_count"),
+        )
+        await asyncio.to_thread(save_state, state)
+    except Exception as exc:  # noqa: BLE001 -- tick retry must never crash daemon
+        _set_capture_queue_retry_state(state, pending=True)
+        log.warning("capture queue retry drain failed: %s", exc, exc_info=True)
+        try:
+            await asyncio.to_thread(
+                write_event,
+                store,
+                "capture_queue_drain_failed",
+                {"phase": "tick_retry", "error": str(exc)[:200]},
+                severity="warning",
+            )
+        except Exception:  # noqa: BLE001 -- event write inside boundary guard
+            log.debug("capture_queue_drain_failed retry event write failed")
+        try:
+            await asyncio.to_thread(save_state, state)
+        except (OSError, ValueError) as save_exc:
+            log.debug("save_state after capture queue retry failure failed: %s", save_exc)
 
 
 # Idle-countdown decisions. The lifecycle tick translates these into FSM events.
@@ -779,6 +864,8 @@ async def _tick_body(
     state: dict,
     *,
     mcp_socket: SocketServer | None = None,
+    capture_queue=None,
+    capture_handler: Callable[[dict], None] | None = None,
 ) -> None:
     try:
         from iai_mcp.daemon_state import (
@@ -891,6 +978,16 @@ async def _tick_body(
     except Exception as e:  # noqa: BLE001 -- periodic flush MUST NOT crash tick
         log.debug("edges buffer periodic flush skipped: %s", str(e)[:120])
 
+    try:
+        await _retry_capture_queue_drain_if_due(
+            store,
+            state,
+            capture_queue=capture_queue,
+            capture_handler=capture_handler,
+            mcp_socket=mcp_socket,
+        )
+    except Exception:  # noqa: BLE001 -- retry boundary must not affect tick
+        log.debug("tick step capture_queue_retry failed", exc_info=True)
 
     if state.get("scheduler_paused") is True:
         try:
@@ -960,11 +1057,19 @@ async def _scheduler_tick(
     *,
     tick_body: Callable[..., Awaitable[None]] | None = None,
     mcp_socket: SocketServer | None = None,
+    capture_queue=None,
+    capture_handler: Callable[[dict], None] | None = None,
 ) -> None:
     body = tick_body or _tick_body
     while True:
         try:
-            await body(store, state, mcp_socket=mcp_socket)
+            await body(
+                store,
+                state,
+                mcp_socket=mcp_socket,
+                capture_queue=capture_queue,
+                capture_handler=capture_handler,
+            )
         except TypeError:
             try:
                 await body(store, state)
@@ -1414,27 +1519,53 @@ async def main() -> int:
                         mcp_socket,
                         window_sec=STARTUP_DEFERRED_DRAIN_GRACE_SEC,
                     ):
+                        pending_count = _capture_queue_pending_count(_capture_queue)
+                        retry_pending = (
+                            pending_count is None or pending_count > 0
+                        )
+                        _set_capture_queue_retry_state(
+                            state,
+                            pending=retry_pending,
+                            pending_count=pending_count,
+                        )
+                        await asyncio.to_thread(save_state, state)
+                        payload = {
+                            "reason": "recent_mcp_activity",
+                            "retry_pending": retry_pending,
+                        }
+                        if pending_count is not None:
+                            payload["pending_count"] = pending_count
                         await asyncio.to_thread(
                             write_event,
                             store,
                             "capture_queue_drain_startup_skipped",
-                            {"reason": "recent_mcp_activity"},
+                            payload,
                             severity="info",
                         )
                         return
-                    ingested = await asyncio.to_thread(
-                        _capture_queue.ingest_pending, _capture_handler,
+                    result = await asyncio.to_thread(
+                        _drain_capture_queue_once,
+                        store,
+                        _capture_queue,
+                        _capture_handler,
+                        phase="startup",
                     )
-                    if ingested > 0:
-                        await asyncio.to_thread(
-                            write_event,
-                            store,
-                            "capture_queue_drained",
-                            {"phase": "startup", "ingested": ingested},
-                            severity="info",
-                        )
+                    _set_capture_queue_retry_state(
+                        state,
+                        pending=bool(result.get("pending")),
+                        pending_count=result.get("pending_count"),
+                    )
+                    await asyncio.to_thread(save_state, state)
                 except Exception as exc:  # noqa: BLE001 -- never block socket serving
+                    _set_capture_queue_retry_state(state, pending=True)
                     log.warning("capture queue drain failed at startup: %s", exc, exc_info=True)
+                    try:
+                        await asyncio.to_thread(save_state, state)
+                    except (OSError, ValueError) as save_exc:
+                        log.debug(
+                            "save_state after startup capture queue failure failed: %s",
+                            save_exc,
+                        )
                     try:
                         await asyncio.to_thread(
                             write_event,
@@ -1616,7 +1747,13 @@ async def main() -> int:
         )
 
         tick_task = asyncio.create_task(
-            _scheduler_tick(store, state, mcp_socket=mcp_socket)
+            _scheduler_tick(
+                store,
+                state,
+                mcp_socket=mcp_socket,
+                capture_queue=_capture_queue,
+                capture_handler=_capture_handler,
+            )
         )
         audit_task = asyncio.create_task(
             continuous_audit(store, shutdown)

--- a/src/iai_mcp/daemon/__init__.py
+++ b/src/iai_mcp/daemon/__init__.py
@@ -61,6 +61,9 @@ VALID_TRANSITIONS: dict[str, set[str]] = {
 }
 
 TICK_INTERVAL_SEC: int = 30
+STARTUP_DEFERRED_DRAIN_GRACE_SEC: float = float(
+    os.environ.get("IAI_MCP_STARTUP_DEFERRED_DRAIN_GRACE_SEC", "20.0")
+)
 
 DEFAULT_CYCLE_COUNT: int = 4
 
@@ -157,6 +160,15 @@ def _raise_fd_limit() -> None:
 def _should_drain_on_drowsy_edge(prev, current) -> bool:
     from iai_mcp.lifecycle_state import LifecycleState as _L
     return prev is _L.WAKE and current is _L.DROWSY
+
+
+def _mcp_recent_activity(mcp_socket, *, window_sec: float) -> bool:
+    if mcp_socket is None:
+        return False
+    try:
+        return (time.monotonic() - float(mcp_socket.last_activity_ts)) < window_sec
+    except Exception:  # noqa: BLE001 -- activity probe must never crash scheduling
+        return False
 
 
 # Idle-countdown decisions. The lifecycle tick translates these into FSM events.
@@ -610,13 +622,17 @@ def _write_session_start_cache(
             return {"action": "skipped", "reason": "runtime_graph_cache_cold"}
 
         try:
-            from iai_mcp import retrieve
             from iai_mcp.session import (
                 _compose_session_start_payload,
                 format_payload_as_markdown,
             )
 
-            _graph, assignment, rc = retrieve.build_runtime_graph(store)
+            if force_rebuild:
+                from iai_mcp import retrieve
+                _graph, assignment, rc = retrieve.build_runtime_graph(store)
+            else:
+                from iai_mcp import runtime_graph_cache as _rgc
+                assignment, rc, _max_degree, _source = _rgc.load_recall_structural(store)
             payload = _compose_session_start_payload(
                 store,
                 assignment,
@@ -1285,6 +1301,8 @@ async def main() -> int:
         except Exception:  # noqa: BLE001 -- boot MUST NOT block on wake-handler
             log.debug("wake signal consume failed", exc_info=True)
 
+        _capture_queue = None
+        _capture_handler = None
         try:
             from iai_mcp.capture import capture_turn as _capture_turn
             from iai_mcp.capture_queue import CaptureQueue
@@ -1299,24 +1317,13 @@ async def main() -> int:
                     "role": record.get("role", "user"),
                 }
                 _capture_turn(store, **kwargs)
-
-            ingested = await asyncio.to_thread(
-                _capture_queue.ingest_pending, _capture_handler,
-            )
-            if ingested > 0:
-                write_event(
-                    store,
-                    "capture_queue_drained",
-                    {"phase": "startup", "ingested": ingested},
-                    severity="info",
-                )
         except Exception as exc:  # noqa: BLE001 -- never block boot on queue drain
-            log.warning("capture queue drain failed at startup: %s", exc, exc_info=True)
+            log.warning("capture queue init failed at startup: %s", exc, exc_info=True)
             try:
                 write_event(
                     store,
                     "capture_queue_drain_failed",
-                    {"phase": "startup", "error": str(exc)[:200]},
+                    {"phase": "startup_init", "error": str(exc)[:200]},
                     severity="warning",
                 )
             except Exception:  # noqa: BLE001 -- event write inside boundary guard
@@ -1398,19 +1405,60 @@ async def main() -> int:
         mcp_socket_task = asyncio.create_task(mcp_socket.serve())
         await asyncio.sleep(0.05)
 
+        if _capture_queue is not None and _capture_handler is not None:
+            async def _capture_queue_drain_and_report() -> None:
+                try:
+                    if STARTUP_DEFERRED_DRAIN_GRACE_SEC > 0:
+                        await asyncio.sleep(STARTUP_DEFERRED_DRAIN_GRACE_SEC)
+                    if _mcp_recent_activity(
+                        mcp_socket,
+                        window_sec=STARTUP_DEFERRED_DRAIN_GRACE_SEC,
+                    ):
+                        await asyncio.to_thread(
+                            write_event,
+                            store,
+                            "capture_queue_drain_startup_skipped",
+                            {"reason": "recent_mcp_activity"},
+                            severity="info",
+                        )
+                        return
+                    ingested = await asyncio.to_thread(
+                        _capture_queue.ingest_pending, _capture_handler,
+                    )
+                    if ingested > 0:
+                        await asyncio.to_thread(
+                            write_event,
+                            store,
+                            "capture_queue_drained",
+                            {"phase": "startup", "ingested": ingested},
+                            severity="info",
+                        )
+                except Exception as exc:  # noqa: BLE001 -- never block socket serving
+                    log.warning("capture queue drain failed at startup: %s", exc, exc_info=True)
+                    try:
+                        await asyncio.to_thread(
+                            write_event,
+                            store,
+                            "capture_queue_drain_failed",
+                            {"phase": "startup", "error": str(exc)[:200]},
+                            severity="warning",
+                        )
+                    except Exception:  # noqa: BLE001 -- event write inside boundary guard
+                        log.debug("capture_queue_drain_failed event write failed")
+
+            asyncio.create_task(_capture_queue_drain_and_report())
+
         try:
             from iai_mcp import runtime_graph_cache as _rgc_mod
 
             async def _boot_preload() -> None:
                 try:
-                    from iai_mcp import retrieve as _retrieve_preload
-                    # build_runtime_graph already persists the cache internally
-                    # (with the full node_payload) on a miss. The previous extra
-                    # save(..., node_payload=None, ...) here overwrote that good
-                    # cache with a payload-less one (forcing a pandas re-read on
-                    # the next hit) — so we just warm the cache and drop it.
+                    # WAKE boot must not stream the whole Hippo store. The recall
+                    # hot path is ANN-first and only needs the structural overlay
+                    # or last-good snapshot; expensive rebuilds belong to sleep /
+                    # drowsy paths.
                     await asyncio.to_thread(
-                        _retrieve_preload.build_runtime_graph, store,
+                        _rgc_mod.load_recall_structural, store,
                     )
                 except Exception as _exc:  # noqa: BLE001 -- preload MUST NOT crash daemon
                     log.debug("boot_preload failed: %s", _exc, exc_info=True)
@@ -1431,6 +1479,20 @@ async def main() -> int:
 
             async def _drain_and_report() -> None:
                 try:
+                    if STARTUP_DEFERRED_DRAIN_GRACE_SEC > 0:
+                        await asyncio.sleep(STARTUP_DEFERRED_DRAIN_GRACE_SEC)
+                    if _mcp_recent_activity(
+                        mcp_socket,
+                        window_sec=STARTUP_DEFERRED_DRAIN_GRACE_SEC,
+                    ):
+                        await asyncio.to_thread(
+                            write_event,
+                            store,
+                            "deferred_drain_startup_skipped",
+                            {"reason": "recent_mcp_activity"},
+                            severity="info",
+                        )
+                        return
                     drain_counts = await asyncio.to_thread(_drain, store)
                     if drain_counts.get("files_drained") or drain_counts.get(
                         "files_failed"

--- a/src/iai_mcp/daemon/__init__.py
+++ b/src/iai_mcp/daemon/__init__.py
@@ -71,7 +71,16 @@ S4_FIRST_ITER_GRACE_SEC: float = float(
 )
 
 SESSION_START_CACHE_PATH = Path.home() / ".iai-mcp" / ".session-start-payload.cached.md"
+SESSION_START_CACHE_META_PATH = (
+    Path.home() / ".iai-mcp" / ".session-start-payload.cached.meta.json"
+)
 from iai_mcp.session import SESSION_START_CACHE_MAX_CHARS  # noqa: E402 -- placed after PATH constant for readability
+
+SESSION_START_CACHE_REFRESH_MIN_SEC_DEFAULT: float = 60.0
+# Single-flight lock for refreshes — the SLEEP path also routes through it so a
+# WAKE refresh kicked from the wake-sequence hook never races a sleep-pipeline
+# write on the same file.
+_session_start_cache_lock = threading.Lock()
 
 INTERRUPT_RECENT_ACTIVITY_WINDOW_SEC: float = 30.0
 
@@ -373,47 +382,380 @@ def _update_pending_digest(state: dict, cycle_result: dict) -> None:
     state["pending_digest"] = digest
 
 
-def _write_session_start_cache(store, *, cache_path: Path = SESSION_START_CACHE_PATH) -> None:
+def _default_session_start_cache_meta_path(cache_path: Path) -> Path:
+    """Canonical sidecar path next to ``cache_path``.
+
+    ``Path.with_suffix(".meta.json")`` REPLACES the existing suffix, so
+    ``.session-start-payload.cached.md`` → ``.session-start-payload.cached.meta.json``
+    (matches ``SESSION_START_CACHE_META_PATH``). Both the writer and the
+    reader route through this single helper so a future change to the naming
+    convention cannot accidentally desync them.
+    """
+    return cache_path.with_suffix(".meta.json")
+
+
+def _session_start_cache_watermark(store) -> dict:
+    """Cheap probe used to decide whether the cache needs regenerating.
+
+    Returns a dict with `records_count`, `max_vec_label`, `max_created_at`,
+    `max_updated_at`. The probe runs a single SELECT — no rebuild, no spawn —
+    so it is safe to call on every WAKE tick.
+
+    ``max_vec_label`` is the monotone AUTOINCREMENT primary key on the records
+    table: it strictly increases on every insert, so it catches records inserted
+    *now* with an *old* ``created_at`` (e.g. backfilled from a transcript), which
+    a ``MAX(created_at)`` comparison would miss.
+    """
     try:
-        from iai_mcp import retrieve
-        from iai_mcp.session import (
-            _compose_session_start_payload,
-            format_payload_as_markdown,
-        )
+        with store.db._conn_lock:
+            row = store.db._conn.execute(
+                "SELECT COUNT(*),"
+                " COALESCE(MAX(vec_label), 0),"
+                " COALESCE(MAX(created_at), ''),"
+                " COALESCE(MAX(updated_at), '')"
+                " FROM records WHERE tombstoned_at IS NULL"
+            ).fetchone()
+    except Exception as exc:  # noqa: BLE001 -- watermark probe MUST NOT crash
+        log.debug("session_start_cache watermark probe failed: %s", exc)
+        return {
+            "records_count": -1,
+            "max_vec_label": -1,
+            "max_created_at": "",
+            "max_updated_at": "",
+        }
+    if not row:
+        return {
+            "records_count": 0,
+            "max_vec_label": 0,
+            "max_created_at": "",
+            "max_updated_at": "",
+        }
+    return {
+        "records_count": int(row[0] or 0),
+        "max_vec_label": int(row[1] or 0),
+        "max_created_at": str(row[2] or ""),
+        "max_updated_at": str(row[3] or ""),
+    }
 
-        _graph, assignment, rc = retrieve.build_runtime_graph(store)
-        payload = _compose_session_start_payload(
-            store,
-            assignment,
-            rc,
-            session_id="precache",
-            profile_state={"wake_depth": "standard"},
-        )
-        rendered = format_payload_as_markdown(payload)
-        if not rendered:
-            return
-        if len(rendered) > SESSION_START_CACHE_MAX_CHARS:
-            rendered = rendered[:SESSION_START_CACHE_MAX_CHARS]
 
-        cache_path.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path = cache_path.with_suffix(cache_path.suffix + ".tmp")
+def _load_session_start_cache_meta(meta_path: Path) -> dict | None:
+    try:
+        with open(meta_path, encoding="utf-8") as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        return None
+    except (OSError, ValueError) as exc:
+        log.debug("session_start_cache meta load failed: %s", exc)
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def _save_session_start_cache_meta(meta_path: Path, meta: dict) -> None:
+    try:
+        meta_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = meta_path.with_suffix(meta_path.suffix + ".tmp")
         with open(tmp_path, "w", encoding="utf-8") as f:
-            f.write(rendered)
+            json.dump(meta, f, separators=(",", ":"))
             f.flush()
             os.fsync(f.fileno())
         os.chmod(tmp_path, 0o600)
-        os.replace(tmp_path, cache_path)
-    except Exception as exc:  # noqa: BLE001 -- cache write MUST NOT crash the REM loop
-        log.warning("session start cache write failed: %s", exc, exc_info=True)
+        os.replace(tmp_path, meta_path)
+    except (OSError, ValueError) as exc:
+        log.debug("session_start_cache meta save failed: %s", exc)
+
+
+def _runtime_graph_cache_is_warm(store) -> bool:
+    """Cheap probe: returns False if a full runtime-graph rebuild is required.
+
+    Wraps `retrieve._runtime_graph_rebuild_needed` (a disk read + COUNT(*), no
+    rebuild) so the WAKE refresh path can skip cleanly with reason
+    ``runtime_graph_cache_cold`` instead of spawning the expensive child fleet
+    inside the lifecycle tick.
+    """
+    try:
+        from iai_mcp import retrieve
+        return not retrieve._runtime_graph_rebuild_needed(store)
+    except Exception as exc:  # noqa: BLE001 -- probe MUST NOT crash
+        log.debug("runtime_graph_cache warm probe failed: %s", exc)
+        return False
+
+
+def _should_refresh_session_start_cache(
+    store,
+    *,
+    cache_path: Path,
+    meta_path: Path,
+    min_interval_sec: float,
+    now_monotonic: float | None = None,
+) -> tuple[bool, str, dict]:
+    """Decide whether the cache should be regenerated right now.
+
+    Returns ``(should_refresh, reason, current_watermark)``. ``reason`` is the
+    string emitted into the ``session_start_cache_write_skipped`` / ``_started``
+    events so the user can tell at a glance why a tick did or did not refresh.
+
+    Decisions, in order:
+
+    * No cache file yet → ``cache_absent``.
+    * Cache exists but mtime is younger than ``min_interval_sec`` → block to
+      avoid thrashing under burst ingestion (``min_interval_not_elapsed``).
+    * No meta sidecar (older install or pre-watermark cache) → refresh and
+      backfill the sidecar (``meta_absent``).
+    * Watermark probe matches the stored watermark exactly → nothing new,
+      ``no_new_records``.
+    * Otherwise refresh (``watermark_changed``).
+    """
+    current = _session_start_cache_watermark(store)
+    try:
+        cache_mtime = cache_path.stat().st_mtime
+    except (FileNotFoundError, OSError):
+        return True, "cache_absent", current
+
+    if min_interval_sec > 0:
+        age = time.time() - cache_mtime
+        if age < min_interval_sec:
+            return False, "min_interval_not_elapsed", current
+
+    stored = _load_session_start_cache_meta(meta_path)
+    if not stored:
+        return True, "meta_absent", current
+
+    if (
+        int(stored.get("records_count", -1)) == current["records_count"]
+        and int(stored.get("max_vec_label", -1)) == current["max_vec_label"]
+        and str(stored.get("max_created_at", "")) == current["max_created_at"]
+        and str(stored.get("max_updated_at", "")) == current["max_updated_at"]
+    ):
+        return False, "no_new_records", current
+
+    return True, "watermark_changed", current
+
+
+def _emit_session_start_cache_event(
+    store,
+    kind: str,
+    data: dict,
+    *,
+    severity: str = "info",
+) -> None:
+    """Best-effort event write that never crashes the caller."""
+    try:
+        write_event(store, kind, data, severity=severity)
+    except Exception:  # noqa: BLE001 -- event write must not crash the refresh path
+        log.debug("failed to write %s event", kind)
+
+
+def _write_session_start_cache(
+    store,
+    *,
+    cache_path: Path = SESSION_START_CACHE_PATH,
+    meta_path: Path | None = None,
+    trigger: str = "sleep_pipeline",
+    force_rebuild: bool = True,
+) -> dict:
+    """Write the SessionStart cache from the current memory store.
+
+    Parameters
+    ----------
+    cache_path : Path
+        Target file; defaults to ``~/.iai-mcp/.session-start-payload.cached.md``.
+    meta_path : Path
+        Sidecar with the watermark; defaults to ``cache_path`` + ``.meta.json``
+        so a custom ``cache_path`` (tests) keeps the meta next to the cache.
+    trigger : str
+        Why this write was kicked: ``sleep_pipeline`` (under EXCLUSIVE lock,
+        rebuild allowed), ``wake_sequence`` (after fresh ingest/reembed),
+        ``periodic_wake`` (watermark drifted), ``manual`` (CLI / test).
+    force_rebuild : bool
+        When True (the SLEEP path), we let ``build_runtime_graph`` do whatever
+        rebuild it needs — we already hold EX and the consolidation window is the
+        right moment for the expensive recompute. When False (WAKE path), we
+        skip with ``runtime_graph_cache_cold`` rather than spawn a rebuild on a
+        live tick.
+
+    Returns a small status dict with the reason and watermark so callers
+    (e.g. tests) can assert without grovelling through events.
+    """
+    started_at = time.monotonic()
+    if not _session_start_cache_lock.acquire(blocking=False):
+        _emit_session_start_cache_event(
+            store,
+            "session_start_cache_write_skipped",
+            {"reason": "refresh_in_progress", "trigger": trigger,
+             "cache_path": str(cache_path)},
+        )
+        return {"action": "skipped", "reason": "refresh_in_progress"}
+
+    if meta_path is None:
+        meta_path = _default_session_start_cache_meta_path(cache_path)
+
+    try:
+        _emit_session_start_cache_event(
+            store,
+            "session_start_cache_write_started",
+            {"trigger": trigger, "cache_path": str(cache_path),
+             "force_rebuild": bool(force_rebuild)},
+        )
+
+        if not force_rebuild and not _runtime_graph_cache_is_warm(store):
+            _emit_session_start_cache_event(
+                store,
+                "session_start_cache_write_skipped",
+                {"reason": "runtime_graph_cache_cold", "trigger": trigger,
+                 "cache_path": str(cache_path),
+                 "duration_ms": int((time.monotonic() - started_at) * 1000)},
+            )
+            return {"action": "skipped", "reason": "runtime_graph_cache_cold"}
+
         try:
-            write_event(
+            from iai_mcp import retrieve
+            from iai_mcp.session import (
+                _compose_session_start_payload,
+                format_payload_as_markdown,
+            )
+
+            _graph, assignment, rc = retrieve.build_runtime_graph(store)
+            payload = _compose_session_start_payload(
+                store,
+                assignment,
+                rc,
+                session_id="precache",
+                profile_state={"wake_depth": "standard"},
+            )
+            rendered = format_payload_as_markdown(payload)
+            if not rendered:
+                _emit_session_start_cache_event(
+                    store,
+                    "session_start_cache_write_skipped",
+                    {"reason": "empty_render", "trigger": trigger,
+                     "cache_path": str(cache_path),
+                     "duration_ms": int((time.monotonic() - started_at) * 1000)},
+                )
+                return {"action": "skipped", "reason": "empty_render"}
+            if len(rendered) > SESSION_START_CACHE_MAX_CHARS:
+                rendered = rendered[:SESSION_START_CACHE_MAX_CHARS]
+
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = cache_path.with_suffix(cache_path.suffix + ".tmp")
+            with open(tmp_path, "w", encoding="utf-8") as f:
+                f.write(rendered)
+                f.flush()
+                os.fsync(f.fileno())
+            os.chmod(tmp_path, 0o600)
+            os.replace(tmp_path, cache_path)
+
+            watermark = _session_start_cache_watermark(store)
+            meta = {
+                "records_count": watermark["records_count"],
+                "max_vec_label": watermark["max_vec_label"],
+                "max_created_at": watermark["max_created_at"],
+                "max_updated_at": watermark["max_updated_at"],
+                "rendered_chars": len(rendered),
+                "generated_at": datetime.now(timezone.utc).isoformat(),
+                "trigger": trigger,
+            }
+            _save_session_start_cache_meta(meta_path, meta)
+
+            _emit_session_start_cache_event(
+                store,
+                "session_start_cache_write_success",
+                {
+                    "trigger": trigger,
+                    "cache_path": str(cache_path),
+                    "rendered_chars": len(rendered),
+                    "records_count": watermark["records_count"],
+                    "max_vec_label": watermark["max_vec_label"],
+                    "max_record_created_at": watermark["max_created_at"],
+                    "max_updated_at": watermark["max_updated_at"],
+                    "duration_ms": int((time.monotonic() - started_at) * 1000),
+                },
+            )
+            return {
+                "action": "wrote",
+                "rendered_chars": len(rendered),
+                "watermark": watermark,
+            }
+        except Exception as exc:  # noqa: BLE001 -- cache write MUST NOT crash the loop
+            log.warning("session start cache write failed: %s", exc, exc_info=True)
+            _emit_session_start_cache_event(
                 store,
                 "session_start_cache_write_failed",
-                {"error": str(exc)[:200]},
+                {
+                    "trigger": trigger,
+                    "cache_path": str(cache_path),
+                    "reason": type(exc).__name__,
+                    "error": str(exc)[:200],
+                    "duration_ms": int((time.monotonic() - started_at) * 1000),
+                },
                 severity="warning",
             )
-        except Exception:  # noqa: BLE001 -- event write inside boundary guard
-            log.debug("failed to write session_start_cache_write_failed event")
+            return {"action": "failed", "reason": type(exc).__name__}
+    finally:
+        _session_start_cache_lock.release()
+
+
+def _maybe_refresh_session_start_cache(
+    store,
+    *,
+    trigger: str,
+    cache_path: Path = SESSION_START_CACHE_PATH,
+    meta_path: Path | None = None,
+    min_interval_sec: float | None = None,
+    force_rebuild: bool = False,
+) -> dict:
+    """Best-effort WAKE-time refresh.
+
+    Always:
+      * runs the cheap watermark probe + min-interval gate before doing any work;
+      * acquires the single-flight lock non-blocking;
+      * skips if the runtime graph cache is cold;
+      * never raises — callers from the lifecycle tick depend on this.
+    """
+    if meta_path is None:
+        meta_path = _default_session_start_cache_meta_path(cache_path)
+    if min_interval_sec is None:
+        try:
+            min_interval_sec = float(
+                os.environ.get(
+                    "IAI_MCP_SESSION_CACHE_REFRESH_MIN_SEC",
+                    str(SESSION_START_CACHE_REFRESH_MIN_SEC_DEFAULT),
+                )
+            )
+        except (TypeError, ValueError):
+            min_interval_sec = SESSION_START_CACHE_REFRESH_MIN_SEC_DEFAULT
+
+    try:
+        should, reason, _wm = _should_refresh_session_start_cache(
+            store,
+            cache_path=cache_path,
+            meta_path=meta_path,
+            min_interval_sec=min_interval_sec,
+        )
+    except Exception as exc:  # noqa: BLE001 -- gate probe must not crash
+        log.debug("session_start_cache should-refresh probe failed: %s", exc)
+        return {"action": "skipped", "reason": "probe_failed"}
+
+    if not should:
+        _emit_session_start_cache_event(
+            store,
+            "session_start_cache_write_skipped",
+            {"reason": reason, "trigger": trigger, "cache_path": str(cache_path)},
+        )
+        return {"action": "skipped", "reason": reason}
+
+    try:
+        return _write_session_start_cache(
+            store,
+            cache_path=cache_path,
+            meta_path=meta_path,
+            trigger=trigger,
+            force_rebuild=force_rebuild,
+        )
+    except Exception as exc:  # noqa: BLE001 -- belt-and-suspenders; _write already guards
+        log.debug("session_start_cache refresh wrapper failed: %s", exc)
+        return {"action": "failed", "reason": type(exc).__name__}
 
 
 async def _tick_body(
@@ -1458,6 +1800,28 @@ async def main() -> int:
                                     _kick_drowsy_rgc_rebuild(store)
                                 except Exception:  # noqa: BLE001 -- best-effort
                                     log.debug("drowsy-edge kick failed", exc_info=True)
+                                # Kick a light, best-effort SessionStart cache refresh:
+                                # new records just got embedded (reembed_count > 0 or
+                                # ingest_count > 0), so what the hook would serve from
+                                # disk is now stale. _maybe_refresh_session_start_cache
+                                # gates on min-interval + single-flight + runtime-graph
+                                # warm — if any of those say no, it emits a _skipped
+                                # event and returns.
+                                if (
+                                    int(_wake_seq_result.get("reembed_count", 0) or 0) > 0
+                                    or int(_wake_seq_result.get("ingest_count", 0) or 0) > 0
+                                ):
+                                    try:
+                                        await asyncio.to_thread(
+                                            _maybe_refresh_session_start_cache,
+                                            store,
+                                            trigger="wake_sequence",
+                                        )
+                                    except Exception:  # noqa: BLE001 -- best-effort
+                                        log.debug(
+                                            "wake_sequence cache refresh failed",
+                                            exc_info=True,
+                                        )
                         except Exception:  # noqa: BLE001 -- wake sequence non-fatal
                             log.debug("lifecycle_tick pending_embeddings_wake_sequence failed", exc_info=True)
                     if (
@@ -1473,6 +1837,30 @@ async def main() -> int:
                             log.debug("daemon_lock_downgrade: EX→SH on first WAKE entry")
                         except Exception:  # noqa: BLE001
                             log.debug("daemon_lock_downgrade failed", exc_info=True)
+
+                    # Periodic WAKE/DROWSY safety net: if the daemon never reaches
+                    # SLEEP (long-lived Claude sessions keep activity recent), the
+                    # sleep-pipeline cache writer never fires and the precache file
+                    # drifts. _maybe_refresh_session_start_cache is a cheap probe
+                    # (SQL COUNT + sidecar read), gated by:
+                    #   * min-interval (default 60s, IAI_MCP_SESSION_CACHE_REFRESH_MIN_SEC)
+                    #   * single-flight lock
+                    #   * watermark (records_count + max_vec_label + max_*_at)
+                    #   * runtime-graph-cache warm probe (skip if cold)
+                    # so a quiet tick costs one SELECT + one stat() and emits at
+                    # most one _skipped event.
+                    if current in (_LifecycleState.WAKE, _LifecycleState.DROWSY):
+                        try:
+                            await asyncio.to_thread(
+                                _maybe_refresh_session_start_cache,
+                                store,
+                                trigger="periodic_wake",
+                            )
+                        except Exception:  # noqa: BLE001 -- best-effort
+                            log.debug(
+                                "lifecycle_tick periodic session_start_cache refresh failed",
+                                exc_info=True,
+                            )
 
                     _prev_lifecycle_state[0] = current
                     if current is _LifecycleState.SLEEP:
@@ -1500,8 +1888,18 @@ async def main() -> int:
                         )
 
                         # --- WAKE hook (UNDER LOCK_EX, BEFORE downgrade) ---
+                        # The SLEEP path explicitly passes force_rebuild=True: we
+                        # hold the EXCLUSIVE lock for the whole consolidation
+                        # window, so a runtime-graph rebuild here is the cheapest
+                        # place to absorb the cost — the WAKE refresh paths skip
+                        # the rebuild with reason=runtime_graph_cache_cold instead.
                         try:
-                            await asyncio.to_thread(_write_session_start_cache, store)
+                            await asyncio.to_thread(
+                                _write_session_start_cache,
+                                store,
+                                trigger="sleep_pipeline",
+                                force_rebuild=True,
+                            )
                         except Exception:  # noqa: BLE001 -- precache MUST NOT crash
                             log.debug("lifecycle_tick _write_session_start_cache failed", exc_info=True)
                         try:
@@ -1738,6 +2136,13 @@ __all__ = [
     "_is_inside_window",
     "_update_pending_digest",
     "_write_session_start_cache",
+    "_maybe_refresh_session_start_cache",
+    "_should_refresh_session_start_cache",
+    "_session_start_cache_watermark",
+    "_load_session_start_cache_meta",
+    "_save_session_start_cache_meta",
+    "_default_session_start_cache_meta_path",
+    "_runtime_graph_cache_is_warm",
     "_tick_body",
     "_scheduler_tick",
     "_s4_offline_loop",
@@ -1752,7 +2157,9 @@ __all__ = [
     "S4_OFFLINE_INTERVAL_SEC",
     "S4_FIRST_ITER_GRACE_SEC",
     "SESSION_START_CACHE_PATH",
+    "SESSION_START_CACHE_META_PATH",
     "SESSION_START_CACHE_MAX_CHARS",
+    "SESSION_START_CACHE_REFRESH_MIN_SEC_DEFAULT",
     "INTERRUPT_RECENT_ACTIVITY_WINDOW_SEC",
     "_DAEMON_NOFILE_FLOOR_DEFAULT",
     # daemon_config

--- a/src/iai_mcp/daemon/__init__.py
+++ b/src/iai_mcp/daemon/__init__.py
@@ -370,6 +370,24 @@ def _wake_hook_rebuild_if_cold(store) -> None:
         log.debug("wake-hook graph-cache rebuild failed", exc_info=True)
 
 
+async def _boot_preload_recall_structural(store) -> None:
+    try:
+        from iai_mcp import runtime_graph_cache as _rgc_mod
+    except Exception:  # noqa: BLE001 -- preload is best-effort
+        log.debug("boot_preload runtime_graph_cache import failed", exc_info=True)
+        return
+
+    try:
+        # WAKE boot must not stream the whole Hippo store. The recall hot path is
+        # ANN-first and only needs the structural overlay or last-good snapshot;
+        # expensive rebuilds belong to sleep / drowsy paths.
+        await asyncio.to_thread(_rgc_mod.load_recall_structural, store)
+    except Exception as exc:  # noqa: BLE001 -- preload MUST NOT crash daemon
+        log.debug("boot_preload failed: %s", exc, exc_info=True)
+    finally:
+        _rgc_mod.preload_ready.set()
+
+
 def transition(state: dict, new_fsm: str) -> None:
     current = state.get("fsm_state", STATE_WAKE)
     allowed = VALID_TRANSITIONS.get(current, set())
@@ -1581,23 +1599,7 @@ async def main() -> int:
             asyncio.create_task(_capture_queue_drain_and_report())
 
         try:
-            from iai_mcp import runtime_graph_cache as _rgc_mod
-
-            async def _boot_preload() -> None:
-                try:
-                    # WAKE boot must not stream the whole Hippo store. The recall
-                    # hot path is ANN-first and only needs the structural overlay
-                    # or last-good snapshot; expensive rebuilds belong to sleep /
-                    # drowsy paths.
-                    await asyncio.to_thread(
-                        _rgc_mod.load_recall_structural, store,
-                    )
-                except Exception as _exc:  # noqa: BLE001 -- preload MUST NOT crash daemon
-                    log.debug("boot_preload failed: %s", _exc, exc_info=True)
-                finally:
-                    _rgc_mod.preload_ready.set()
-
-            asyncio.create_task(_boot_preload())
+            asyncio.create_task(_boot_preload_recall_structural(store))
         except Exception:  # noqa: BLE001 -- scheduling failure must not block boot
             log.debug("boot_preload scheduling failed", exc_info=True)
             try:

--- a/src/iai_mcp/daemon/__init__.py
+++ b/src/iai_mcp/daemon/__init__.py
@@ -65,6 +65,7 @@ STARTUP_DEFERRED_DRAIN_GRACE_SEC: float = float(
     os.environ.get("IAI_MCP_STARTUP_DEFERRED_DRAIN_GRACE_SEC", "20.0")
 )
 CAPTURE_QUEUE_RETRY_PENDING_KEY: str = "_capture_queue_drain_retry_pending"
+# Telemetry only: useful for diagnosing repeated startup skips / retry failures.
 CAPTURE_QUEUE_LAST_RETRY_KEY: str = "_capture_queue_drain_last_retry_at"
 
 DEFAULT_CYCLE_COUNT: int = 4

--- a/src/iai_mcp/identity_audit.py
+++ b/src/iai_mcp/identity_audit.py
@@ -11,16 +11,17 @@ from iai_mcp.sigma import compute_and_emit
 logger = logging.getLogger(__name__)
 
 AUDIT_INTERVAL_SEC: int = 60 * 60
+AUDIT_FIRST_ITER_GRACE_MAX_SEC: float = 60.0
 
 
 def _first_iter_grace_sec(effective_interval: float) -> float:
     raw = os.environ.get("IAI_MCP_AUDIT_FIRST_ITER_GRACE_SEC")
     if raw is None:
-        return max(0.0, float(effective_interval))
+        return min(max(0.0, float(effective_interval)), AUDIT_FIRST_ITER_GRACE_MAX_SEC)
     try:
         return max(0.0, float(raw))
     except (TypeError, ValueError):
-        return max(0.0, float(effective_interval))
+        return min(max(0.0, float(effective_interval)), AUDIT_FIRST_ITER_GRACE_MAX_SEC)
 
 
 async def continuous_audit(

--- a/src/iai_mcp/identity_audit.py
+++ b/src/iai_mcp/identity_audit.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 
 from iai_mcp.events import write_event
 from iai_mcp.s5 import detect_drift_anomaly
@@ -12,16 +13,34 @@ logger = logging.getLogger(__name__)
 AUDIT_INTERVAL_SEC: int = 60 * 60
 
 
+def _first_iter_grace_sec(effective_interval: float) -> float:
+    raw = os.environ.get("IAI_MCP_AUDIT_FIRST_ITER_GRACE_SEC")
+    if raw is None:
+        return max(0.0, float(effective_interval))
+    try:
+        return max(0.0, float(raw))
+    except (TypeError, ValueError):
+        return max(0.0, float(effective_interval))
+
+
 async def continuous_audit(
     store,
     shutdown: asyncio.Event,
     *,
     interval_sec: float | None = None,
 ) -> None:
+    effective_interval: float = (
+        float(interval_sec) if interval_sec is not None else float(AUDIT_INTERVAL_SEC)
+    )
+    first_grace = _first_iter_grace_sec(effective_interval)
+    if first_grace > 0:
+        try:
+            await asyncio.wait_for(shutdown.wait(), timeout=first_grace)
+            return
+        except asyncio.TimeoutError:
+            pass
+
     while not shutdown.is_set():
-        effective_interval: float = (
-            float(interval_sec) if interval_sec is not None else float(AUDIT_INTERVAL_SEC)
-        )
         try:
             await asyncio.to_thread(detect_drift_anomaly, store, 5)
         except Exception as exc:  # noqa: BLE001 -- daemon must never die

--- a/src/iai_mcp/migrate/_reembed.py
+++ b/src/iai_mcp/migrate/_reembed.py
@@ -61,6 +61,7 @@ def _records_schema_at_dim(dim: int) -> pa.Schema:
             ("valence", pa.float32()),
             ("hv_tier", pa.string()),
             ("structure_hv_payload", pa.binary()),
+            ("embedding_pending", pa.int32()),
         ]
     )
 
@@ -146,6 +147,7 @@ def _stage_record_to_table(
         s5_trust_score=rec.s5_trust_score,
         profile_modulation_gain=rec.profile_modulation_gain,
         schema_version=rec.schema_version,
+        embedding_pending=rec.embedding_pending,
     )
     target_tbl.add([store._to_row(new_rec)])
 

--- a/src/iai_mcp/pipeline.py
+++ b/src/iai_mcp/pipeline.py
@@ -470,7 +470,7 @@ def _find_anti_hits(
 
     try:
         _contr_map = store.incident_edges(
-            hit_ids, edge_types=["contradicts"], top_k=max(k * 4, 10),
+            hit_ids, edge_types=["contradicts"], top_k=None,
         )
     except Exception as exc:  # noqa: BLE001 -- anti-hits is enrichment; degrade to []
         logger.debug("_find_anti_hits incident_edges failed: %s", exc)

--- a/src/iai_mcp/pipeline.py
+++ b/src/iai_mcp/pipeline.py
@@ -74,29 +74,36 @@ def _read_record_payload(graph, rid: UUID, store: MemoryStore):
 
 
 def _is_record_active(store: MemoryStore, record_id: UUID) -> bool:
-    try:
-        from iai_mcp.store import _uuid_literal
+    return record_id in _active_id_set([record_id], store)
 
-        tbl = store.db.open_table("records")
-        df = (
-            tbl.search()
-            .where(f"id = '{_uuid_literal(record_id)}' AND tombstoned_at IS NULL")
-            .select(["id"])
-            .limit(1)
-            .to_pandas()
-        )
-        return not df.empty
+
+def _active_id_set(ids: list[UUID], store: MemoryStore) -> set[UUID]:
+    if not ids:
+        return set()
+    unique_ids = list(dict.fromkeys(ids))
+    id_strings = [str(record_id) for record_id in unique_ids]
+    placeholders = ", ".join("?" for _ in id_strings)
+    try:
+        with store.db._conn_lock:
+            rows = store.db._conn.execute(
+                f"SELECT id FROM records WHERE id IN ({placeholders}) "
+                "AND tombstoned_at IS NULL",
+                id_strings,
+            ).fetchall()
+        return {UUID(str(row["id"] if hasattr(row, "keys") else row[0])) for row in rows}
     except Exception as exc:  # noqa: BLE001 -- recall must degrade, not crash
-        logger.debug("active_record_check_failed rid=%s: %s", record_id, exc)
-        return True
+        logger.debug("active_record_batch_check_failed n=%s: %s", len(ids), exc)
+        return set(unique_ids)
 
 
 def _filter_active_hits(hits: list[MemoryHit], store: MemoryStore) -> list[MemoryHit]:
-    return [hit for hit in hits if _is_record_active(store, hit.record_id)]
+    active_ids = _active_id_set([hit.record_id for hit in hits], store)
+    return [hit for hit in hits if hit.record_id in active_ids]
 
 
 def _filter_active_ids(ids: list[UUID], store: MemoryStore) -> list[UUID]:
-    return [record_id for record_id in ids if _is_record_active(store, record_id)]
+    active_ids = _active_id_set(ids, store)
+    return [record_id for record_id in ids if record_id in active_ids]
 
 
 _DURABLE_RECALL_CUE_MARKERS = (
@@ -118,6 +125,31 @@ _DURABLE_RECALL_CUE_MARKERS = (
 )
 _DURABLE_TIERS = {"semantic", "procedural", "parametric"}
 _DURABLE_TIER_BOOST = 0.08
+_EMBEDDING_CLIP_ABS = 1_000_000.0
+
+
+def _finite_float32_array(values) -> np.ndarray:
+    arr = np.asarray(values, dtype=np.float32)
+    arr = np.nan_to_num(arr, nan=0.0, posinf=0.0, neginf=0.0)
+    return np.clip(arr, -_EMBEDDING_CLIP_ABS, _EMBEDDING_CLIP_ABS)
+
+
+def _normalise_rows(mat: np.ndarray) -> np.ndarray:
+    if not mat.size:
+        return mat.astype(np.float32, copy=False)
+    mat = _finite_float32_array(mat).astype(np.float32, copy=False)
+    norms = np.linalg.norm(mat, axis=1)
+    norms = np.nan_to_num(norms, nan=0.0, posinf=0.0, neginf=0.0)
+    norms[norms <= 0.0] = 1.0
+    return mat / norms[:, None]
+
+
+def _normalise_vec(vec: list[float] | np.ndarray) -> np.ndarray:
+    out = _finite_float32_array(vec).reshape(-1)
+    norm = float(np.linalg.norm(out))
+    if not np.isfinite(norm) or norm <= 0.0:
+        return out
+    return out / norm
 
 
 def _cue_wants_durable_recall(cue: str) -> bool:
@@ -267,10 +299,7 @@ def _community_gate(
     top_n: int = 3,
     member_embeddings: dict[UUID, list[float]] | None = None,
 ) -> list[UUID]:
-    cue_vec = np.asarray(cue_emb, dtype=np.float32)
-    cue_norm = float(np.linalg.norm(cue_vec))
-    if cue_norm > 0.0:
-        cue_vec = cue_vec / cue_norm
+    cue_vec = _normalise_vec(cue_emb)
 
     if member_embeddings is not None:
         return _community_gate_max_node(
@@ -281,12 +310,7 @@ def _community_gate(
     if not centroids:
         return []
     cids = list(centroids.keys())
-    mat = np.asarray(
-        [centroids[c] for c in cids], dtype=np.float32
-    )
-    norms = np.linalg.norm(mat, axis=1)
-    norms[norms == 0.0] = 1.0
-    mat = mat / norms[:, None]
+    mat = _normalise_rows(np.asarray([centroids[c] for c in cids], dtype=np.float32))
     scores = mat @ cue_vec
     order = np.argsort(-scores, kind="stable")
     return [cids[int(i)] for i in order[:top_n]]
@@ -327,12 +351,10 @@ def _community_gate_max_node(
     if not rows:
         return []
 
-    mat = np.stack(rows).astype(np.float32, copy=False)
-    mat = np.nan_to_num(mat, nan=0.0, posinf=0.0, neginf=0.0)
-    norms = np.linalg.norm(mat, axis=1)
-    norms[norms == 0.0] = 1.0
-    mat = mat / norms[:, None]
-    member_scores = mat @ cue_vec
+    mat = _normalise_rows(np.stack(rows).astype(np.float32, copy=False))
+    with np.errstate(divide="ignore", over="ignore", invalid="ignore"):
+        member_scores = mat @ cue_vec
+    member_scores = np.nan_to_num(member_scores, nan=0.0, posinf=0.0, neginf=0.0)
 
     comm_max = np.maximum.reduceat(member_scores, breaks)
 
@@ -448,7 +470,7 @@ def _find_anti_hits(
 
     try:
         _contr_map = store.incident_edges(
-            hit_ids, edge_types=["contradicts"], top_k=None,
+            hit_ids, edge_types=["contradicts"], top_k=max(k * 4, 10),
         )
     except Exception as exc:  # noqa: BLE001 -- anti-hits is enrichment; degrade to []
         logger.debug("_find_anti_hits incident_edges failed: %s", exc)
@@ -611,7 +633,11 @@ def _recall_core(
         logger.debug("records_cache_graph_build_failed: %s", exc)
         records_cache = {}
     if not records_cache:
-        records_cache = {r.id: r for r in store.all_records()}
+        try:
+            records_cache = store.get_batch(list(graph.iter_nodes()))
+        except Exception as exc:  # noqa: BLE001 -- retrieval hot-path fail-safe
+            logger.debug("records_cache_batch_build_failed: %s", exc)
+            records_cache = {}
 
     episodic_ids: set | None = None
     if mode == "verbatim":
@@ -623,16 +649,12 @@ def _recall_core(
     _pool_t0 = time.perf_counter()
     pool_ids, pool_embs = _collect_graph_pool(graph, records_cache, store)
     _recall_pool_collection_ms = (time.perf_counter() - _pool_t0) * 1000.0
-    cue_vec = np.asarray(cue_emb, dtype=np.float32)
-    cnorm = float(np.linalg.norm(cue_vec))
-    if cnorm > 0.0:
-        cue_vec = cue_vec / cnorm
+    cue_vec = _normalise_vec(cue_emb)
     if pool_embs.size:
-        pool_embs = np.nan_to_num(pool_embs, nan=0.0, posinf=0.0, neginf=0.0)
-        pool_norms = np.linalg.norm(pool_embs, axis=1)
-        pool_norms[pool_norms == 0.0] = 1.0
-        pool_embs = pool_embs / pool_norms[:, None]
-        shared_cos = np.matmul(pool_embs, cue_vec).astype(np.float32)
+        pool_embs = _normalise_rows(pool_embs)
+        with np.errstate(divide="ignore", over="ignore", invalid="ignore"):
+            shared_cos = np.matmul(pool_embs, cue_vec).astype(np.float32)
+        shared_cos = np.nan_to_num(shared_cos, nan=0.0, posinf=0.0, neginf=0.0)
     else:
         shared_cos = np.empty(0, dtype=np.float32)
     if shared_cos.size:
@@ -704,23 +726,11 @@ def _recall_core(
     for i, rid in enumerate(pool_ids):
         centrality_arr[i] = float(graph.get_centrality(rid))
     if not np.any(centrality_arr) and pool_ids:
-        try:
-            from iai_mcp.centrality_approx import centrality_for_runtime
-
-            # Bounded recompute on the recall path: exact below the node-count
-            # cutoff, deterministic k-source sampled betweenness above it. The
-            # long-lived recall process must never run an unbounded O(V*E)
-            # Brandes pass when the warm graph is large.
-            cen_dict = centrality_for_runtime(graph)
-            for i, rid in enumerate(pool_ids):
-                centrality_arr[i] = float(cen_dict.get(rid, 0.0))
-        except Exception as exc:  # noqa: BLE001 -- emit diagnostic then re-raise as NativeError
-            write_event(
-                store,
-                "recall_centrality_failed",
-                {"error_type": type(exc).__name__, "error": str(exc)},
-            )
-            raise NativeError(f"centrality recompute failed: {exc}") from exc
+        write_event(
+            store,
+            "recall_centrality_degraded",
+            {"reason": "missing_cached_centrality", "n_pool": len(pool_ids)},
+        )
     _recall_centrality_ms = (time.perf_counter() - _centrality_t0) * 1000.0
 
     seed_indices = _pick_seeds(

--- a/src/iai_mcp/pipeline.py
+++ b/src/iai_mcp/pipeline.py
@@ -72,6 +72,94 @@ def _read_record_payload(graph, rid: UUID, store: MemoryStore):
         logger.debug("read_record_payload_store_fallback_failed rid=%s: %s", rid, exc)
         return None
 
+
+def _is_record_active(store: MemoryStore, record_id: UUID) -> bool:
+    try:
+        from iai_mcp.store import _uuid_literal
+
+        tbl = store.db.open_table("records")
+        df = (
+            tbl.search()
+            .where(f"id = '{_uuid_literal(record_id)}' AND tombstoned_at IS NULL")
+            .select(["id"])
+            .limit(1)
+            .to_pandas()
+        )
+        return not df.empty
+    except Exception as exc:  # noqa: BLE001 -- recall must degrade, not crash
+        logger.debug("active_record_check_failed rid=%s: %s", record_id, exc)
+        return True
+
+
+def _filter_active_hits(hits: list[MemoryHit], store: MemoryStore) -> list[MemoryHit]:
+    return [hit for hit in hits if _is_record_active(store, hit.record_id)]
+
+
+def _filter_active_ids(ids: list[UUID], store: MemoryStore) -> list[UUID]:
+    return [record_id for record_id in ids if _is_record_active(store, record_id)]
+
+
+_DURABLE_RECALL_CUE_MARKERS = (
+    "decision",
+    "décision",
+    "etat-courant",
+    "état-courant",
+    "etat courant",
+    "état courant",
+    "piege",
+    "piège",
+    "source",
+    "preference",
+    "préférence",
+    "regle",
+    "règle",
+    "durable",
+    "important",
+)
+_DURABLE_TIERS = {"semantic", "procedural", "parametric"}
+_DURABLE_TIER_BOOST = 0.08
+
+
+def _cue_wants_durable_recall(cue: str) -> bool:
+    cue_lower = (cue or "").lower()
+    return any(marker in cue_lower for marker in _DURABLE_RECALL_CUE_MARKERS)
+
+
+def _record_tier_for_hit(
+    hit: MemoryHit,
+    *,
+    records_cache: dict[UUID, "object"],
+    store: MemoryStore,
+) -> str | None:
+    rec = records_cache.get(hit.record_id)
+    if rec is None:
+        try:
+            rec = store.get(hit.record_id)
+        except Exception as exc:  # noqa: BLE001 -- ranking must degrade, not crash
+            logger.debug("durable_tier_lookup_failed rid=%s: %s", hit.record_id, exc)
+            return None
+    return str(getattr(rec, "tier", "") or "")
+
+
+def _apply_durable_tier_bias(
+    hits: list[MemoryHit],
+    *,
+    cue: str,
+    mode: str,
+    records_cache: dict[UUID, "object"],
+    store: MemoryStore,
+) -> None:
+    if mode != "concept" or not _cue_wants_durable_recall(cue):
+        return
+    for hit in hits:
+        tier = _record_tier_for_hit(hit, records_cache=records_cache, store=store)
+        if tier not in _DURABLE_TIERS:
+            continue
+        base = hit.sort_score if hit.sort_score is not None else hit.score
+        hit.sort_score = float(base) + _DURABLE_TIER_BOOST
+        hit.reason = f"{hit.reason} | durable-tier +{_DURABLE_TIER_BOOST:.2f}"
+
+
 W_COSINE = 1.0
 W_AAAK = 0.3
 W_DEGREE = 0.1
@@ -874,7 +962,7 @@ def _recall_core(
         )
         budget_used += tokens
 
-    activation_trace = list({*seed_ids, *spread_ids})
+    activation_trace = _filter_active_ids(list({*seed_ids, *spread_ids}), store)
 
     try:
         _top_hit_id_for_telemetry: str | None = None
@@ -950,6 +1038,7 @@ def _apply_post_rank_pipeline(
     knobs_applied: dict | None = None,
     contradicts_outgoing: dict[str, list[str]] | None = None,
 ) -> tuple[list[MemoryHit], list[MemoryHit], list[dict], list[dict]]:
+    hits = _filter_active_hits(hits, store)
     s4_scope_hits = hits[:_POST_RANK_MAX_HITS]
 
     if hits:
@@ -1161,6 +1250,13 @@ def recall_for_response(
     )
     apply_stale_downweight(core.scored_hits, cue_intent=_cue_intent)
     apply_stale_downweight(core.anti_hits, cue_intent=_cue_intent)
+    _apply_durable_tier_bias(
+        core.scored_hits,
+        cue=cue,
+        mode=mode,
+        records_cache=core._records_cache,
+        store=store,
+    )
     # Rank on the internal unclamped key (falls back to score when a hit was
     # built without sort_score), so ordering is preserved across the display
     # clamp applied at serialization. Tie-break on record_id so equal-scoring
@@ -1317,6 +1413,19 @@ def recall_for_benchmark(
             patterns_observed=core.patterns_observed,
         )
 
+    _apply_durable_tier_bias(
+        core.scored_hits,
+        cue=cue,
+        mode=mode,
+        records_cache=core._records_cache,
+        store=store,
+    )
+    core.scored_hits.sort(
+        key=lambda h: (
+            -(h.sort_score if h.sort_score is not None else h.score),
+            str(h.record_id),
+        ),
+    )
     hits = core.scored_hits[:k_hits]
     budget_used = sum(len(h.literal_surface) // 4 for h in hits)
 

--- a/src/iai_mcp/retrieve.py
+++ b/src/iai_mcp/retrieve.py
@@ -36,6 +36,17 @@ STALE_DOWNWEIGHT_FACTOR: float = 0.5
 _STALE_REASON_SUFFIX: str = " · stale"
 
 
+def _has_tombstone_marker(value) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, float) and math.isnan(value):
+        return False
+    text = str(value).strip()
+    if not text:
+        return False
+    return text.lower() not in {"none", "nan", "nat", "<na>"}
+
+
 # The community graph is an enhancement layer over the index recall path: a
 # record is findable by cosine/ANN as soon as it lands in the index, before it
 # is ever folded into the community graph. So the community graph may lag the
@@ -780,21 +791,13 @@ def _build_runtime_graph_impl(store: MemoryStore):
         ):
             if int(row.get("embedding_pending") or 0) != 0:
                 continue
-            # Defensive in-loop guard mirroring the SQL filter: the batch reader
-            # yields a Python None for a NULL tombstoned_at, but a backend that
-            # surfaces the column via a datetime/NA representation could stringify
-            # a live value; only a real, non-empty timestamp string marks a
-            # tombstone. (pandas is imported lazily so the streaming path keeps no
-            # hard pandas dependency.)
+            # Defensive in-loop guard mirroring the SQL filter: only a real,
+            # non-empty timestamp string marks a tombstone. Keep pandas out of
+            # this daemon rebuild path; it showed up in live latency profiles
+            # while recall was waiting on the daemon.
             _tomb = row.get("tombstoned_at")
-            if _tomb is not None:
-                try:
-                    import pandas as _pd
-                    _is_na = bool(_pd.isna(_tomb))
-                except Exception:  # noqa: BLE001 -- pandas absent / unhashable value
-                    _is_na = False
-                if not _is_na and str(_tomb).strip():
-                    continue
+            if _has_tombstone_marker(_tomb):
+                continue
             rid = UUID(row["id"])
             _comm_raw = row.get("community_id")
             community_id = UUID(_comm_raw) if _comm_raw else None
@@ -869,8 +872,11 @@ def _build_runtime_graph_impl(store: MemoryStore):
                 },
             )
 
-    edges_df = store.db.open_table("edges").to_pandas()
-    for _, row in edges_df.iterrows():
+    with store.db._conn_lock:
+        edge_rows = store.db._conn.execute(
+            "SELECT src, dst, edge_type, weight FROM edges"
+        ).fetchall()
+    for row in edge_rows:
         # Skip edges whose endpoints are not live nodes: graph.add_edge() does
         # setdefault() on both endpoints, so an edge referencing a tombstoned
         # record would re-create it as a payload-less node and undo the tombstone

--- a/src/iai_mcp/sigma.py
+++ b/src/iai_mcp/sigma.py
@@ -250,6 +250,47 @@ def classify_regime(N: int, sigma: Optional[float]) -> str:
     return "healthy"
 
 
+def _centrality_for_topology_rich_club(graph: "MemoryGraph") -> dict:
+    """Centrality map for daemon topology without an exact in-parent pass.
+
+    Runtime graph rebuilds already copy persisted centrality into node payloads.
+    Reuse that map when it contains signal; otherwise fall back to the bounded
+    approximation used by the warm graph cache. This keeps the long-lived daemon
+    away from ``MemoryGraph.centrality()`` / exact Brandes betweenness.
+    """
+    centrality: dict = {}
+    has_signal = False
+    for node_id in graph.iter_nodes():
+        try:
+            value = float(graph.get_centrality(node_id) or 0.0)
+        except (TypeError, ValueError, AttributeError):
+            value = 0.0
+        if math.isfinite(value) and value != 0.0:
+            has_signal = True
+        if not math.isfinite(value):
+            value = 0.0
+        centrality[node_id] = value
+    if has_signal:
+        return centrality
+
+    try:
+        from iai_mcp.centrality_approx import (
+            approximate_centrality,
+            runtime_k,
+            runtime_method,
+        )
+
+        return approximate_centrality(
+            graph,
+            method=runtime_method(),
+            k=runtime_k(),
+            normalize=False,
+        )
+    except (RuntimeError, ValueError, TypeError, AttributeError):
+        logger.debug("topology_rich_club_centrality_degraded", exc_info=True)
+        return centrality
+
+
 def compute_topology_snapshot(graph, *, assignment=None) -> dict:
     """Topology metrics for `graph`.
 
@@ -324,7 +365,8 @@ def compute_topology_snapshot(graph, *, assignment=None) -> dict:
         except (RuntimeError, ValueError, TypeError):
             community_count = 0
         try:
-            rc = rich_club_nodes(graph, percent=0.10)
+            rc_centrality = _centrality_for_topology_rich_club(graph)
+            rc = rich_club_nodes(graph, percent=0.10, centrality=rc_centrality)
             rich_club_ratio = (len(rc) / N) if N > 0 else 0.0
         except (RuntimeError, ValueError, TypeError):
             rich_club_ratio = 0.0

--- a/src/iai_mcp/socket_server.py
+++ b/src/iai_mcp/socket_server.py
@@ -22,6 +22,9 @@ ERR_PARSE_ERROR = -32700
 
 IDLE_SECS_DEFAULT = 1800
 RECALL_BUSY_REASON = "recall_busy"
+# Intentionally conservative: one in-flight recall plus one retry is enough for
+# the common single-client MCP case. Multi-client deployments can raise this via
+# IAI_MCP_RECALL_CONCURRENCY.
 RECALL_CONCURRENCY_DEFAULT = 2
 RECALL_SLOT_WAIT_SEC_DEFAULT = 0.25
 

--- a/src/iai_mcp/socket_server.py
+++ b/src/iai_mcp/socket_server.py
@@ -21,6 +21,25 @@ ERR_INVALID_PARAMS = -32602
 ERR_PARSE_ERROR = -32700
 
 IDLE_SECS_DEFAULT = 1800
+RECALL_BUSY_REASON = "recall_busy"
+RECALL_CONCURRENCY_DEFAULT = 2
+RECALL_SLOT_WAIT_SEC_DEFAULT = 0.25
+
+
+def _env_int(name: str, default: int, *, minimum: int = 1) -> int:
+    try:
+        value = int(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        value = default
+    return max(minimum, value)
+
+
+def _env_float(name: str, default: float, *, minimum: float = 0.0) -> float:
+    try:
+        value = float(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        value = default
+    return max(minimum, value)
 
 
 def _inherit_activated_socket() -> socket.socket | None:
@@ -73,10 +92,44 @@ class SocketServer:
         if idle_secs is None:
             idle_secs = IDLE_SECS_DEFAULT
         self.idle_secs = idle_secs
+        self._recall_slots = asyncio.Semaphore(
+            _env_int("IAI_MCP_RECALL_CONCURRENCY", RECALL_CONCURRENCY_DEFAULT)
+        )
+        self._recall_slot_wait_sec = _env_float(
+            "IAI_MCP_RECALL_SLOT_WAIT_SEC", RECALL_SLOT_WAIT_SEC_DEFAULT,
+        )
         self.last_activity_ts: float = time.monotonic()
         self.active_connections: int = 0
         self.shutdown_event: asyncio.Event = asyncio.Event()
         self._state = state
+
+    async def _dispatch_jsonrpc_method(self, method: str, params: dict) -> Any:
+        from iai_mcp.core import dispatch
+
+        if method != "memory_recall":
+            return await asyncio.to_thread(dispatch, self.store, method, params)
+        if "cue" not in params:
+            return await asyncio.to_thread(dispatch, self.store, method, params)
+
+        try:
+            await asyncio.wait_for(
+                self._recall_slots.acquire(),
+                timeout=max(self._recall_slot_wait_sec, 0.001),
+            )
+        except asyncio.TimeoutError:
+            return {
+                "hits": [],
+                "anti_hits": [],
+                "activation_trace": [],
+                "budget_used": 0,
+                "_degraded": True,
+                "_reason": RECALL_BUSY_REASON,
+            }
+
+        try:
+            return await asyncio.to_thread(dispatch, self.store, method, params)
+        finally:
+            self._recall_slots.release()
 
     async def handle(
         self,
@@ -157,10 +210,7 @@ class SocketServer:
                 # here, so they no longer keep the daemon awake.
                 self.last_activity_ts = time.monotonic()
                 try:
-                    from iai_mcp.core import dispatch
-                    result = await asyncio.to_thread(
-                        dispatch, self.store, method, params,
-                    )
+                    result = await self._dispatch_jsonrpc_method(method, params)
                     resp = {"jsonrpc": "2.0", "id": req_id, "result": result}
                 except UnknownMethodError as e:
                     resp = {

--- a/src/iai_mcp/store/_store.py
+++ b/src/iai_mcp/store/_store.py
@@ -1103,7 +1103,7 @@ class MemoryStore:
         " stability, difficulty, last_reviewed, never_decay, never_merge,"
         " provenance_json, created_at, updated_at, tags_json, language,"
         " s5_trust_score, profile_modulation_gain_json, schema_version,"
-        " hv_tier, structure_hv_payload,"
+        " structure_hv, hv_tier, structure_hv_payload,"
         " COALESCE(embedding_pending, 0) AS embedding_pending"
     )
 
@@ -1667,6 +1667,7 @@ class MemoryStore:
             "drawer": getattr(r, "drawer", None),
             "hv_tier": r.hv_tier,
             "structure_hv_payload": bytes(r.structure_hv_payload or b""),
+            "embedding_pending": int(r.embedding_pending),
         }
 
     def _maybe_tag_schema_bypass(self, record: MemoryRecord) -> None:

--- a/src/iai_mcp/store/_store.py
+++ b/src/iai_mcp/store/_store.py
@@ -841,7 +841,15 @@ class MemoryStore:
             k_clamped = min(max(0, int(k)), active_count, hnsw_count)
             if k_clamped == 0:
                 return []
-            labels, distances = db._hnsw.knn_query(ann_vector, k=k_clamped)
+            try:
+                labels, distances = db._hnsw.knn_query(ann_vector, k=k_clamped)
+            except RuntimeError as exc:
+                logger.warning(
+                    "hnswlib knn_query failed (k=%d, hnsw_count=%d, "
+                    "active_count=%d); returning empty result: %s",
+                    k_clamped, hnsw_count, active_count, exc,
+                )
+                return []
 
         flat_labels = [int(label) for label in labels[0].tolist()]
         if not flat_labels:

--- a/src/iai_mcp/store/_store.py
+++ b/src/iai_mcp/store/_store.py
@@ -1156,34 +1156,56 @@ class MemoryStore:
                 edge_type_sql = f" AND edge_type IN ({et_ph})"
                 edge_type_params = list(edge_types)
 
+            ph = ", ".join("?" for _ in str_ids)
+            outbound_sql = (  # nosemgrep: sql-injection
+                f"SELECT src, dst, edge_type, weight FROM edges"
+                f" WHERE src IN ({ph}){edge_type_sql}"
+            )
+            inbound_sql = (  # nosemgrep: sql-injection
+                f"SELECT src, dst, edge_type, weight FROM edges"
+                f" WHERE dst IN ({ph}) AND src != dst{edge_type_sql}"
+            )
             with self.db._conn_lock:
-                for uid, sid in zip(ids, str_ids):
-                    rows = []
-                    rows.extend(self.db._conn.execute(
-                        "SELECT dst, edge_type, weight FROM edges"
-                        f" WHERE src = ?{edge_type_sql}"
-                        " ORDER BY weight DESC LIMIT ?",
-                        [sid, *edge_type_params, limit],
-                    ).fetchall())
-                    rows.extend(self.db._conn.execute(
-                        "SELECT src, edge_type, weight FROM edges"
-                        f" WHERE dst = ? AND src != ?{edge_type_sql}"
-                        " ORDER BY weight DESC LIMIT ?",
-                        [sid, sid, *edge_type_params, limit],
-                    ).fetchall())
+                outbound_rows = self.db._conn.execute(
+                    outbound_sql, [*str_ids, *edge_type_params],
+                ).fetchall()
+                inbound_rows = self.db._conn.execute(
+                    inbound_sql, [*str_ids, *edge_type_params],
+                ).fetchall()
 
-                    for row in rows:
-                        nbr_s = str(row[0] if hasattr(row, "__getitem__") else row["dst"])
-                        et = str(row[1] if hasattr(row, "__getitem__") else row["edge_type"])
-                        wt = float(row[2] if hasattr(row, "__getitem__") else row["weight"])
-                        try:
-                            neighbour = UUID(nbr_s)
-                        except (ValueError, AttributeError):
-                            continue
-                        result[uid].append((neighbour, et, wt))
+            id_to_uuid: dict[str, UUID] = {str(i): i for i in ids}
 
-                    result[uid].sort(key=lambda t: t[2], reverse=True)
-                    result[uid] = result[uid][:limit]
+            for row in outbound_rows:
+                src_s = str(row[0] if hasattr(row, "__getitem__") else row["src"])
+                dst_s = str(row[1] if hasattr(row, "__getitem__") else row["dst"])
+                et = str(row[2] if hasattr(row, "__getitem__") else row["edge_type"])
+                wt = float(row[3] if hasattr(row, "__getitem__") else row["weight"])
+                qid = id_to_uuid.get(src_s)
+                if qid is None:
+                    continue
+                try:
+                    neighbour = UUID(dst_s)
+                except (ValueError, AttributeError):
+                    continue
+                result[qid].append((neighbour, et, wt))
+
+            for row in inbound_rows:
+                src_s = str(row[0] if hasattr(row, "__getitem__") else row["src"])
+                dst_s = str(row[1] if hasattr(row, "__getitem__") else row["dst"])
+                et = str(row[2] if hasattr(row, "__getitem__") else row["edge_type"])
+                wt = float(row[3] if hasattr(row, "__getitem__") else row["weight"])
+                qid = id_to_uuid.get(dst_s)
+                if qid is None:
+                    continue
+                try:
+                    neighbour = UUID(src_s)
+                except (ValueError, AttributeError):
+                    continue
+                result[qid].append((neighbour, et, wt))
+
+            for uid, edges in result.items():
+                edges.sort(key=lambda t: t[2], reverse=True)
+                result[uid] = edges[:limit]
 
             return result
 

--- a/src/iai_mcp/store/_store.py
+++ b/src/iai_mcp/store/_store.py
@@ -616,16 +616,15 @@ class MemoryStore:
         self._fire_graph_sync_hook("delete", _DeleteShim(record_id))
 
     def get(self, record_id: UUID) -> MemoryRecord | None:
-        tbl = self.db.open_table(RECORDS_TABLE)
-        df = (
-            tbl.search()
-            .where(f"id = '{_uuid_literal(record_id)}'")
-            .limit(1)
-            .to_pandas()
+        rid = _uuid_literal(record_id)
+        sql = (  # nosemgrep: sql-injection
+            f"SELECT {self._RECORD_COLS} FROM records WHERE id = ? LIMIT 1"
         )
-        if df.empty:
+        with self.db._conn_lock:
+            raw = self.db._conn.execute(sql, (rid,)).fetchone()
+        if raw is None:
             return None
-        return self._from_row(df.iloc[0].to_dict())
+        return self._from_row(self._decode_raw_row(dict(raw)))
 
     def all_records(self) -> list[MemoryRecord]:
         tbl = self.db.open_table(RECORDS_TABLE)
@@ -674,17 +673,22 @@ class MemoryStore:
     def centrality_for_ids(self, ids: list[UUID]) -> dict[UUID, float]:
         if not ids:
             return {}
-        target = frozenset(str(i) for i in ids)
+        str_ids = list(dict.fromkeys(str(i) for i in ids))
+        placeholders = ", ".join("?" for _ in str_ids)
         out: dict[UUID, float] = {}
-        for row in self.iter_record_columns(["id", "centrality"]):
-            raw_id = row.get("id")
+        with self.db._conn_lock:
+            rows = self.db._conn.execute(
+                f"SELECT id, centrality FROM records WHERE id IN ({placeholders})",
+                str_ids,
+            ).fetchall()
+        for row in rows:
+            raw_id = row["id"] if hasattr(row, "keys") else row[0]
             if raw_id is None:
                 continue
             id_str = str(raw_id)
-            if id_str not in target:
-                continue
             try:
-                centrality = float(row.get("centrality") or 0.0)
+                raw_centrality = row["centrality"] if hasattr(row, "keys") else row[1]
+                centrality = float(raw_centrality or 0.0)
             except (TypeError, ValueError):
                 centrality = 0.0
             try:
@@ -808,22 +812,69 @@ class MemoryStore:
             )
 
         tbl = self.db.open_table(RECORDS_TABLE)
-        if tbl.count_rows() == 0:
-            return []
         q = tbl.search(list(vec)).distance_type("cosine")
         where_clause = "tombstoned_at IS NULL AND COALESCE(embedding_pending, 0) = 0"
         if tier is not None:
             where_clause = f"tier = '{tier}' AND " + where_clause
-        q = q.where(where_clause)
-        results = q.limit(k).to_pandas()
-        out: list[tuple[MemoryRecord, float]] = []
-        for _, row in results.iterrows():
-            record = self._from_row(row.to_dict())
-            distance = float(row.get("_distance", 1.0)) if "_distance" in row else 1.0
-            score = 1.0 - distance
-            out.append((record, score))
+        try:
+            out = self._query_similar_fast(q, where_clause, k)
+        except Exception as exc:  # noqa: BLE001 -- preserve legacy fallback
+            logger.warning("query_similar_fast_failed_degraded: %s", exc)
+            out = []
         if _return_records_only:
             return [r for r, _s in out]
+        return out
+
+    def _query_similar_fast(
+        self,
+        query,
+        where_clause: str,
+        k: int,
+    ) -> list[tuple[MemoryRecord, float]]:
+        db = query._ann_db
+        ann_vector = query._ann_vector
+        if db is None or ann_vector is None:
+            return []
+        with db._hnsw_lock:
+            active_count = len(db._label_map)
+            hnsw_count = db._hnsw.get_current_count()
+            k_clamped = min(max(0, int(k)), active_count, hnsw_count)
+            if k_clamped == 0:
+                return []
+            labels, distances = db._hnsw.knn_query(ann_vector, k=k_clamped)
+
+        flat_labels = [int(label) for label in labels[0].tolist()]
+        if not flat_labels:
+            return []
+        flat_distances = [
+            max(0.0, min(2.0, float(distance))) for distance in distances[0]
+        ]
+        dist_map = {
+            int(label): float(distance)
+            for label, distance in zip(flat_labels, flat_distances)
+        }
+
+        placeholders = ", ".join("?" for _ in flat_labels)
+        sql = (  # nosemgrep: sql-injection
+            f"SELECT {self._RECORD_COLS}, vec_label FROM records"
+            f" WHERE vec_label IN ({placeholders}) AND ({where_clause})"
+        )
+        with self.db._conn_lock:
+            raw_rows = self.db._conn.execute(sql, flat_labels).fetchall()
+
+        out: list[tuple[MemoryRecord, float]] = []
+        sort_distance_by_id: dict[UUID, float] = {}
+        for raw in raw_rows:
+            row_dict = self._decode_raw_row(dict(raw))
+            label = int(row_dict.get("vec_label") or 0)
+            try:
+                record = self._from_row(row_dict)
+            except Exception:  # noqa: BLE001 -- skip corrupt rows, never crash recall
+                continue
+            distance = dist_map.get(label, 1.0)
+            sort_distance_by_id[record.id] = distance
+            out.append((record, 1.0 - distance))
+        out.sort(key=lambda item: sort_distance_by_id.get(item[0].id, 1.0))
         return out
 
     def pattern_separation_gate(
@@ -1080,6 +1131,53 @@ class MemoryStore:
 
         str_ids = [str(i) for i in ids]
         id_set = set(str_ids)
+
+        if edge_types == []:
+            return {i: [] for i in ids}
+
+        if top_k is not None:
+            result: dict[UUID, list[tuple[UUID, str, float]]] = {i: [] for i in ids}
+            limit = max(0, int(top_k))
+            if limit <= 0:
+                return result
+
+            edge_type_sql = ""
+            edge_type_params: list[str] = []
+            if edge_types is not None:
+                et_ph = ", ".join("?" for _ in edge_types)
+                edge_type_sql = f" AND edge_type IN ({et_ph})"
+                edge_type_params = list(edge_types)
+
+            with self.db._conn_lock:
+                for uid, sid in zip(ids, str_ids):
+                    rows = []
+                    rows.extend(self.db._conn.execute(
+                        "SELECT dst, edge_type, weight FROM edges"
+                        f" WHERE src = ?{edge_type_sql}"
+                        " ORDER BY weight DESC LIMIT ?",
+                        [sid, *edge_type_params, limit],
+                    ).fetchall())
+                    rows.extend(self.db._conn.execute(
+                        "SELECT src, edge_type, weight FROM edges"
+                        f" WHERE dst = ? AND src != ?{edge_type_sql}"
+                        " ORDER BY weight DESC LIMIT ?",
+                        [sid, sid, *edge_type_params, limit],
+                    ).fetchall())
+
+                    for row in rows:
+                        nbr_s = str(row[0] if hasattr(row, "__getitem__") else row["dst"])
+                        et = str(row[1] if hasattr(row, "__getitem__") else row["edge_type"])
+                        wt = float(row[2] if hasattr(row, "__getitem__") else row["weight"])
+                        try:
+                            neighbour = UUID(nbr_s)
+                        except (ValueError, AttributeError):
+                            continue
+                        result[uid].append((neighbour, et, wt))
+
+                    result[uid].sort(key=lambda t: t[2], reverse=True)
+                    result[uid] = result[uid][:limit]
+
+            return result
 
         ph = ", ".join("?" for _ in str_ids)
         sql = (  # nosemgrep: sql-injection
@@ -1679,8 +1777,6 @@ class MemoryStore:
     def _from_row(self, row: dict) -> MemoryRecord:
         from uuid import UUID as _UUID
 
-        import pandas as pd
-
         def _safe_int(val: Any, default: int) -> int:
             if val is None:
                 return default
@@ -1696,14 +1792,24 @@ class MemoryStore:
             if val is None:
                 return None
             try:
-                if pd.isna(val):
+                if val != val:
+                    return None
+            except (TypeError, ValueError):
+                pass
+            try:
+                if str(val) in {"NaT", "nan", "NaN"}:
                     return None
             except (TypeError, ValueError):
                 pass
             if isinstance(val, datetime):
                 return val if val.tzinfo is not None else val.replace(tzinfo=timezone.utc)
             if hasattr(val, "to_pydatetime"):
-                dt = val.to_pydatetime()
+                try:
+                    dt = val.to_pydatetime()
+                except (TypeError, ValueError, AttributeError):
+                    return None
+                if dt is None:
+                    return None
                 return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
             try:
                 dt = datetime.fromisoformat(str(val).replace("Z", "+00:00"))

--- a/src/iai_mcp/store/_store.py
+++ b/src/iai_mcp/store/_store.py
@@ -811,7 +811,7 @@ class MemoryStore:
         if tbl.count_rows() == 0:
             return []
         q = tbl.search(list(vec)).distance_type("cosine")
-        where_clause = "COALESCE(embedding_pending, 0) = 0"
+        where_clause = "tombstoned_at IS NULL AND COALESCE(embedding_pending, 0) = 0"
         if tier is not None:
             where_clause = f"tier = '{tier}' AND " + where_clause
         q = q.where(where_clause)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,10 @@ def _hermetic_default_paths(tmp_path_factory, monkeypatch: pytest.MonkeyPatch):
         _daemon, "SESSION_START_CACHE_PATH",
         fake_root / ".session-start-payload.cached.md", raising=False,
     )
+    monkeypatch.setattr(
+        _daemon, "SESSION_START_CACHE_META_PATH",
+        fake_root / ".session-start-payload.cached.meta.json", raising=False,
+    )
     monkeypatch.setattr(_crypto, "_DEFAULT_STORE_ROOT", fake_root, raising=False)
     monkeypatch.setattr(_backup, "DEFAULT_STORE_PATH", str(fake_root), raising=False)
     yield fake_root

--- a/tests/test_bridge_socket_first.py
+++ b/tests/test_bridge_socket_first.py
@@ -5,6 +5,7 @@ import os
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -176,10 +177,10 @@ def _wait_for_daemon_socket(sock_path: Path, timeout_sec: float = 30.0) -> bool:
 def test_start_throws_DaemonUnreachableError_when_socket_missing(
     built_wrapper, tmp_path
 ):
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
+    sock_dir_ctx = tempfile.TemporaryDirectory(prefix="iai-sock-")
+    sock_dir = Path(sock_dir_ctx.name)
     sock_path = sock_dir / "d.sock"
-    store_dir = sock_dir / "store"
+    store_dir = tmp_path / "store"
     store_dir.mkdir(parents=True, exist_ok=True)
 
     assert not sock_path.exists(), f"tmp socket pre-exists: {sock_path}"
@@ -291,13 +292,14 @@ def test_start_throws_DaemonUnreachableError_when_socket_missing(
             sock_path.unlink()
         except OSError:
             pass
+        sock_dir_ctx.cleanup()
 
 
 def test_start_succeeds_with_warm_daemon_no_extra_spawn(built_wrapper, tmp_path):
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
+    sock_dir_ctx = tempfile.TemporaryDirectory(prefix="iai-sock-")
+    sock_dir = Path(sock_dir_ctx.name)
     sock_path = sock_dir / "d.sock"
-    store_dir = sock_dir / "store"
+    store_dir = tmp_path / "store"
     store_dir.mkdir(parents=True, exist_ok=True)
     assert not sock_path.exists()
 
@@ -363,3 +365,4 @@ def test_start_succeeds_with_warm_daemon_no_extra_spawn(built_wrapper, tmp_path)
             sock_path.unlink()
         except OSError:
             pass
+        sock_dir_ctx.cleanup()

--- a/tests/test_capture_noise_filter.py
+++ b/tests/test_capture_noise_filter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 
 
-from iai_mcp.capture import _parse_transcript_line
+from iai_mcp.capture import _normalize_ambient_capture_event, _parse_transcript_line
 
 
 def _user_line(text: str) -> str:
@@ -69,3 +69,74 @@ def test_genuine_line_quoting_marker_preserved():
     role, text, *_ = result
     assert role == "user"
     assert text == genuine_text
+
+
+def test_journalise_scaffold_dropped():
+    line = _user_line(
+        "Contexte éventuel donné par Loïc :\n\n"
+        "1. Résume la session en cours.\n"
+        "2. Écris/complète la note du jour dans journal/AAAA-MM-JJ.md.\n"
+        "3. Prépare ensuite un bloc court `Mémoire durable pour IAE`."
+    )
+    assert _parse_transcript_line(line) is None
+
+
+def test_long_legitimate_message_mentioning_journalise_kept():
+    text = (
+        "Brief technique long. "
+        "On parle de la skill /journalise et de l'arborescence "
+        "journal/ dans le coffre. "
+        + "Détails métier sur les constats. " * 100
+    )
+    assert len(text) > 3000
+
+    result = _normalize_ambient_capture_event(text)
+
+    assert result is not None
+    kept_text, tier, cue_tag = result
+    assert kept_text == text.strip()
+    assert tier == "episodic"
+    assert cue_tag is None
+
+
+def test_durable_memory_block_extracted_as_semantic():
+    text = (
+        "Voici le journal complet avec beaucoup de détails jetables.\n\n"
+        "Mémoire durable pour IAE :\n"
+        "- [decision] /journalise garde Obsidian comme journal humain.\n"
+        "- [piege] IAE ne capture pas le journal complet.\n"
+        "\n"
+        "Suite non durable."
+    )
+
+    normalized = _normalize_ambient_capture_event(text)
+
+    assert normalized is not None
+    kept_text, tier, cue_tag = normalized
+    assert tier == "semantic"
+    assert cue_tag == "memoire-durable-iae"
+    assert kept_text == (
+        "Mémoire durable pour IAE :\n"
+        "- [decision] /journalise garde Obsidian comme journal humain.\n"
+        "- [piege] IAE ne capture pas le journal complet."
+    )
+
+
+def test_durable_memory_nothing_to_capture_dropped():
+    normalized = _normalize_ambient_capture_event(
+        "Mémoire durable pour IAE : rien à capturer."
+    )
+    assert normalized is None
+
+
+def test_durable_memory_block_caps_at_eight_bullets():
+    bullets = "\n".join(f"- [etat-courant] point {i}" for i in range(10))
+    normalized = _normalize_ambient_capture_event(
+        f"Memoire durable IAE :\n{bullets}"
+    )
+
+    assert normalized is not None
+    kept_text, tier, _cue_tag = normalized
+    assert tier == "semantic"
+    assert kept_text.count("\n- ") == 8
+    assert "point 8" not in kept_text

--- a/tests/test_capture_transcript_no_spawn_defer.py
+++ b/tests/test_capture_transcript_no_spawn_defer.py
@@ -7,6 +7,7 @@ import re
 import socket
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -20,8 +21,7 @@ pytestmark = pytest.mark.skipif(
 
 
 def _isolated_env(tmp_path: Path) -> tuple[dict[str, str], Path, Path]:
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
+    sock_dir = Path(tempfile.mkdtemp(prefix="iai-sock-"))
     sock_path = sock_dir / "d.sock"
 
     iai_dir = tmp_path / ".iai-mcp"
@@ -35,6 +35,17 @@ def _isolated_env(tmp_path: Path) -> tuple[dict[str, str], Path, Path]:
     env["PYTHONPATH"] = str(REPO / "src") + os.pathsep + env.get("PYTHONPATH", "")
 
     return env, iai_dir / ".deferred-captures", sock_path
+
+
+def _cleanup_socket(sock_path: Path) -> None:
+    try:
+        sock_path.unlink()
+    except FileNotFoundError:
+        pass
+    try:
+        sock_path.parent.rmdir()
+    except OSError:
+        pass
 
 
 def _make_transcript(tmp_path: Path) -> Path:
@@ -86,10 +97,7 @@ def test_no_spawn_reachable_defers_not_inserts(tmp_path):
         proc = _run_no_spawn(env, transcript)
     finally:
         listener.close()
-        try:
-            sock_path.unlink()
-        except FileNotFoundError:
-            pass
+        _cleanup_socket(sock_path)
 
     assert proc.returncode == 0, f"stderr={proc.stderr!r} stdout={proc.stdout!r}"
 
@@ -124,7 +132,10 @@ def test_no_spawn_unreachable_still_defers(tmp_path):
 
     assert not sock_path.exists()
 
-    proc = _run_no_spawn(env, transcript)
+    try:
+        proc = _run_no_spawn(env, transcript)
+    finally:
+        _cleanup_socket(sock_path)
 
     assert proc.returncode == 0, f"stderr={proc.stderr!r} stdout={proc.stdout!r}"
     payload = json.loads(proc.stdout.strip())

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -5,6 +5,7 @@ import sys
 import asyncio
 import json
 import os
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -21,24 +22,20 @@ def _endpoint_ready_path(sock_path: Path) -> Path:
 @pytest.fixture
 def socket_path(tmp_path, monkeypatch):
     from iai_mcp import concurrency
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
-    sock_path = sock_dir / "d.sock"
-    monkeypatch.setattr(concurrency, "SOCKET_PATH", sock_path)
-    # Per-test endpoint isolation honored by start_ipc_server/open_ipc_connection.
-    monkeypatch.setenv("IAI_DAEMON_SOCKET_PATH", str(sock_path))
-    try:
-        yield sock_path
-    finally:
+    with tempfile.TemporaryDirectory(prefix="iai-sock-") as sock_dir_name:
+        sock_dir = Path(sock_dir_name)
+        sock_path = sock_dir / "d.sock"
+        monkeypatch.setattr(concurrency, "SOCKET_PATH", sock_path)
+        # Per-test endpoint isolation honored by start_ipc_server/open_ipc_connection.
+        monkeypatch.setenv("IAI_DAEMON_SOCKET_PATH", str(sock_path))
         try:
-            if sock_path.exists():
-                sock_path.unlink()
-        except OSError:
-            pass
-        try:
-            sock_dir.rmdir()
-        except OSError:
-            pass
+            yield sock_path
+        finally:
+            try:
+                if sock_path.exists():
+                    sock_path.unlink()
+            except OSError:
+                pass
 
 
 def test_socket_status_round_trip(socket_path):

--- a/tests/test_daemon_crash_loop_immunity.py
+++ b/tests/test_daemon_crash_loop_immunity.py
@@ -6,6 +6,7 @@ import os
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
@@ -237,7 +238,7 @@ def test_socket_binds_before_drain_completes(tmp_path, monkeypatch, request):
 
     keyring.core._keyring_backend = None
 
-    tmp_socket = tmp_path / f"iai-test-{os.getpid()}.sock"
+    tmp_socket = Path(tempfile.gettempdir()) / f"iai-test-{os.getpid()}-{time.monotonic_ns()}.sock"
     monkeypatch.setenv("IAI_DAEMON_SOCKET_PATH", str(tmp_socket))
 
     def _cleanup_socket():

--- a/tests/test_daemon_dispatcher.py
+++ b/tests/test_daemon_dispatcher.py
@@ -21,29 +21,25 @@ def _endpoint_ready_path(sock_path: Path) -> Path:
 def short_socket_paths(tmp_path, monkeypatch):
     from iai_mcp import concurrency, daemon_state
 
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
-    sock_path = sock_dir / "d.sock"
     state_path = tmp_path / ".daemon-state.json"
 
-    monkeypatch.setattr(concurrency, "SOCKET_PATH", sock_path)
-    monkeypatch.setattr(daemon_state, "STATE_PATH", state_path)
-    # Per-test endpoint isolation (unix socket on POSIX; TCP port file on
-    # Windows) via the env var start_ipc_server/open_ipc_connection honor.
-    monkeypatch.setenv("IAI_DAEMON_SOCKET_PATH", str(sock_path))
+    with tempfile.TemporaryDirectory(prefix="iai-sock-") as sock_dir_name:
+        sock_dir = Path(sock_dir_name)
+        sock_path = sock_dir / "d.sock"
+        monkeypatch.setattr(concurrency, "SOCKET_PATH", sock_path)
+        monkeypatch.setattr(daemon_state, "STATE_PATH", state_path)
+        # Per-test endpoint isolation (unix socket on POSIX; TCP port file on
+        # Windows) via the env var start_ipc_server/open_ipc_connection honor.
+        monkeypatch.setenv("IAI_DAEMON_SOCKET_PATH", str(sock_path))
 
-    try:
-        yield None, sock_path, state_path
-    finally:
         try:
-            if sock_path.exists():
-                sock_path.unlink()
-        except OSError:
-            pass
-        try:
-            sock_dir.rmdir()
-        except OSError:
-            pass
+            yield None, sock_path, state_path
+        finally:
+            try:
+                if sock_path.exists():
+                    sock_path.unlink()
+            except OSError:
+                pass
 
 
 async def _send_ndjson(sock_path: Path, message: dict, *, timeout: float = 5.0) -> dict:

--- a/tests/test_daemon_fdlimit_and_fsm.py
+++ b/tests/test_daemon_fdlimit_and_fsm.py
@@ -149,7 +149,10 @@ class TestPlistRendersFdFloor:
         assert "SoftResourceLimits" in rendered
         assert "NumberOfFiles" in rendered
 
-        import defusedxml.ElementTree as ET
+        try:
+            import defusedxml.ElementTree as ET
+        except ModuleNotFoundError:
+            import xml.etree.ElementTree as ET
 
         root = ET.fromstring(rendered)
         top_dict = root.find("dict")

--- a/tests/test_daemon_tick_yields_to_mcp_activity.py
+++ b/tests/test_daemon_tick_yields_to_mcp_activity.py
@@ -103,3 +103,14 @@ def test_tick_body_works_with_none_mcp_socket(tick_env, monkeypatch):
     asyncio.run(daemon_mod._tick_body(store, state, mcp_socket=None))
 
     assert "last_tick_at" in state
+
+
+def test_mcp_recent_activity_probe():
+    from iai_mcp import daemon as daemon_mod
+
+    recent = types.SimpleNamespace(last_activity_ts=time.monotonic() - 2.0)
+    stale = types.SimpleNamespace(last_activity_ts=time.monotonic() - 120.0)
+
+    assert daemon_mod._mcp_recent_activity(recent, window_sec=30.0) is True
+    assert daemon_mod._mcp_recent_activity(stale, window_sec=30.0) is False
+    assert daemon_mod._mcp_recent_activity(None, window_sec=30.0) is False

--- a/tests/test_daemon_tick_yields_to_mcp_activity.py
+++ b/tests/test_daemon_tick_yields_to_mcp_activity.py
@@ -114,3 +114,88 @@ def test_mcp_recent_activity_probe():
     assert daemon_mod._mcp_recent_activity(recent, window_sec=30.0) is True
     assert daemon_mod._mcp_recent_activity(stale, window_sec=30.0) is False
     assert daemon_mod._mcp_recent_activity(None, window_sec=30.0) is False
+
+
+def test_capture_queue_retry_waits_for_quiet_socket(tick_env, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+
+    store, _ = tick_env
+    writes: list = []
+    handled: list = []
+
+    class _FakeCaptureQueue:
+        calls = 0
+
+        def ingest_pending(self, handler):
+            self.calls += 1
+            handler({"literal_surface": "queued"})
+            return 1
+
+        def pending_count(self):
+            return 0
+
+    monkeypatch.setattr(daemon_mod, "write_event", lambda *a, **kw: writes.append((a, kw)))
+    monkeypatch.setattr(daemon_mod, "save_state", lambda state: None)
+
+    state = {daemon_mod.CAPTURE_QUEUE_RETRY_PENDING_KEY: True}
+    queue = _FakeCaptureQueue()
+    recent_socket = types.SimpleNamespace(last_activity_ts=time.monotonic())
+
+    asyncio.run(
+        daemon_mod._retry_capture_queue_drain_if_due(
+            store,
+            state,
+            capture_queue=queue,
+            capture_handler=handled.append,
+            mcp_socket=recent_socket,
+        )
+    )
+
+    assert queue.calls == 0
+    assert handled == []
+    assert state[daemon_mod.CAPTURE_QUEUE_RETRY_PENDING_KEY] is True
+    assert writes == []
+
+
+def test_capture_queue_retry_drains_when_socket_is_quiet(tick_env, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+
+    store, _ = tick_env
+    writes: list = []
+    handled: list = []
+
+    class _FakeCaptureQueue:
+        calls = 0
+
+        def ingest_pending(self, handler):
+            self.calls += 1
+            handler({"literal_surface": "queued"})
+            return 1
+
+        def pending_count(self):
+            return 0
+
+    monkeypatch.setattr(daemon_mod, "write_event", lambda *a, **kw: writes.append((a, kw)))
+    monkeypatch.setattr(daemon_mod, "save_state", lambda state: None)
+
+    state = {daemon_mod.CAPTURE_QUEUE_RETRY_PENDING_KEY: True}
+    queue = _FakeCaptureQueue()
+    stale_socket = types.SimpleNamespace(last_activity_ts=time.monotonic() - 120.0)
+
+    asyncio.run(
+        daemon_mod._retry_capture_queue_drain_if_due(
+            store,
+            state,
+            capture_queue=queue,
+            capture_handler=handled.append,
+            mcp_socket=stale_socket,
+        )
+    )
+
+    assert queue.calls == 1
+    assert handled == [{"literal_surface": "queued"}]
+    assert state[daemon_mod.CAPTURE_QUEUE_RETRY_PENDING_KEY] is False
+    assert state["_capture_queue_pending_count"] == 0
+    assert writes
+    assert writes[0][0][1] == "capture_queue_drained"
+    assert writes[0][0][2]["phase"] == "tick_retry"

--- a/tests/test_doctor_checklist.py
+++ b/tests/test_doctor_checklist.py
@@ -5,6 +5,7 @@ import io
 import json
 import os
 import sys
+import tempfile
 from contextlib import redirect_stdout
 from pathlib import Path
 
@@ -17,33 +18,29 @@ from _socket_test_helpers import bind_fake_daemon_socket
 @pytest.fixture
 def short_socket_paths(tmp_path, monkeypatch):
     lock_path = tmp_path / ".lock"
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
-    sock_path = sock_dir / "d.sock"
     state_path = tmp_path / ".daemon-state.json"
     store_dir = tmp_path / "store"
     store_dir.mkdir(parents=True, exist_ok=True)
 
     from iai_mcp import cli, daemon_state
 
-    monkeypatch.setenv("IAI_DAEMON_SOCKET_PATH", str(sock_path))
-    monkeypatch.setenv("IAI_MCP_STORE", str(store_dir))
-    monkeypatch.setattr(daemon_state, "STATE_PATH", state_path)
-    monkeypatch.setattr(cli, "LOCK_PATH", lock_path)
-    monkeypatch.setattr(cli, "SOCKET_PATH", sock_path)
+    with tempfile.TemporaryDirectory(prefix="iai-sock-") as sock_dir_name:
+        sock_dir = Path(sock_dir_name)
+        sock_path = sock_dir / "d.sock"
+        monkeypatch.setenv("IAI_DAEMON_SOCKET_PATH", str(sock_path))
+        monkeypatch.setenv("IAI_MCP_STORE", str(store_dir))
+        monkeypatch.setattr(daemon_state, "STATE_PATH", state_path)
+        monkeypatch.setattr(cli, "LOCK_PATH", lock_path)
+        monkeypatch.setattr(cli, "SOCKET_PATH", sock_path)
 
-    try:
-        yield lock_path, sock_path, state_path
-    finally:
         try:
-            if sock_path.exists():
-                sock_path.unlink()
-        except OSError:
-            pass
-        try:
-            sock_dir.rmdir()
-        except OSError:
-            pass
+            yield lock_path, sock_path, state_path
+        finally:
+            try:
+                if sock_path.exists():
+                    sock_path.unlink()
+            except OSError:
+                pass
 
 
 def test_clean_environment_yields_check_a_fail_exit_1(short_socket_paths, capsys):

--- a/tests/test_drain_deferred_captures.py
+++ b/tests/test_drain_deferred_captures.py
@@ -6,6 +6,7 @@ import platform
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -361,6 +362,7 @@ def test_daemon_main_drain_does_not_crash_on_bad_file(tmp_path, monkeypatch):
     monkeypatch.setenv("HF_HOME", str(Path.home() / ".cache" / "huggingface"))
     monkeypatch.setenv("PYTHON_KEYRING_BACKEND", "keyring.backends.fail.Keyring")
     monkeypatch.setenv("IAI_MCP_CRYPTO_PASSPHRASE", "test-drain-integration-pass")
+    monkeypatch.setenv("IAI_MCP_STARTUP_DEFERRED_DRAIN_GRACE_SEC", "0")
 
     iai_dir = tmp_path / ".iai-mcp"
     iai_dir.mkdir(parents=True, exist_ok=True)
@@ -377,8 +379,8 @@ def test_daemon_main_drain_does_not_crash_on_bad_file(tmp_path, monkeypatch):
     )
     assert bad.exists()
 
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
+    sock_dir_ctx = tempfile.TemporaryDirectory(prefix="iai-sock-")
+    sock_dir = Path(sock_dir_ctx.name)
     sock_path = sock_dir / "d.sock"
 
     proc = None
@@ -423,5 +425,6 @@ def test_daemon_main_drain_does_not_crash_on_bad_file(tmp_path, monkeypatch):
             sock_dir.rmdir()
         except OSError:
             pass
+        sock_dir_ctx.cleanup()
         import keyring.core
         keyring.core._keyring_backend = None

--- a/tests/test_hippea_cascade_core_fallback.py
+++ b/tests/test_hippea_cascade_core_fallback.py
@@ -224,8 +224,8 @@ def _invoke_first_turn_hook(session_id="sess-a", cue="hello"):
             "iai_mcp.retrieve.recall",
             return_value=mock.MagicMock(hits=[], budget_used=0, anti_hits=[]),
         ), mock.patch(
-            "iai_mcp.retrieve.build_runtime_graph",
-            return_value=(None, _make_assignment_with_communities(), None),
+            "iai_mcp.runtime_graph_cache.load_recall_structural",
+            return_value=(_make_assignment_with_communities(), None, 0, "test"),
         ):
             _core._first_turn_recall_hook(response, params=params, store=store)
     return response
@@ -296,8 +296,8 @@ def test_m04_regression_fence_cascade_is_read_only():
     ), mock.patch(
         "iai_mcp.retrieve.recall", side_effect=_recall_side_effect,
     ), mock.patch(
-        "iai_mcp.retrieve.build_runtime_graph",
-        return_value=(None, _make_assignment_with_communities(), None),
+        "iai_mcp.runtime_graph_cache.load_recall_structural",
+        return_value=(_make_assignment_with_communities(), None, 0, "test"),
     ):
         from iai_mcp import core as _core
 
@@ -313,6 +313,39 @@ def test_m04_regression_fence_cascade_is_read_only():
             ):
                 _core._first_turn_recall_hook(resp, params=params, store=store)
     assert len(observed_results) == 3
+
+
+def test_first_turn_core_cascade_does_not_rebuild_runtime_graph():
+    from iai_mcp import core as _core
+
+    response: dict = {}
+    params = {"session_id": "sess-no-rebuild", "cue": "hello"}
+    store = mock.MagicMock()
+    store.get = mock.MagicMock(return_value=None)
+
+    with mock.patch(
+        "iai_mcp.hippea_cascade.snapshot_warm_ids", return_value=[]
+    ), mock.patch(
+        "iai_mcp.hippea_cascade.compute_core_side_warm_snapshot",
+        return_value=[uuid4()],
+    ), mock.patch(
+        "iai_mcp.runtime_graph_cache.load_recall_structural",
+        return_value=(_make_assignment_with_communities(), None, 0, "test"),
+    ) as load_structural, mock.patch(
+        "iai_mcp.retrieve.build_runtime_graph",
+        side_effect=AssertionError("runtime graph rebuild must stay off recall hot path"),
+    ), mock.patch(
+        "iai_mcp.daemon_state.consume_first_turn", return_value=True
+    ), mock.patch(
+        "iai_mcp.daemon_state.load_state", return_value={}
+    ), mock.patch(
+        "iai_mcp.retrieve.recall",
+        return_value=mock.MagicMock(hits=[], budget_used=0, anti_hits=[]),
+    ):
+        _core._first_turn_recall_hook(response, params=params, store=store)
+
+    assert "first_turn_recall" in response
+    assert load_structural.call_count == 1
 
 
 def test_response_carries_warm_lru_source():

--- a/tests/test_hippo_incident_edges.py
+++ b/tests/test_hippo_incident_edges.py
@@ -166,6 +166,21 @@ def test_incident_edges_top_k_cap(store):
     assert weights == sorted(weights, reverse=True), "Neighbours must be sorted by weight desc"
 
 
+def test_incident_edges_top_k_ranks_across_inbound_and_outbound(store):
+    hub = _make_rec(seed=150)
+    low_out = _make_rec(seed=151)
+    high_in = _make_rec(seed=152)
+    for rec in (hub, low_out, high_in):
+        store.insert(rec)
+
+    store.boost_edges([(hub.id, low_out.id)], delta=0.1, edge_type="hebbian")
+    store.boost_edges([(high_in.id, hub.id)], delta=0.9, edge_type="hebbian")
+
+    result = store.incident_edges([hub.id], top_k=1)
+
+    assert result[hub.id] == [(high_in.id, "hebbian", pytest.approx(0.9))]
+
+
 def test_incident_edges_uncapped_contradicts(store):
     hub = _make_rec(seed=200)
     store.insert(hub)

--- a/tests/test_hippo_incident_edges.py
+++ b/tests/test_hippo_incident_edges.py
@@ -107,44 +107,62 @@ def test_incident_edges_batched_one_query(store):
     assert result[records[2].id] == [], "records[2] with no edges must return empty list"
 
 
-def test_incident_edges_parameterized_bind(store):
-    import inspect
-    src = inspect.getsource(store.incident_edges)
-    assert '"?"' in src or "'?'" in src or "\"?\"\n" in src or "join(\"?\"" in src or 'join("?"' in src or "? " in src, (
-        "incident_edges source must build parameterized placeholders with '?'"
-    )
-
+def test_incident_edges_edge_type_filter_treats_values_as_data(store):
     a = _make_rec(seed=10)
     b = _make_rec(seed=11)
+    c = _make_rec(seed=12)
+    malicious_type = "hebbian') OR 1=1 --"
+    for rec in (a, b, c):
+        store.insert(rec)
+    store.boost_edges([(a.id, b.id)], edge_type="hebbian", delta=0.5)
+    store.db._conn.execute(
+        "INSERT INTO edges (src, dst, edge_type, weight, updated_at) VALUES (?, ?, ?, ?, ?)",
+        (str(a.id), str(c.id), malicious_type, 0.9, "2026-06-29T00:00:00+00:00"),
+    )
+    store.db._conn.commit()
+
+    hebbian_only = store.incident_edges(
+        [a.id], edge_types=["hebbian"], top_k=None,
+    )
+    exact_malicious = store.incident_edges(
+        [a.id], edge_types=[malicious_type], top_k=None,
+    )
+
+    assert {t[0] for t in hebbian_only[a.id]} == {b.id}
+    assert {t[0] for t in exact_malicious[a.id]} == {c.id}
+
+
+def test_incident_edges_top_k_batches_inbound_and_outbound_for_multiple_ids(store):
+    a = _make_rec(seed=20)
+    b = _make_rec(seed=21)
+    c = _make_rec(seed=22)
+    d = _make_rec(seed=23)
+    for rec in (a, b, c, d):
+        store.insert(rec)
+    store.boost_edges([(a.id, b.id)], delta=0.5)
+    store.boost_edges([(c.id, a.id)], delta=0.8)
+    store.boost_edges([(d.id, b.id)], delta=0.7)
+
+    result = store.incident_edges([a.id, b.id], top_k=2)
+
+    assert {t[0] for t in result[a.id]} == {b.id, c.id}
+    assert {t[0] for t in result[b.id]} == {a.id, d.id}
+    assert [t[2] for t in result[a.id]] == sorted(
+        [t[2] for t in result[a.id]], reverse=True,
+    )
+
+
+def test_incident_edges_empty_edge_type_filter_returns_empty(store):
+    a = _make_rec(seed=30)
+    b = _make_rec(seed=31)
     store.insert(a)
     store.insert(b)
     store.boost_edges([(a.id, b.id)], delta=0.5)
 
-    res_a = store.incident_edges([a.id])
-    res_b = store.incident_edges([b.id])
-    assert b.id in {t[0] for t in res_a.get(a.id, [])}, "B must be A's neighbour"
-    assert a.id in {t[0] for t in res_b.get(b.id, [])}, "A must be B's neighbour"
-
-
-def test_incident_edges_or_bind_two_placeholders(store):
-    import inspect
-    src = inspect.getsource(store.incident_edges)
-    assert "src IN" in src or "src in" in src.lower(), (
-        "incident_edges must use 'src IN (...)' in the OR-bind SQL"
-    )
-    assert "dst IN" in src or "dst in" in src.lower(), (
-        "incident_edges must use 'dst IN (...)' in the OR-bind SQL"
-    )
-
-    a = _make_rec(seed=20)
-    b = _make_rec(seed=21)
-    store.insert(a)
-    store.insert(b)
-    store.boost_edges([(a.id, b.id)])
-
-    result = store.incident_edges([a.id, b.id])
-    assert b.id in {t[0] for t in result.get(a.id, [])}, "B must appear from A"
-    assert a.id in {t[0] for t in result.get(b.id, [])}, "A must appear from B"
+    assert store.incident_edges([a.id, b.id], edge_types=[]) == {
+        a.id: [],
+        b.id: [],
+    }
 
 
 def test_incident_edges_top_k_cap(store):

--- a/tests/test_iai_recall_fail_fast.py
+++ b/tests/test_iai_recall_fail_fast.py
@@ -111,6 +111,7 @@ def _hermetic_env(monkeypatch, tmp_path: Path):
     monkeypatch.setenv("HOME", str(fake_home))
     monkeypatch.setenv("IAI_MCP_STORE", str(tmp_path / "store"))
     monkeypatch.delenv("IAI_DAEMON_SOCKET_PATH", raising=False)
+    monkeypatch.delenv("IAI_RECALL_READ_TIMEOUT", raising=False)
     yield
 
 

--- a/tests/test_identity_audit.py
+++ b/tests/test_identity_audit.py
@@ -119,6 +119,23 @@ def test_audit_defers_first_iteration_by_default(monkeypatch):
     assert s5_calls == []
 
 
+def test_first_iter_grace_default_is_capped(monkeypatch):
+    from iai_mcp import identity_audit
+
+    monkeypatch.delenv("IAI_MCP_AUDIT_FIRST_ITER_GRACE_SEC", raising=False)
+
+    assert identity_audit._first_iter_grace_sec(3600.0) == 60.0
+    assert identity_audit._first_iter_grace_sec(30.0) == 30.0
+
+
+def test_first_iter_grace_env_override_wins(monkeypatch):
+    from iai_mcp import identity_audit
+
+    monkeypatch.setenv("IAI_MCP_AUDIT_FIRST_ITER_GRACE_SEC", "0.25")
+
+    assert identity_audit._first_iter_grace_sec(3600.0) == 0.25
+
+
 def test_audit_survives_s5_exception_and_emits_event(monkeypatch):
     from iai_mcp import identity_audit
 

--- a/tests/test_identity_audit.py
+++ b/tests/test_identity_audit.py
@@ -92,6 +92,33 @@ def test_audit_shuts_down_cleanly(monkeypatch):
     asyncio.run(runner())
 
 
+def test_audit_defers_first_iteration_by_default(monkeypatch):
+    from iai_mcp import identity_audit
+
+    s5_calls: list = []
+
+    def fake_s5(store, window):
+        s5_calls.append(1)
+        return []
+
+    monkeypatch.setattr(identity_audit, "detect_drift_anomaly", fake_s5)
+    monkeypatch.setattr(identity_audit, "compute_and_emit", lambda s: {})
+    monkeypatch.delenv("IAI_MCP_AUDIT_FIRST_ITER_GRACE_SEC", raising=False)
+
+    async def runner():
+        shutdown = asyncio.Event()
+        task = asyncio.create_task(
+            identity_audit.continuous_audit(object(), shutdown, interval_sec=10.0)
+        )
+        await asyncio.sleep(0.03)
+        shutdown.set()
+        await asyncio.wait_for(task, timeout=2.0)
+
+    asyncio.run(runner())
+
+    assert s5_calls == []
+
+
 def test_audit_survives_s5_exception_and_emits_event(monkeypatch):
     from iai_mcp import identity_audit
 

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -33,10 +33,10 @@ def built_wrapper() -> Path:
 
 @pytest.fixture(scope="module")
 def daemon_sock() -> "Path":
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
+    sock_dir_ctx = tempfile.TemporaryDirectory(prefix="iai-sock-")
+    sock_dir = Path(sock_dir_ctx.name)
     sock_path = sock_dir / "d.sock"
-    store_dir = sock_dir / "store"
+    store_dir = Path(tempfile.mkdtemp(prefix="iai-store-"))
     store_dir.mkdir(parents=True, exist_ok=True)
 
     env = os.environ.copy()
@@ -91,7 +91,8 @@ def daemon_sock() -> "Path":
     except OSError:
         pass
     try:
-        shutil.rmtree(sock_dir, ignore_errors=True)
+        sock_dir_ctx.cleanup()
+        shutil.rmtree(store_dir, ignore_errors=True)
     except OSError:
         pass
 

--- a/tests/test_recall_core_unit.py
+++ b/tests/test_recall_core_unit.py
@@ -747,17 +747,30 @@ def test_preload_ready_flag_exists_and_is_event():
     )
 
 
-def test_boot_preload_does_not_rebuild_runtime_graph():
-    import inspect
+def test_boot_preload_does_not_rebuild_runtime_graph(monkeypatch):
+    import asyncio
     import iai_mcp.daemon as daemon_mod
+    import iai_mcp.retrieve as retrieve_mod
+    import iai_mcp.runtime_graph_cache as rgc_mod
 
-    source = inspect.getsource(daemon_mod)
-    start = source.index("async def _boot_preload")
-    end = source.index("asyncio.create_task(_boot_preload())", start)
-    preload_source = source[start:end]
+    calls: list = []
+    rgc_mod.preload_ready.clear()
 
-    assert "load_recall_structural" in preload_source
-    assert "build_runtime_graph" not in preload_source
+    def _no_build_runtime_graph(*_args, **_kwargs):
+        raise AssertionError("boot preload must not rebuild runtime graph")
+
+    def _load_recall_structural(store):
+        calls.append(store)
+        return _flat_assignment([]), [], 0, "cold_degrade"
+
+    monkeypatch.setattr(retrieve_mod, "build_runtime_graph", _no_build_runtime_graph)
+    monkeypatch.setattr(rgc_mod, "load_recall_structural", _load_recall_structural)
+
+    store = object()
+    asyncio.run(daemon_mod._boot_preload_recall_structural(store))
+
+    assert calls == [store]
+    assert rgc_mod.preload_ready.is_set()
 
 
 def test_session_start_payload_dispatch_does_not_rebuild_runtime_graph(tmp_path, monkeypatch):

--- a/tests/test_recall_core_unit.py
+++ b/tests/test_recall_core_unit.py
@@ -747,6 +747,43 @@ def test_preload_ready_flag_exists_and_is_event():
     )
 
 
+def test_boot_preload_does_not_rebuild_runtime_graph():
+    import inspect
+    import iai_mcp.daemon as daemon_mod
+
+    source = inspect.getsource(daemon_mod)
+    start = source.index("async def _boot_preload")
+    end = source.index("asyncio.create_task(_boot_preload())", start)
+    preload_source = source[start:end]
+
+    assert "load_recall_structural" in preload_source
+    assert "build_runtime_graph" not in preload_source
+
+
+def test_session_start_payload_dispatch_does_not_rebuild_runtime_graph():
+    import inspect
+    import iai_mcp.core as core_mod
+
+    source = inspect.getsource(core_mod)
+    start = source.index('if method == "session_start_payload"')
+    end = source.index('if method == "session_refresh_if_stale"', start)
+    payload_source = source[start:end]
+
+    assert "load_recall_structural" in payload_source
+    assert "build_runtime_graph" not in payload_source
+
+
+def test_wake_session_cache_write_uses_structural_snapshot_unless_forced():
+    import inspect
+    import iai_mcp.daemon as daemon_mod
+
+    source = inspect.getsource(daemon_mod._write_session_start_cache)
+
+    assert "load_recall_structural" in source
+    assert "if force_rebuild" in source
+    assert source.index("load_recall_structural") > source.index("if force_rebuild")
+
+
 def test_uncapped_contradicts_ts_by_id(tmp_path, monkeypatch):
     store = _make_store_hermetic(tmp_path, monkeypatch)
 

--- a/tests/test_recall_core_unit.py
+++ b/tests/test_recall_core_unit.py
@@ -760,28 +760,64 @@ def test_boot_preload_does_not_rebuild_runtime_graph():
     assert "build_runtime_graph" not in preload_source
 
 
-def test_session_start_payload_dispatch_does_not_rebuild_runtime_graph():
-    import inspect
+def test_session_start_payload_dispatch_does_not_rebuild_runtime_graph(tmp_path, monkeypatch):
     import iai_mcp.core as core_mod
+    import iai_mcp.retrieve as retrieve_mod
+    import iai_mcp.runtime_graph_cache as rgc_mod
 
-    source = inspect.getsource(core_mod)
-    start = source.index('if method == "session_start_payload"')
-    end = source.index('if method == "session_refresh_if_stale"', start)
-    payload_source = source[start:end]
+    store = _make_store_hermetic(tmp_path, monkeypatch)
+    recs = _insert_recs(store, 3)
+    assignment = _flat_assignment(recs)
 
-    assert "load_recall_structural" in payload_source
-    assert "build_runtime_graph" not in payload_source
+    def _no_build_runtime_graph(*_args, **_kwargs):
+        raise AssertionError("session_start_payload must not rebuild runtime graph")
+
+    monkeypatch.setattr(retrieve_mod, "build_runtime_graph", _no_build_runtime_graph)
+    monkeypatch.setattr(
+        rgc_mod,
+        "load_recall_structural",
+        lambda _store: (assignment, [recs[0].id], 0, "warm"),
+    )
+
+    payload = core_mod.dispatch(
+        store,
+        "session_start_payload",
+        {"session_id": "session-start-no-rebuild"},
+    )
+
+    assert "l0" in payload
+    assert "l1" in payload
+    assert "wake_depth" in payload
 
 
-def test_wake_session_cache_write_uses_structural_snapshot_unless_forced():
-    import inspect
+def test_wake_session_cache_write_uses_structural_snapshot_unless_forced(tmp_path, monkeypatch):
     import iai_mcp.daemon as daemon_mod
+    import iai_mcp.retrieve as retrieve_mod
+    import iai_mcp.runtime_graph_cache as rgc_mod
 
-    source = inspect.getsource(daemon_mod._write_session_start_cache)
+    store = _make_store_hermetic(tmp_path, monkeypatch)
+    recs = _insert_recs(store, 3)
+    assignment = _flat_assignment(recs)
 
-    assert "load_recall_structural" in source
-    assert "if force_rebuild" in source
-    assert source.index("load_recall_structural") > source.index("if force_rebuild")
+    def _no_build_runtime_graph(*_args, **_kwargs):
+        raise AssertionError("WAKE session cache write must not rebuild runtime graph")
+
+    monkeypatch.setattr(retrieve_mod, "build_runtime_graph", _no_build_runtime_graph)
+    monkeypatch.setattr(daemon_mod, "_runtime_graph_cache_is_warm", lambda _store: True)
+    monkeypatch.setattr(
+        rgc_mod,
+        "load_recall_structural",
+        lambda _store: (assignment, [recs[0].id], 0, "warm"),
+    )
+
+    result = daemon_mod._write_session_start_cache(
+        store,
+        cache_path=tmp_path / "session-start.cached.md",
+        trigger="periodic_wake",
+        force_rebuild=False,
+    )
+
+    assert result["action"] == "wrote"
 
 
 def test_uncapped_contradicts_ts_by_id(tmp_path, monkeypatch):
@@ -812,6 +848,136 @@ def test_uncapped_contradicts_ts_by_id(tmp_path, monkeypatch):
     assert len(uncapped_nbrs) == 6, "UNCAPPED should return all 6 contradicts targets"
     assert len(capped_nbrs) <= 5, "Capped top_k=5 should return at most 5"
     assert uncapped_nbrs >= capped_nbrs, "UNCAPPED must be a superset of capped"
+
+
+def test_memory_recall_global_degree_uses_uncapped_hub_edges(monkeypatch):
+    import iai_mcp.core as core_mod
+    import iai_mcp.embed as embed_mod
+    import iai_mcp.runtime_graph_cache as rgc_mod
+    import iai_mcp.pipeline as pipeline_mod
+    from iai_mcp.types import RecallResponse
+
+    hub = _make([1.0] + [0.0] * (EMBED_DIM - 1), text="hub")
+    spokes = [
+        _make([0.0, 1.0] + [0.0] * (EMBED_DIM - 2), text=f"spoke{i}")
+        for i in range(51)
+    ]
+    contradicts = [
+        _make([0.0, 0.0, 1.0] + [0.0] * (EMBED_DIM - 3), text=f"contr{i}")
+        for i in range(12)
+    ]
+    all_records = {r.id: r for r in [hub, *spokes, *contradicts]}
+    assignment = _flat_assignment([hub])
+    captured: dict[str, Any] = {"incident_calls": []}
+
+    class _Table:
+        def count_rows(self):
+            return 1
+
+    class _Db:
+        def open_table(self, name):
+            assert name == "records"
+            return _Table()
+
+    class _Store:
+        db = _Db()
+
+        def query_similar(self, vec, k):
+            return [(hub, 1.0)]
+
+        def incident_edges(self, ids, edge_types=None, top_k=5):
+            captured["incident_calls"].append((tuple(ids), edge_types, top_k))
+            if edge_types == ["hebbian"]:
+                assert top_k is None
+                return {
+                    hub.id: [
+                        (spoke.id, "hebbian", 1.0)
+                        for spoke in spokes
+                    ],
+                }
+            if edge_types == ["contradicts"]:
+                assert top_k is None
+                return {
+                    hub.id: [
+                        (rec.id, "contradicts", 1.0)
+                        for rec in contradicts
+                    ],
+                }
+            return {i: [] for i in ids}
+
+        def get_batch(self, ids):
+            return {rid: all_records[rid] for rid in ids if rid in all_records}
+
+        def reinforce_record(self, *_args, **_kwargs):
+            return None
+
+        def get(self, rid):
+            return all_records.get(rid)
+
+    class _Embedder:
+        def embed(self, text):
+            return [1.0] + [0.0] * (EMBED_DIM - 1)
+
+    def _fake_embedder_for_store(store):
+        return _Embedder()
+
+    def _fake_recall_for_response(**kwargs):
+        captured["graph"] = kwargs["graph"]
+        captured["tv_maps"] = kwargs.get("tv_maps")
+        return RecallResponse(
+            hits=[],
+            anti_hits=[],
+            activation_trace=[],
+            budget_used=0,
+        )
+
+    monkeypatch.setattr(rgc_mod, "load_recall_structural", lambda store: (assignment, [], 0, "warm"))
+    monkeypatch.setattr(embed_mod, "embedder_for_store", _fake_embedder_for_store)
+    monkeypatch.setattr(pipeline_mod, "recall_for_response", _fake_recall_for_response)
+
+    core_mod.dispatch(_Store(), "memory_recall", {"cue": "hub", "budget_tokens": 100})
+
+    graph = captured["graph"]
+    assert graph._global_degree[str(hub.id)] == 51
+    outgoing, ts_by_id = captured["tv_maps"]
+    assert len(outgoing[str(hub.id)]) == 12
+    assert str(contradicts[-1].id) in ts_by_id
+    assert any(call[1] == ["hebbian"] and call[2] is None for call in captured["incident_calls"])
+    assert any(call[1] == ["contradicts"] and call[2] is None for call in captured["incident_calls"])
+
+
+def test_find_anti_hits_queries_uncapped_contradictions():
+    from iai_mcp.graph import MemoryGraph
+    from iai_mcp.pipeline import _find_anti_hits
+    from iai_mcp.types import MemoryHit
+
+    hit_id = uuid4()
+    captured: dict[str, Any] = {}
+
+    class _Store:
+        def incident_edges(self, ids, edge_types=None, top_k=5):
+            captured["ids"] = ids
+            captured["edge_types"] = edge_types
+            captured["top_k"] = top_k
+            return {hit_id: []}
+
+        @property
+        def db(self):
+            raise RuntimeError("db unused by this test")
+
+    hits = [
+        MemoryHit(
+            record_id=hit_id,
+            score=1.0,
+            reason="test",
+            literal_surface="hit",
+            adjacent_suggestions=[],
+        )
+    ]
+
+    assert _find_anti_hits(hits, _Store(), MemoryGraph(), k=3) == []
+    assert captured["edge_types"] == ["contradicts"]
+    assert captured["top_k"] is None
 
 
 def test_find_anti_hits_does_not_call_edges_to_pandas(tmp_path, monkeypatch):

--- a/tests/test_recall_for_response.py
+++ b/tests/test_recall_for_response.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from datetime import datetime, timezone
 from uuid import uuid4
 
@@ -131,7 +132,7 @@ def test_recall_for_response_returns_recall_response_type(tmp_path) -> None:
 
 
 def test_active_id_filter_excludes_tombstoned_records(tmp_path) -> None:
-    from iai_mcp.pipeline import _filter_active_ids
+    from iai_mcp.pipeline import _active_id_set, _filter_active_ids
 
     store = MemoryStore(path=tmp_path / "hippo")
     live = _make([1.0] + [0.0] * (EMBED_DIM - 1), text="live")
@@ -145,6 +146,110 @@ def test_active_id_filter_excludes_tombstoned_records(tmp_path) -> None:
     store.db._conn.commit()
 
     assert _filter_active_ids([live.id, stale.id], store) == [live.id]
+    assert _active_id_set([live.id, stale.id, live.id], store) == {live.id}
+
+
+def test_recall_for_response_sanitizes_non_finite_vectors(tmp_path) -> None:
+    from iai_mcp.pipeline import recall_for_response
+
+    store = MemoryStore(path=tmp_path / "hippo")
+    recs = [
+        _make([1.0] + [0.0] * (EMBED_DIM - 1), text="inf rec"),
+        _make([0.0, 1.0] + [0.0] * (EMBED_DIM - 2), text="nan rec"),
+    ]
+    for rec in recs:
+        store.insert(rec)
+    graph_vectors = [
+        [float("inf")] + [0.0] * (EMBED_DIM - 1),
+        [float("nan")] + [1.0] + [0.0] * (EMBED_DIM - 2),
+    ]
+    graph = MemoryGraph()
+    for rec, graph_vec in zip(recs, graph_vectors):
+        graph.add_node(rec.id, community_id=None, embedding=list(graph_vec))
+        graph.set_node_payload(rec.id, {
+            "embedding": list(graph_vec),
+            "surface": rec.literal_surface,
+            "centrality": 0.0,
+            "tier": rec.tier,
+            "tags": [],
+            "language": "en",
+        })
+    assignment = _flat_assignment(recs)
+    bad_cue = [float("nan"), float("inf")] + [0.0] * (EMBED_DIM - 2)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        resp = recall_for_response(
+            store=store,
+            graph=graph,
+            assignment=assignment,
+            rich_club=[],
+            embedder=_FakeEmbedder(vec=bad_cue),
+            cue="non finite cue",
+            session_id="s-non-finite",
+        )
+
+    assert isinstance(resp, RecallResponse)
+
+
+def test_recall_for_response_does_not_recompute_missing_centrality(
+    tmp_path, monkeypatch,
+) -> None:
+    from iai_mcp import centrality_approx
+    from iai_mcp.pipeline import recall_for_response
+
+    store, graph, recs = _build_store_and_graph(tmp_path, n=5)
+    assignment = _flat_assignment(recs)
+
+    def _raise_if_called(_graph):
+        raise AssertionError("recall hot path must not recompute graph centrality")
+
+    monkeypatch.setattr(centrality_approx, "centrality_for_runtime", _raise_if_called)
+
+    resp = recall_for_response(
+        store=store,
+        graph=graph,
+        assignment=assignment,
+        rich_club=[],
+        embedder=_FakeEmbedder(),
+        cue="missing centrality",
+        session_id="s-missing-centrality",
+    )
+
+    assert isinstance(resp, RecallResponse)
+    assert isinstance(resp.hits, list)
+
+
+def test_recall_for_response_uses_batch_cache_not_all_records(
+    tmp_path, monkeypatch,
+) -> None:
+    from iai_mcp.pipeline import recall_for_response
+
+    store, graph, recs = _build_store_and_graph(tmp_path, n=5)
+    graph_without_payload = MemoryGraph()
+    for rec in recs:
+        graph_without_payload.add_node(
+            rec.id, community_id=None, embedding=list(rec.embedding),
+        )
+    assignment = _flat_assignment(recs)
+
+    def _no_all_records():
+        raise AssertionError("recall hot path must not call all_records")
+
+    monkeypatch.setattr(store, "all_records", _no_all_records)
+
+    resp = recall_for_response(
+        store=store,
+        graph=graph_without_payload,
+        assignment=assignment,
+        rich_club=[],
+        embedder=_FakeEmbedder(),
+        cue="batch cache",
+        session_id="s-batch-cache",
+    )
+
+    assert isinstance(resp, RecallResponse)
+    assert isinstance(resp.hits, list)
 
 
 def test_durable_tier_bias_prefers_semantic_for_durable_cues(tmp_path) -> None:

--- a/tests/test_recall_for_response.py
+++ b/tests/test_recall_for_response.py
@@ -8,7 +8,7 @@ import pytest
 from iai_mcp.community import CommunityAssignment
 from iai_mcp.graph import MemoryGraph
 from iai_mcp.store import MemoryStore
-from iai_mcp.types import EMBED_DIM, MemoryRecord, RecallResponse
+from iai_mcp.types import EMBED_DIM, MemoryHit, MemoryRecord, RecallResponse
 
 
 class _FakeEmbedder:
@@ -128,6 +128,102 @@ def test_recall_for_response_returns_recall_response_type(tmp_path) -> None:
     assert isinstance(resp.hints, list)
     assert isinstance(resp.cue_mode, str)
     assert isinstance(resp.patterns_observed, list)
+
+
+def test_active_id_filter_excludes_tombstoned_records(tmp_path) -> None:
+    from iai_mcp.pipeline import _filter_active_ids
+
+    store = MemoryStore(path=tmp_path / "hippo")
+    live = _make([1.0] + [0.0] * (EMBED_DIM - 1), text="live")
+    stale = _make([1.0] + [0.0] * (EMBED_DIM - 1), text="stale")
+    store.insert(live)
+    store.insert(stale)
+    store.db._conn.execute(
+        "UPDATE records SET tombstoned_at = ? WHERE id = ?",
+        (datetime.now(timezone.utc).isoformat(), str(stale.id)),
+    )
+    store.db._conn.commit()
+
+    assert _filter_active_ids([live.id, stale.id], store) == [live.id]
+
+
+def test_durable_tier_bias_prefers_semantic_for_durable_cues(tmp_path) -> None:
+    from iai_mcp.pipeline import _apply_durable_tier_bias
+
+    store = MemoryStore(path=tmp_path / "hippo")
+    semantic = _make(
+        [1.0] + [0.0] * (EMBED_DIM - 1),
+        text="durable source",
+        tier="semantic",
+    )
+    episodic = _make(
+        [1.0] + [0.0] * (EMBED_DIM - 1),
+        text="chatty session recap",
+        tier="episodic",
+    )
+    store.insert(semantic)
+    store.insert(episodic)
+    hits = [
+        MemoryHit(
+            record_id=semantic.id,
+            score=0.9,
+            sort_score=0.9,
+            reason="base",
+            literal_surface=semantic.literal_surface,
+            adjacent_suggestions=[],
+        ),
+        MemoryHit(
+            record_id=episodic.id,
+            score=0.91,
+            sort_score=0.91,
+            reason="base",
+            literal_surface=episodic.literal_surface,
+            adjacent_suggestions=[],
+        ),
+    ]
+
+    _apply_durable_tier_bias(
+        hits,
+        cue="decision etat-courant source",
+        mode="concept",
+        records_cache={semantic.id: semantic, episodic.id: episodic},
+        store=store,
+    )
+
+    assert hits[0].sort_score is not None
+    assert hits[0].sort_score > hits[1].sort_score
+    assert "durable-tier" in hits[0].reason
+
+
+def test_durable_tier_bias_skips_verbatim_mode(tmp_path) -> None:
+    from iai_mcp.pipeline import _apply_durable_tier_bias
+
+    store = MemoryStore(path=tmp_path / "hippo")
+    semantic = _make(
+        [1.0] + [0.0] * (EMBED_DIM - 1),
+        text="durable source",
+        tier="semantic",
+    )
+    store.insert(semantic)
+    hit = MemoryHit(
+        record_id=semantic.id,
+        score=0.9,
+        sort_score=0.9,
+        reason="base",
+        literal_surface=semantic.literal_surface,
+        adjacent_suggestions=[],
+    )
+
+    _apply_durable_tier_bias(
+        [hit],
+        cue="decision etat-courant source",
+        mode="verbatim",
+        records_cache={semantic.id: semantic},
+        store=store,
+    )
+
+    assert hit.sort_score == 0.9
+    assert hit.reason == "base"
 
 
 def test_recall_for_response_packs_under_budget(tmp_path) -> None:

--- a/tests/test_runtime_graph_cache.py
+++ b/tests/test_runtime_graph_cache.py
@@ -573,3 +573,11 @@ def test_hippea_cascade_not_on_fragmentation_path():
     assert "build_runtime_graph" in source, (
         "the hippea cascade must use the interval-gated recall builder"
     )
+
+
+def test_runtime_graph_rebuild_keeps_pandas_off_daemon_scan_paths():
+    source = inspect.getsource(retrieve._build_runtime_graph_impl)
+
+    assert 'open_table("edges").to_pandas' not in source
+    assert "import pandas as _pd" not in source
+    assert ".isna(" not in source

--- a/tests/test_session_recall_precache.py
+++ b/tests/test_session_recall_precache.py
@@ -259,6 +259,11 @@ def test_hook_falls_back_when_cache_absent(tmp_path):
     )
 
 def test_hook_serves_stale_cache(tmp_path):
+    """Legacy behaviour (serve cache regardless of age) is now opt-in via
+    ``IAI_MCP_SESSION_CACHE_MAX_AGE_SEC=0``. The default is 12h, so an operator
+    who wants the old contract must disable the TTL explicitly. The age cap
+    matters because a daemon that's down for days would otherwise re-inject
+    a multi-day-old precache into every new session."""
     assert HOOK_PATH.exists(), f"hook script missing: {HOOK_PATH}"
     home = tmp_path / "home"
     home.mkdir()
@@ -275,7 +280,7 @@ def test_hook_serves_stale_cache(tmp_path):
     _make_stub_cli(stub_dir, "#!/usr/bin/env bash\necho CLI_SHOULD_NOT_BE_CALLED\nexit 0\n")
     (home / ".iai-mcp" / ".cli-path").write_text(str(stub_dir / "iai-mcp"))
 
-    proc = _run_hook(home)
+    proc = _run_hook(home, extra_env={"IAI_MCP_SESSION_CACHE_MAX_AGE_SEC": "0"})
     assert proc.returncode == 0, proc.stderr
     assert proc.stdout == cache_content, (
         f"hook did not return cache verbatim. stdout={proc.stdout!r}"

--- a/tests/test_session_start_cache_refresh.py
+++ b/tests/test_session_start_cache_refresh.py
@@ -1,0 +1,703 @@
+"""Tests for the WAKE-time SessionStart cache refresh path.
+
+Covers the bug where ``_write_session_start_cache`` was only called from the
+SLEEP branch of the lifecycle tick, so a long-lived Claude session (heartbeat
+never quiet for 30 minutes) left the precache file frozen for days while the
+store kept ingesting records. The fix adds:
+
+  * a watermark sidecar (records_count + max_vec_label + max_*_at) so the cache
+    knows what corpus it was built from
+  * a cheap probe `_should_refresh_session_start_cache` that compares the live
+    watermark to the stored one
+  * `_maybe_refresh_session_start_cache`, a best-effort WAKE refresh that gates
+    on min-interval + single-flight + runtime-graph-cache-warm
+  * lifecycle-tick hooks that call the refresh after `wake_sequence` (when new
+    records were just embedded) and as a periodic safety net in WAKE/DROWSY
+  * a TTL safety net in the SessionStart shell hook
+    (`IAI_MCP_SESSION_CACHE_MAX_AGE_SEC`)
+
+The tests run against a hermetic store, never touch ``~/.iai-mcp``, and never
+spawn a real daemon.
+"""
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+pytestmark = pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX paths + shell hook")
+
+HOOK_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "src" / "iai_mcp" / "_deploy" / "hooks" / "iai-mcp-session-recall.sh"
+)
+
+
+def _fresh_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("IAI_MCP_STORE", str(tmp_path / "iai"))
+    monkeypatch.setenv("IAI_MCP_EMBED_DIM", "384")
+    from iai_mcp.store import MemoryStore
+    return MemoryStore()
+
+
+def _seed(store, n: int = 3) -> None:
+    from iai_mcp.core import _seed_l0_identity
+    from iai_mcp.types import EMBED_DIM, MemoryRecord
+    _seed_l0_identity(store)
+    now = datetime.now(timezone.utc)
+    for i in range(n):
+        store.insert(MemoryRecord(
+            id=uuid4(),
+            tier="semantic",
+            literal_surface=f"Pinned fact {i}: high-detail context.",
+            aaak_index="",
+            embedding=[0.1] * EMBED_DIM,
+            community_id=None,
+            centrality=0.5,
+            detail_level=5,
+            pinned=True,
+            stability=0.0,
+            difficulty=0.0,
+            last_reviewed=None,
+            never_decay=True,
+            never_merge=False,
+            provenance=[],
+            created_at=now,
+            updated_at=now,
+            tags=[],
+            language="en",
+        ))
+
+
+def _query_events(store, kind: str) -> list[dict]:
+    from iai_mcp.events import query_events
+    return list(query_events(store, kind=kind, limit=10000))
+
+
+def _cache_paths(tmp_path) -> tuple[Path, Path]:
+    cache = tmp_path / "cache.md"
+    # The canonical sidecar uses Path.with_suffix(".meta.json") which REPLACES
+    # the existing suffix — `.cached.md` → `.cached.meta.json` — matching
+    # SESSION_START_CACHE_META_PATH. The reader and the writer route through
+    # _default_session_start_cache_meta_path so the two cannot drift.
+    meta = tmp_path / "cache.meta.json"
+    return cache, meta
+
+
+def test_default_meta_path_matches_module_constant():
+    """The default sidecar derived from cache_path MUST match
+    SESSION_START_CACHE_META_PATH when cache_path == SESSION_START_CACHE_PATH.
+    Guards against a future refactor renaming one side and forgetting the other.
+    """
+    from iai_mcp import daemon as daemon_mod
+
+    derived = daemon_mod._default_session_start_cache_meta_path(
+        daemon_mod.SESSION_START_CACHE_PATH
+    )
+    assert derived == daemon_mod.SESSION_START_CACHE_META_PATH, (
+        f"sidecar default {derived} != module constant "
+        f"{daemon_mod.SESSION_START_CACHE_META_PATH}"
+    )
+
+
+def test_write_and_should_refresh_use_same_default_meta_path(tmp_path, monkeypatch):
+    """Anti-divergence: if _write_session_start_cache writes the sidecar at one
+    path and _should_refresh_session_start_cache reads it at another, the cache
+    will refresh on EVERY tick because the watermark is always missing. Pin both
+    sides to the helper and verify the round-trip succeeds."""
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+
+    cache = tmp_path / "cache.md"
+    # Do NOT pass meta_path explicitly — both helpers must default to the same
+    # path on their own.
+    result = daemon_mod._write_session_start_cache(
+        store, cache_path=cache, trigger="manual", force_rebuild=True,
+    )
+    assert result["action"] == "wrote"
+
+    # The reader, given only cache_path, must find the sidecar the writer left.
+    should, reason, _wm = daemon_mod._should_refresh_session_start_cache(
+        store, cache_path=cache,
+        meta_path=daemon_mod._default_session_start_cache_meta_path(cache),
+        min_interval_sec=0.0,
+    )
+    assert not should, (
+        f"reader didn't see the writer's sidecar — reason={reason}; "
+        f"this means the read/write paths use different default sidecar paths"
+    )
+    assert reason == "no_new_records"
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic: SLEEP-only call path => stale cache (the bug we are fixing)
+# ---------------------------------------------------------------------------
+
+def test_diagnostic_old_path_only_runs_in_sleep_branch(tmp_path, monkeypatch):
+    """Document the pre-fix bug: _write_session_start_cache was wired *only*
+    into the SLEEP branch of the lifecycle tick, so a never-sleeping daemon
+    never regenerated the cache."""
+    from iai_mcp import daemon as daemon_mod
+    import inspect
+
+    src = inspect.getsource(daemon_mod._tick_body) if hasattr(daemon_mod, "_tick_body") else ""
+    # The lifecycle tick body lives in this module; just check the file-wide
+    # picture: the only *unconditional* call to `_write_session_start_cache`
+    # used to sit inside the `current is _LifecycleState.SLEEP` arm. We now
+    # also call it via the WAKE refresh wrapper, but the sleep-pipeline call
+    # MUST stay (it backs the post-consolidation cache write).
+    text = Path(daemon_mod.__file__).read_text()
+    assert "_LifecycleState.SLEEP" in text
+    assert "_maybe_refresh_session_start_cache" in text, (
+        "WAKE-side refresh helper is missing — fix not applied"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Watermark probe
+# ---------------------------------------------------------------------------
+
+def test_watermark_probe_counts_active_records(tmp_path, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store, n=4)
+
+    wm = daemon_mod._session_start_cache_watermark(store)
+    assert wm["records_count"] >= 4
+    assert wm["max_vec_label"] >= 4
+    assert wm["max_created_at"]  # non-empty ISO
+
+
+def test_watermark_probe_distinguishes_new_record_with_old_created_at(
+    tmp_path, monkeypatch,
+):
+    """A record inserted *now* but stamped with an *old* ``created_at`` (e.g.
+    backfilled from a transcript) still bumps ``max_vec_label`` — that's why
+    the watermark uses the monotone vec_label, not just MAX(created_at)."""
+    from iai_mcp import daemon as daemon_mod
+    from iai_mcp.types import EMBED_DIM, MemoryRecord
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store, n=2)
+
+    before = daemon_mod._session_start_cache_watermark(store)
+
+    old_ts = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    store.insert(MemoryRecord(
+        id=uuid4(),
+        tier="semantic",
+        literal_surface="Backfilled from old transcript.",
+        aaak_index="",
+        embedding=[0.1] * EMBED_DIM,
+        community_id=None,
+        centrality=0.5,
+        detail_level=5,
+        pinned=False,
+        stability=0.0,
+        difficulty=0.0,
+        last_reviewed=None,
+        never_decay=False,
+        never_merge=False,
+        provenance=[],
+        created_at=old_ts,
+        updated_at=old_ts,
+        tags=[],
+        language="en",
+    ))
+
+    after = daemon_mod._session_start_cache_watermark(store)
+    assert after["max_vec_label"] > before["max_vec_label"]
+    assert after["records_count"] > before["records_count"]
+    # MAX(created_at) likely UNCHANGED (the new record's date is older), proving
+    # the vec_label component is what catches this case.
+    assert after["max_created_at"] >= before["max_created_at"]
+
+
+# ---------------------------------------------------------------------------
+# should_refresh decision matrix
+# ---------------------------------------------------------------------------
+
+def test_should_refresh_when_cache_absent(tmp_path, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+
+    cache, meta = _cache_paths(tmp_path)
+    should, reason, _wm = daemon_mod._should_refresh_session_start_cache(
+        store, cache_path=cache, meta_path=meta, min_interval_sec=60.0,
+    )
+    assert should
+    assert reason == "cache_absent"
+
+
+def test_should_refresh_blocks_within_min_interval(tmp_path, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+
+    cache, meta = _cache_paths(tmp_path)
+    # Pretend a refresh just happened: write cache + meta + bump mtime to now.
+    cache.write_text("seed")
+    meta.write_text(json.dumps({
+        "records_count": 999, "max_vec_label": 999,
+        "max_created_at": "z", "max_updated_at": "z",
+    }))
+    os.utime(cache, (time.time(), time.time()))
+
+    should, reason, _wm = daemon_mod._should_refresh_session_start_cache(
+        store, cache_path=cache, meta_path=meta, min_interval_sec=300.0,
+    )
+    assert not should
+    assert reason == "min_interval_not_elapsed"
+
+
+def test_should_refresh_when_meta_absent(tmp_path, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+
+    cache, meta = _cache_paths(tmp_path)
+    cache.write_text("seed")
+    # Make the cache look old enough to bypass the min-interval gate.
+    old = time.time() - 600
+    os.utime(cache, (old, old))
+
+    should, reason, _wm = daemon_mod._should_refresh_session_start_cache(
+        store, cache_path=cache, meta_path=meta, min_interval_sec=60.0,
+    )
+    assert should
+    assert reason == "meta_absent"
+
+
+def test_should_refresh_no_new_records(tmp_path, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+
+    cache, meta = _cache_paths(tmp_path)
+    cache.write_text("seed")
+    wm = daemon_mod._session_start_cache_watermark(store)
+    meta.write_text(json.dumps({
+        "records_count": wm["records_count"],
+        "max_vec_label": wm["max_vec_label"],
+        "max_created_at": wm["max_created_at"],
+        "max_updated_at": wm["max_updated_at"],
+    }))
+    old = time.time() - 600
+    os.utime(cache, (old, old))
+
+    should, reason, _wm = daemon_mod._should_refresh_session_start_cache(
+        store, cache_path=cache, meta_path=meta, min_interval_sec=60.0,
+    )
+    assert not should
+    assert reason == "no_new_records"
+
+
+def test_should_refresh_when_watermark_changes(tmp_path, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store, n=2)
+
+    cache, meta = _cache_paths(tmp_path)
+    cache.write_text("seed")
+    wm = daemon_mod._session_start_cache_watermark(store)
+    meta.write_text(json.dumps({
+        "records_count": wm["records_count"],
+        "max_vec_label": wm["max_vec_label"],
+        "max_created_at": wm["max_created_at"],
+        "max_updated_at": wm["max_updated_at"],
+    }))
+    old = time.time() - 600
+    os.utime(cache, (old, old))
+
+    _seed(store, n=1)  # add one more record
+
+    should, reason, _wm = daemon_mod._should_refresh_session_start_cache(
+        store, cache_path=cache, meta_path=meta, min_interval_sec=60.0,
+    )
+    assert should
+    assert reason == "watermark_changed"
+
+
+# ---------------------------------------------------------------------------
+# _write_session_start_cache: telemetry + skip paths
+# ---------------------------------------------------------------------------
+
+def test_write_emits_started_and_success_events(tmp_path, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+
+    cache, meta = _cache_paths(tmp_path)
+    result = daemon_mod._write_session_start_cache(
+        store, cache_path=cache, meta_path=meta,
+        trigger="manual", force_rebuild=True,
+    )
+    assert result["action"] == "wrote"
+    assert cache.exists()
+    assert meta.exists()
+
+    started = _query_events(store, "session_start_cache_write_started")
+    success = _query_events(store, "session_start_cache_write_success")
+    failed = _query_events(store, "session_start_cache_write_failed")
+    assert len(started) == 1, started
+    assert len(success) == 1, success
+    assert len(failed) == 0
+
+    # Inspect the success-event payload: all the watermark fields are there.
+    from iai_mcp.events import query_events
+    s = list(query_events(store, kind="session_start_cache_write_success", limit=10))[0]
+    data = s.get("data") or {}
+    for key in (
+        "trigger", "cache_path", "rendered_chars", "records_count",
+        "max_vec_label", "max_record_created_at", "max_updated_at", "duration_ms",
+    ):
+        assert key in data, f"missing {key} in success event: {data}"
+    assert data["trigger"] == "manual"
+    assert data["rendered_chars"] > 0
+    assert data["records_count"] >= 3
+
+
+def test_write_skips_when_runtime_graph_cache_cold(tmp_path, monkeypatch):
+    """When the runtime graph cache is cold and force_rebuild=False, the WAKE
+    refresh MUST skip with reason=runtime_graph_cache_cold instead of spawning
+    a heavyweight rebuild inside the lifecycle tick."""
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+
+    monkeypatch.setattr(
+        daemon_mod, "_runtime_graph_cache_is_warm", lambda _store: False,
+    )
+
+    cache, meta = _cache_paths(tmp_path)
+    result = daemon_mod._write_session_start_cache(
+        store, cache_path=cache, meta_path=meta,
+        trigger="periodic_wake", force_rebuild=False,
+    )
+    assert result["action"] == "skipped"
+    assert result["reason"] == "runtime_graph_cache_cold"
+    assert not cache.exists(), "cold-cache skip MUST NOT write the cache"
+
+    skipped = _query_events(store, "session_start_cache_write_skipped")
+    assert any(
+        (e.get("data") or {}).get("reason") == "runtime_graph_cache_cold"
+        for e in skipped
+    ), skipped
+
+
+def test_write_force_rebuild_ignores_cold_probe(tmp_path, monkeypatch):
+    """The SLEEP branch passes force_rebuild=True; even a cold probe shouldn't
+    stop the write — that's the cheapest moment to absorb the rebuild cost."""
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+
+    monkeypatch.setattr(
+        daemon_mod, "_runtime_graph_cache_is_warm", lambda _store: False,
+    )
+
+    cache, meta = _cache_paths(tmp_path)
+    result = daemon_mod._write_session_start_cache(
+        store, cache_path=cache, meta_path=meta,
+        trigger="sleep_pipeline", force_rebuild=True,
+    )
+    assert result["action"] == "wrote"
+    assert cache.exists()
+
+
+def test_write_emits_failed_event_on_render_crash(tmp_path, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+    from iai_mcp import session as session_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("synthetic-render-failure")
+
+    monkeypatch.setattr(session_mod, "format_payload_as_markdown", _boom)
+
+    cache, meta = _cache_paths(tmp_path)
+    result = daemon_mod._write_session_start_cache(
+        store, cache_path=cache, meta_path=meta,
+        trigger="manual", force_rebuild=True,
+    )
+    assert result["action"] == "failed"
+
+    failed = _query_events(store, "session_start_cache_write_failed")
+    assert failed, "expected at least one _failed event"
+    data = failed[-1].get("data") or {}
+    assert data.get("reason") == "RuntimeError"
+    assert "synthetic-render-failure" in str(data.get("error", ""))
+    assert "duration_ms" in data
+    assert data.get("trigger") == "manual"
+
+
+# ---------------------------------------------------------------------------
+# Single-flight + min-interval gates on _maybe_refresh
+# ---------------------------------------------------------------------------
+
+def test_maybe_refresh_single_flight_under_concurrency(tmp_path, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+
+    cache, meta = _cache_paths(tmp_path)
+
+    # Make the write itself slow so the second thread definitely contends.
+    real_write = daemon_mod._write_session_start_cache
+
+    def _slow_write(store, **kwargs):
+        time.sleep(0.2)
+        return real_write(store, **kwargs)
+
+    monkeypatch.setattr(daemon_mod, "_write_session_start_cache", _slow_write)
+
+    results = []
+    def _kick():
+        results.append(daemon_mod._maybe_refresh_session_start_cache(
+            store, trigger="manual", cache_path=cache, meta_path=meta,
+            min_interval_sec=0.0, force_rebuild=True,
+        ))
+
+    t1 = threading.Thread(target=_kick)
+    t2 = threading.Thread(target=_kick)
+    t1.start(); t2.start()
+    t1.join(); t2.join()
+
+    actions = [r.get("action") for r in results]
+    reasons = [r.get("reason") for r in results]
+    assert actions.count("wrote") == 1, (actions, reasons)
+    assert "refresh_in_progress" in reasons, (actions, reasons)
+
+
+def test_maybe_refresh_respects_min_interval_env(tmp_path, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+    cache, meta = _cache_paths(tmp_path)
+
+    monkeypatch.setenv("IAI_MCP_SESSION_CACHE_REFRESH_MIN_SEC", "120")
+
+    # First refresh writes the cache + meta and stamps mtime=now.
+    r1 = daemon_mod._maybe_refresh_session_start_cache(
+        store, trigger="periodic_wake",
+        cache_path=cache, meta_path=meta, force_rebuild=True,
+    )
+    assert r1["action"] == "wrote"
+
+    # Immediate second call: blocked by the min-interval gate, NOT by single-flight.
+    r2 = daemon_mod._maybe_refresh_session_start_cache(
+        store, trigger="periodic_wake",
+        cache_path=cache, meta_path=meta, force_rebuild=True,
+    )
+    assert r2 == {"action": "skipped", "reason": "min_interval_not_elapsed"}
+
+
+def test_maybe_refresh_runs_when_new_records_after_interval(tmp_path, monkeypatch):
+    """End-to-end of the WAKE refresh: stale cache + new records + interval
+    elapsed → the next call writes a fresh cache *without* the lifecycle tick
+    ever entering SLEEP."""
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store, n=2)
+    cache, meta = _cache_paths(tmp_path)
+
+    daemon_mod._write_session_start_cache(
+        store, cache_path=cache, meta_path=meta,
+        trigger="manual", force_rebuild=True,
+    )
+    assert cache.exists()
+
+    # Pretend a few minutes have passed since the first write so the min-interval
+    # gate lets the second refresh through.
+    old = time.time() - 600
+    os.utime(cache, (old, old))
+
+    _seed(store, n=2)  # new records → watermark moves
+
+    result = daemon_mod._maybe_refresh_session_start_cache(
+        store, trigger="periodic_wake",
+        cache_path=cache, meta_path=meta,
+        min_interval_sec=60.0, force_rebuild=True,
+    )
+    assert result["action"] == "wrote"
+    new_mtime = cache.stat().st_mtime
+    # The successful refresh re-stamped the mtime back to "now", so it must be
+    # far newer than the artificially-aged value we set above.
+    assert new_mtime > old + 60
+    # Watermark sidecar reflects the new corpus size.
+    sidecar = json.loads(meta.read_text())
+    wm_now = daemon_mod._session_start_cache_watermark(store)
+    assert sidecar["records_count"] == wm_now["records_count"]
+    assert sidecar["max_vec_label"] == wm_now["max_vec_label"]
+    # Content may or may not change byte-for-byte depending on payload tail,
+    # but the rendered_chars field should match the new file length.
+    assert sidecar["rendered_chars"] == len(cache.read_text())
+
+
+# ---------------------------------------------------------------------------
+# Hook TTL safety net (opt-in via IAI_MCP_SESSION_CACHE_MAX_AGE_SEC)
+# ---------------------------------------------------------------------------
+
+def _run_hook(home: Path, *, env: dict[str, str], stdin: str = '{"session_id":"x","source":"startup"}'):
+    full_env = os.environ.copy()
+    full_env["HOME"] = str(home)
+    full_env.update(env)
+    return subprocess.run(
+        ["bash", str(HOOK_PATH)], input=stdin, env=full_env,
+        capture_output=True, text=True, timeout=10.0,
+    )
+
+
+def _today_log(home: Path) -> Path:
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return home / ".iai-mcp" / "logs" / f"recall-{today}.log"
+
+
+def _make_stub_cli(dir_: Path, body: str) -> Path:
+    cli = dir_ / "iai-mcp"
+    cli.write_text(body)
+    cli.chmod(cli.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return cli
+
+
+def test_hook_serves_fresh_cache_when_ttl_set(tmp_path):
+    """TTL set + cache fresh → still serve the cache, log cache-hit."""
+    home = tmp_path / "home"; home.mkdir()
+    (home / ".iai-mcp").mkdir()
+    cache = home / ".iai-mcp" / ".session-start-payload.cached.md"
+    cache.write_text("fresh-cache-content")
+
+    stub_dir = tmp_path / "stub"; stub_dir.mkdir()
+    _make_stub_cli(stub_dir, "#!/usr/bin/env bash\necho CLI_SHOULD_NOT_BE_CALLED\nexit 0\n")
+    (home / ".iai-mcp" / ".cli-path").write_text(str(stub_dir / "iai-mcp"))
+
+    proc = _run_hook(home, env={"IAI_MCP_SESSION_CACHE_MAX_AGE_SEC": "3600"})
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout == "fresh-cache-content"
+    assert "CLI_SHOULD_NOT_BE_CALLED" not in proc.stdout
+    log = _today_log(home).read_text()
+    assert "cache-hit age=" in log
+    assert "cache-stale" not in log
+
+
+def test_hook_falls_through_when_cache_older_than_ttl(tmp_path):
+    """TTL set + cache stale → fall through to live CLI, log cache-stale."""
+    home = tmp_path / "home"; home.mkdir()
+    (home / ".iai-mcp").mkdir()
+    cache = home / ".iai-mcp" / ".session-start-payload.cached.md"
+    cache.write_text("stale-content")
+    twenty_five_h_ago = time.time() - (25 * 3600)
+    os.utime(cache, (twenty_five_h_ago, twenty_five_h_ago))
+
+    stub_dir = tmp_path / "stub"; stub_dir.mkdir()
+    _make_stub_cli(stub_dir, "#!/usr/bin/env bash\nprintf '%s' FRESH_FROM_CLI\nexit 0\n")
+    (home / ".iai-mcp" / ".cli-path").write_text(str(stub_dir / "iai-mcp"))
+
+    proc = _run_hook(home, env={"IAI_MCP_SESSION_CACHE_MAX_AGE_SEC": "3600"})
+    assert proc.returncode == 0, proc.stderr
+    assert "FRESH_FROM_CLI" in proc.stdout
+    assert "stale-content" not in proc.stdout
+    log = _today_log(home).read_text()
+    assert "cache-stale age=" in log
+    assert " max=3600s" in log
+
+
+def test_hook_default_ttl_falls_through_when_unset(tmp_path):
+    """Unset env → default-on 12h TTL: a 25h-old cache MUST fall through to the
+    live CLI rather than re-injecting a stale prefix. This is the safety-net
+    behaviour: if the daemon is down, we'd rather pay the live-CLI cost than
+    silently serve a multi-day-old precache."""
+    home = tmp_path / "home"; home.mkdir()
+    (home / ".iai-mcp").mkdir()
+    cache = home / ".iai-mcp" / ".session-start-payload.cached.md"
+    cache.write_text("stale-content")
+    twenty_five_h_ago = time.time() - (25 * 3600)
+    os.utime(cache, (twenty_five_h_ago, twenty_five_h_ago))
+
+    stub_dir = tmp_path / "stub"; stub_dir.mkdir()
+    _make_stub_cli(stub_dir, "#!/usr/bin/env bash\nprintf '%s' FRESH_FROM_CLI\nexit 0\n")
+    (home / ".iai-mcp" / ".cli-path").write_text(str(stub_dir / "iai-mcp"))
+
+    env_no_ttl = {k: v for k, v in os.environ.items()
+                  if k != "IAI_MCP_SESSION_CACHE_MAX_AGE_SEC"}
+    full = env_no_ttl.copy()
+    full["HOME"] = str(home)
+    proc = subprocess.run(
+        ["bash", str(HOOK_PATH)],
+        input='{"session_id":"x","source":"startup"}',
+        env=full, capture_output=True, text=True, timeout=10.0,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "FRESH_FROM_CLI" in proc.stdout
+    assert "stale-content" not in proc.stdout
+    log = _today_log(home).read_text()
+    assert "cache-stale age=" in log
+    assert " max=43200s" in log, log
+
+
+def test_hook_ttl_disabled_explicitly_serves_stale(tmp_path):
+    """IAI_MCP_SESSION_CACHE_MAX_AGE_SEC=0 → explicit legacy behaviour: cache
+    served regardless of age. The opt-out is the escape hatch for operators who
+    consciously accept a stale precache (e.g. offline triage)."""
+    home = tmp_path / "home"; home.mkdir()
+    (home / ".iai-mcp").mkdir()
+    cache = home / ".iai-mcp" / ".session-start-payload.cached.md"
+    cache.write_text("stale-content")
+    twenty_five_h_ago = time.time() - (25 * 3600)
+    os.utime(cache, (twenty_five_h_ago, twenty_five_h_ago))
+
+    stub_dir = tmp_path / "stub"; stub_dir.mkdir()
+    _make_stub_cli(stub_dir, "#!/usr/bin/env bash\nprintf '%s' CLI_SHOULD_NOT_BE_CALLED\nexit 0\n")
+    (home / ".iai-mcp" / ".cli-path").write_text(str(stub_dir / "iai-mcp"))
+
+    proc = _run_hook(home, env={"IAI_MCP_SESSION_CACHE_MAX_AGE_SEC": "0"})
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout == "stale-content"
+    assert "CLI_SHOULD_NOT_BE_CALLED" not in proc.stdout
+
+
+def test_hook_ttl_garbage_env_falls_back_to_default(tmp_path):
+    """A non-numeric env value MUST NOT silently disable the safety net — it
+    falls back to the 12h default. Documents the case() guard."""
+    home = tmp_path / "home"; home.mkdir()
+    (home / ".iai-mcp").mkdir()
+    cache = home / ".iai-mcp" / ".session-start-payload.cached.md"
+    cache.write_text("stale-content")
+    twenty_five_h_ago = time.time() - (25 * 3600)
+    os.utime(cache, (twenty_five_h_ago, twenty_five_h_ago))
+
+    stub_dir = tmp_path / "stub"; stub_dir.mkdir()
+    _make_stub_cli(stub_dir, "#!/usr/bin/env bash\nprintf '%s' FRESH_FROM_CLI\nexit 0\n")
+    (home / ".iai-mcp" / ".cli-path").write_text(str(stub_dir / "iai-mcp"))
+
+    proc = _run_hook(home, env={"IAI_MCP_SESSION_CACHE_MAX_AGE_SEC": "not-a-number"})
+    assert proc.returncode == 0, proc.stderr
+    assert "FRESH_FROM_CLI" in proc.stdout
+    log = _today_log(home).read_text()
+    assert " max=43200s" in log, log

--- a/tests/test_sigma.py
+++ b/tests/test_sigma.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
 
 import networkx as nx
 import pytest
@@ -134,3 +136,28 @@ def test_compute_sigma_ceiling_env_override(monkeypatch):
     g = nx.connected_watts_strogatz_graph(300, 6, 0.1, seed=42)
     mg = _nx_graph_to_memory_graph(g)
     assert compute_sigma(mg) is None
+
+
+def test_topology_snapshot_reuses_payload_centrality_for_rich_club(monkeypatch):
+    from iai_mcp import sigma
+    from iai_mcp.graph import MemoryGraph
+
+    graph = MemoryGraph()
+    nodes = [uuid4() for _ in range(12)]
+    for idx, node_id in enumerate(nodes):
+        graph.add_node(node_id, community_id=None, embedding=[0.0] * 8)
+        graph.set_node_centrality(node_id, float(idx + 1))
+    for left, right in zip(nodes, nodes[1:]):
+        graph.add_edge(left, right, weight=1.0, edge_type="hebbian")
+
+    def fail_exact_centrality(self):
+        raise AssertionError("topology snapshot must not call exact centrality")
+
+    monkeypatch.setattr(MemoryGraph, "centrality", fail_exact_centrality)
+
+    snap = sigma.compute_topology_snapshot(
+        graph,
+        assignment=SimpleNamespace(community_centroids={0: [nodes[0]]}),
+    )
+
+    assert snap["rich_club_ratio"] > 0.0

--- a/tests/test_socket_activity_tracking.py
+++ b/tests/test_socket_activity_tracking.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -33,32 +34,28 @@ def _endpoint_ready_path(sock_path: Path) -> Path:
 def short_socket_paths(tmp_path, monkeypatch):
     from iai_mcp import concurrency, daemon_state
 
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
-    sock_path = sock_dir / "d.sock"
     state_path = tmp_path / ".daemon-state.json"
-
-    monkeypatch.setattr(concurrency, "SOCKET_PATH", sock_path)
-    monkeypatch.setattr(daemon_state, "STATE_PATH", state_path)
-    # Per-test endpoint isolation (unix socket on POSIX; TCP port file on
-    # Windows) via the env var both serve() and open_ipc_connection() honor.
-    monkeypatch.setenv("IAI_DAEMON_SOCKET_PATH", str(sock_path))
     store_root = tmp_path / "store_root"
     store_root.mkdir(parents=True, exist_ok=True)
     monkeypatch.setenv("IAI_MCP_STORE", str(store_root))
 
-    try:
-        yield sock_path
-    finally:
+    with tempfile.TemporaryDirectory(prefix="iai-sock-") as sock_dir_name:
+        sock_dir = Path(sock_dir_name)
+        sock_path = sock_dir / "d.sock"
+        monkeypatch.setattr(concurrency, "SOCKET_PATH", sock_path)
+        monkeypatch.setattr(daemon_state, "STATE_PATH", state_path)
+        # Per-test endpoint isolation (unix socket on POSIX; TCP port file on
+        # Windows) via the env var both serve() and open_ipc_connection() honor.
+        monkeypatch.setenv("IAI_DAEMON_SOCKET_PATH", str(sock_path))
+
         try:
-            if sock_path.exists():
-                sock_path.unlink()
-        except OSError:
-            pass
-        try:
-            sock_dir.rmdir()
-        except OSError:
-            pass
+            yield sock_path
+        finally:
+            try:
+                if sock_path.exists():
+                    sock_path.unlink()
+            except OSError:
+                pass
 
 
 async def _send_line(sock_path: Path, payload: dict, *, timeout: float = 10.0) -> dict:

--- a/tests/test_socket_disconnect_reconnect.py
+++ b/tests/test_socket_disconnect_reconnect.py
@@ -173,8 +173,8 @@ def _drop_fake_daemon_conn(proc: subprocess.Popen) -> None:
 
 @pytest.fixture
 def fake_daemon():
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
+    sock_dir_ctx = tempfile.TemporaryDirectory(prefix="iai-sock-")
+    sock_dir = Path(sock_dir_ctx.name)
     sock_path = sock_dir / "d.sock"
 
     proc = _spawn_fake_daemon(sock_path)
@@ -200,6 +200,7 @@ def fake_daemon():
         shutil.rmtree(sock_dir, ignore_errors=True)
     except OSError:
         pass
+    sock_dir_ctx.cleanup()
 
 def _spawn_wrapper(
     built_wrapper: Path,

--- a/tests/test_socket_fail_loud.py
+++ b/tests/test_socket_fail_loud.py
@@ -7,6 +7,7 @@ import signal
 import socket as sk
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -23,23 +24,19 @@ from _socket_test_helpers import (
 @pytest.fixture
 def short_socket_paths(tmp_path):
     lock_path = tmp_path / ".lock"
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
-    sock_path = sock_dir / "d.sock"
     state_path = tmp_path / ".daemon-state.json"
 
-    try:
-        yield lock_path, sock_path, state_path
-    finally:
+    with tempfile.TemporaryDirectory(prefix="iai-sock-") as sock_dir_name:
+        sock_dir = Path(sock_dir_name)
+        sock_path = sock_dir / "d.sock"
         try:
-            if sock_path.exists():
-                sock_path.unlink()
-        except OSError:
-            pass
-        try:
-            sock_dir.rmdir()
-        except OSError:
-            pass
+            yield lock_path, sock_path, state_path
+        finally:
+            try:
+                if sock_path.exists():
+                    sock_path.unlink()
+            except OSError:
+                pass
 
 def _count_iai_mcp_processes() -> dict[str, int]:
     counts = {"core": 0, "daemon": 0}

--- a/tests/test_socket_first_store_hermeticity.py
+++ b/tests/test_socket_first_store_hermeticity.py
@@ -163,7 +163,8 @@ class TestSendSocketRequestOverride:
         assert result is None
 
     def test_socket_request_default_without_override(self, monkeypatch):
-        from iai_mcp.cli import SOCKET_PATH, _send_socket_request
+        from iai_mcp._ipc import SOCKET_PATH
+        from iai_mcp.cli import _send_socket_request
 
         monkeypatch.delenv("IAI_DAEMON_SOCKET_PATH", raising=False)
 

--- a/tests/test_socket_inherit_launchd_fd.py
+++ b/tests/test_socket_inherit_launchd_fd.py
@@ -5,6 +5,7 @@ import json
 import os
 import platform
 import socket
+import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator
@@ -48,8 +49,7 @@ def _bind_to_fd_3(sock_path: Path) -> Iterator[socket.socket]:
             pass
 
 def _short_sock_path(suffix: str) -> Path:
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
+    sock_dir = Path(tempfile.mkdtemp(prefix=f"iai-sock-{suffix}-"))
     return sock_dir / "d.sock"
 
 def _cleanup_sock(sock_path: Path) -> None:

--- a/tests/test_socket_server_dispatch.py
+++ b/tests/test_socket_server_dispatch.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import os
 import tempfile
+import time
 from pathlib import Path
 
 import pytest
@@ -22,34 +23,30 @@ def _endpoint_ready_path(sock_path: Path) -> Path:
 def short_socket_paths(tmp_path, monkeypatch):
     from iai_mcp import concurrency, daemon_state
 
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
-    sock_path = sock_dir / "d.sock"
-    state_path = tmp_path / ".daemon-state.json"
+    with tempfile.TemporaryDirectory(prefix="iai-sock-") as sock_dir_raw:
+        sock_dir = Path(sock_dir_raw)
+        sock_path = sock_dir / "d.sock"
+        state_path = tmp_path / ".daemon-state.json"
 
-    monkeypatch.setattr(concurrency, "SOCKET_PATH", sock_path)
-    monkeypatch.setattr(daemon_state, "STATE_PATH", state_path)
-    # Isolate the IPC endpoint per-test. POSIX uses this as the unix socket
-    # path; Windows persists the ephemeral TCP port to "<sock_path>.port".
-    # Both SocketServer.serve() and open_ipc_connection() resolve through it,
-    # so concurrent tests never collide on the shared default endpoint.
-    monkeypatch.setenv("IAI_DAEMON_SOCKET_PATH", str(sock_path))
-    store_root = tmp_path / "store_root"
-    store_root.mkdir(parents=True, exist_ok=True)
-    monkeypatch.setenv("IAI_MCP_STORE", str(store_root))
+        monkeypatch.setattr(concurrency, "SOCKET_PATH", sock_path)
+        monkeypatch.setattr(daemon_state, "STATE_PATH", state_path)
+        # Isolate the IPC endpoint per-test. POSIX uses this as the unix socket
+        # path; Windows persists the ephemeral TCP port to "<sock_path>.port".
+        # Both SocketServer.serve() and open_ipc_connection() resolve through it,
+        # so concurrent tests never collide on the shared default endpoint.
+        monkeypatch.setenv("IAI_DAEMON_SOCKET_PATH", str(sock_path))
+        store_root = tmp_path / "store_root"
+        store_root.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("IAI_MCP_STORE", str(store_root))
 
-    try:
-        yield None, sock_path, state_path
-    finally:
         try:
-            if sock_path.exists():
-                sock_path.unlink()
-        except OSError:
-            pass
-        try:
-            sock_dir.rmdir()
-        except OSError:
-            pass
+            yield None, sock_path, state_path
+        finally:
+            try:
+                if sock_path.exists():
+                    sock_path.unlink()
+            except OSError:
+                pass
 
 async def _send_jsonrpc(
     sock_path: Path,
@@ -143,6 +140,38 @@ def test_memory_recall_routed_over_socket(short_socket_paths):
     assert resp["id"] == 1, resp
     assert "result" in resp, resp
     assert "hits" in resp["result"], resp["result"]
+
+
+@pytest.mark.perf
+def test_memory_recall_socket_round_trip_latency(short_socket_paths, monkeypatch):
+    _, sock_path, _ = short_socket_paths
+    from iai_mcp import core
+    from iai_mcp.store import MemoryStore
+
+    def _fast_dispatch(store, method, params):
+        assert method == "memory_recall"
+        assert params["cue"] == "latency probe"
+        return {"hits": [], "_recall_latency_ms": 0.1}
+
+    monkeypatch.setattr(core, "dispatch", _fast_dispatch)
+    store = MemoryStore()
+
+    async def _runner(sock_path, store):
+        t0 = time.perf_counter()
+        resp = await _send_jsonrpc(
+            sock_path,
+            "memory_recall",
+            {"cue": "latency probe", "budget_tokens": 100},
+            req_id=7,
+        )
+        return resp, (time.perf_counter() - t0) * 1000.0
+
+    resp, elapsed_ms = asyncio.run(_with_socket_server(sock_path, store, _runner))
+
+    assert resp["jsonrpc"] == "2.0", resp
+    assert resp["id"] == 7, resp
+    assert resp["result"]["hits"] == []
+    assert elapsed_ms < 250.0, f"socket round-trip took {elapsed_ms:.1f} ms"
 
 def test_session_start_payload_routed(short_socket_paths):
     _, sock_path, _ = short_socket_paths

--- a/tests/test_socket_server_dispatch.py
+++ b/tests/test_socket_server_dispatch.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import os
 import tempfile
+import threading
 import time
 from pathlib import Path
 
@@ -172,6 +173,65 @@ def test_memory_recall_socket_round_trip_latency(short_socket_paths, monkeypatch
     assert resp["id"] == 7, resp
     assert resp["result"]["hits"] == []
     assert elapsed_ms < 250.0, f"socket round-trip took {elapsed_ms:.1f} ms"
+
+
+def test_memory_recall_socket_concurrency_limit_returns_busy(short_socket_paths, monkeypatch):
+    _, sock_path, _ = short_socket_paths
+    from iai_mcp import core
+    from iai_mcp.store import MemoryStore
+
+    monkeypatch.setenv("IAI_MCP_RECALL_CONCURRENCY", "1")
+    monkeypatch.setenv("IAI_MCP_RECALL_SLOT_WAIT_SEC", "0.02")
+
+    slow_started = threading.Event()
+    release_slow = threading.Event()
+    calls: list[str] = []
+
+    def _dispatch(store, method, params):
+        assert method == "memory_recall"
+        cue = params["cue"]
+        calls.append(cue)
+        if cue == "slow":
+            slow_started.set()
+            assert release_slow.wait(timeout=2.0)
+        return {"hits": [], "_recall_latency_ms": 0.1, "cue": cue}
+
+    monkeypatch.setattr(core, "dispatch", _dispatch)
+    store = MemoryStore()
+
+    async def _runner(sock_path, store):
+        slow_task = asyncio.create_task(
+            _send_jsonrpc(
+                sock_path,
+                "memory_recall",
+                {"cue": "slow", "budget_tokens": 100},
+                req_id="slow",
+                timeout=5.0,
+            )
+        )
+        for _ in range(200):
+            if slow_started.is_set():
+                break
+            await asyncio.sleep(0.005)
+        assert slow_started.is_set(), "slow recall never acquired the only slot"
+
+        busy = await _send_jsonrpc(
+            sock_path,
+            "memory_recall",
+            {"cue": "busy", "budget_tokens": 100},
+            req_id="busy",
+            timeout=5.0,
+        )
+        release_slow.set()
+        slow = await slow_task
+        return slow, busy
+
+    slow, busy = asyncio.run(_with_socket_server(sock_path, store, _runner))
+
+    assert slow["result"]["cue"] == "slow"
+    assert busy["result"]["_degraded"] is True
+    assert busy["result"]["_reason"] == "recall_busy"
+    assert calls == ["slow"]
 
 def test_session_start_payload_routed(short_socket_paths):
     _, sock_path, _ = short_socket_paths

--- a/tests/test_socket_subagent_reuse.py
+++ b/tests/test_socket_subagent_reuse.py
@@ -6,6 +6,7 @@ import select
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -155,10 +156,10 @@ def _spawn_daemon_in_background(
     )
 
 def test_subagent_spawns_zero_new_processes(built_wrapper, tmp_path):
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
+    sock_dir_ctx = tempfile.TemporaryDirectory(prefix="iai-sock-")
+    sock_dir = Path(sock_dir_ctx.name)
     sock_path = sock_dir / "d.sock"
-    store_dir = sock_dir / "store"
+    store_dir = tmp_path / "store"
     store_dir.mkdir(parents=True, exist_ok=True)
     assert not sock_path.exists()
 
@@ -205,7 +206,7 @@ def test_subagent_spawns_zero_new_processes(built_wrapper, tmp_path):
         )
 
         daemon_delta = after["daemon"] - before["daemon"]
-        assert daemon_delta == 0, (
+        assert daemon_delta <= 0, (
             f"singleton violated: sub-agent path spawned an extra daemon "
             f"(before={before['daemon']} after={after['daemon']} delta={daemon_delta})"
         )
@@ -221,3 +222,4 @@ def test_subagent_spawns_zero_new_processes(built_wrapper, tmp_path):
             sock_path.unlink()
         except OSError:
             pass
+        sock_dir_ctx.cleanup()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -86,6 +86,26 @@ def test_query_returns_top_k(tmp_path):
     assert len(results) == 3
 
 
+def test_query_similar_excludes_tombstoned_records(tmp_path):
+    store = MemoryStore(path=tmp_path)
+    live = _make(text="live fact", vec=[0.1] * EMBED_DIM)
+    tombstoned = _make(text="stale fact", vec=[0.1] * EMBED_DIM)
+    store.insert(live)
+    store.insert(tombstoned)
+
+    now = datetime.now(timezone.utc).isoformat()
+    store.db._conn.execute(
+        "UPDATE records SET tombstoned_at = ? WHERE id = ?",
+        (now, str(tombstoned.id)),
+    )
+    store.db._conn.commit()
+
+    ids = {record.id for record, _score in store.query_similar([0.1] * EMBED_DIM, k=10)}
+
+    assert live.id in ids
+    assert tombstoned.id not in ids
+
+
 def test_invalid_tier_rejected():
     with pytest.raises(ValueError):
         _make(tier="unknown-tier")

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -86,6 +86,81 @@ def test_query_returns_top_k(tmp_path):
     assert len(results) == 3
 
 
+def test_query_similar_does_not_use_pandas_ann_path(tmp_path, monkeypatch):
+    from iai_mcp.hippo._table import HippoQuery
+
+    store = MemoryStore(path=tmp_path)
+    rec = _make()
+    store.insert(rec)
+
+    def _no_to_pandas(*_args, **_kwargs):
+        raise AssertionError("query_similar hot path must not call to_pandas")
+
+    monkeypatch.setattr(HippoQuery, "to_pandas", _no_to_pandas)
+
+    results = store.query_similar([0.1] * EMBED_DIM, k=3)
+
+    assert results and results[0][0].id == rec.id
+
+
+def test_get_does_not_use_pandas_path(tmp_path, monkeypatch):
+    from iai_mcp.hippo._table import HippoQuery, HippoTable
+
+    store = MemoryStore(path=tmp_path)
+    rec = _make(text="direct get")
+    store.insert(rec)
+
+    def _no_to_pandas(*_args, **_kwargs):
+        raise AssertionError("get hot path must not call to_pandas")
+
+    monkeypatch.setattr(HippoQuery, "to_pandas", _no_to_pandas)
+    monkeypatch.setattr(HippoTable, "to_pandas", _no_to_pandas)
+
+    got = store.get(rec.id)
+
+    assert got is not None
+    assert got.id == rec.id
+    assert got.literal_surface == "direct get"
+
+
+def test_from_row_hot_paths_do_not_call_pandas_isna(tmp_path, monkeypatch):
+    import pandas as pd
+
+    store = MemoryStore(path=tmp_path)
+    rec = _make(text="no pandas isna")
+    store.insert(rec)
+
+    def _no_isna(*_args, **_kwargs):
+        raise AssertionError("_from_row hot path must not call pandas.isna")
+
+    monkeypatch.setattr(pd, "isna", _no_isna)
+
+    got = store.get(rec.id)
+    results = store.query_similar([0.1] * EMBED_DIM, k=3)
+
+    assert got is not None
+    assert got.id == rec.id
+    assert results and results[0][0].id == rec.id
+
+
+def test_query_similar_fast_failure_degrades_without_pandas(tmp_path, monkeypatch):
+    from iai_mcp.hippo._table import HippoQuery
+
+    store = MemoryStore(path=tmp_path)
+    store.insert(_make())
+
+    def _fast_fails(*_args, **_kwargs):
+        raise RuntimeError("forced fast-path failure")
+
+    def _no_to_pandas(*_args, **_kwargs):
+        raise AssertionError("query_similar fallback must not call to_pandas")
+
+    monkeypatch.setattr(store, "_query_similar_fast", _fast_fails)
+    monkeypatch.setattr(HippoQuery, "to_pandas", _no_to_pandas)
+
+    assert store.query_similar([0.1] * EMBED_DIM, k=3) == []
+
+
 def test_query_similar_excludes_tombstoned_records(tmp_path):
     store = MemoryStore(path=tmp_path)
     live = _make(text="live fact", vec=[0.1] * EMBED_DIM)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -161,6 +161,32 @@ def test_query_similar_fast_failure_degrades_without_pandas(tmp_path, monkeypatc
     assert store.query_similar([0.1] * EMBED_DIM, k=3) == []
 
 
+def test_query_similar_fast_catches_hnsw_runtime_error(tmp_path):
+    import threading
+    import types
+
+    store = MemoryStore(path=tmp_path)
+
+    class _BrokenHnsw:
+        def get_current_count(self):
+            return 1
+
+        def knn_query(self, *_args, **_kwargs):
+            raise RuntimeError("label map skew")
+
+    fake_db = types.SimpleNamespace(
+        _hnsw_lock=threading.Lock(),
+        _label_map={1: "abc"},
+        _hnsw=_BrokenHnsw(),
+    )
+    query = types.SimpleNamespace(
+        _ann_db=fake_db,
+        _ann_vector=[0.1] * EMBED_DIM,
+    )
+
+    assert store._query_similar_fast(query, "tombstoned_at IS NULL", 3) == []
+
+
 def test_query_similar_excludes_tombstoned_records(tmp_path):
     store = MemoryStore(path=tmp_path)
     live = _make(text="live fact", vec=[0.1] * EMBED_DIM)


### PR DESCRIPTION
## Summary
- refresh the SessionStart cache from WAKE/DROWSY, not only after SLEEP
- add single-flight, min-interval and watermark sidecar guards for cheap best-effort refreshes
- make the SessionStart hook TTL default to 12h so stale caches fall through to live recall
- add coverage for refresh decisions, telemetry, sidecar path consistency, TTL fallback and failure cases

## Validation
- .venv/bin/python -m pytest tests/test_session_start_cache_refresh.py tests/test_session_recall_precache.py tests/test_session_refresh_rpc.py tests/test_frozen_constant_hermeticity.py tests/test_consolidation_single_driver.py
- 45 passed in 13.25s

## Notes
- This branch is based on origin/main at v1.2.0.
- It supersedes the earlier branch that was accidentally based on v1.1.7.
- Local production smoke testing showed periodic_wake writes the cache successfully, with session_start_cache_write_started -> session_start_cache_write_success and no failures.