### PR TITLE
fix(daemon): refresh SessionStart cache during WAKE

### DIFF
--- a/src/iai_mcp/_deploy/hooks/iai-mcp-session-recall.sh
+++ b/src/iai_mcp/_deploy/hooks/iai-mcp-session-recall.sh
@@ -43,10 +43,23 @@ ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 } >> "$log" 2>/dev/null
 
 # precache for SessionStart hook
-# Read the daemon-written cache whenever it is non-empty (no age cap).
+# Read the daemon-written cache whenever it is non-empty AND younger than the
+# max-age safety net. Default: 43200s (12h). Set
+# IAI_MCP_SESSION_CACHE_MAX_AGE_SEC=0 to disable the cap (legacy behaviour:
+# serve the cache regardless of age). Unset / non-numeric → 43200s.
+#
+# Rationale: if the daemon is down, crashed, or its regeneration path is
+# silently failing, we MUST NOT re-inject a multi-day-old prefix into every
+# new Claude/Codex session. The TTL is a back-stop; the primary defence is
+# `daemon._maybe_refresh_session_start_cache`, which refreshes the cache on
+# WAKE whenever new records land.
 # Each branch writes a contract log marker. Falls through to the live CLI path
 # on any miss.
 cache_path="$HOME/.iai-mcp/.session-start-payload.cached.md"
+cache_max_age="${IAI_MCP_SESSION_CACHE_MAX_AGE_SEC-43200}"
+case "$cache_max_age" in
+  ''|*[!0-9]*) cache_max_age=43200 ;;
+esac
 if [ -s "$cache_path" ]; then
   # Cross-platform mtime: try GNU stat, then BSD stat.
   cache_mtime=$(stat -c %Y "$cache_path" 2>/dev/null || stat -f %m "$cache_path" 2>/dev/null || echo 0)
@@ -55,13 +68,17 @@ if [ -s "$cache_path" ]; then
   else
     now_epoch=$(date +%s)
     age=$(( now_epoch - cache_mtime ))
-    cache_out=$(head -c 10000 "$cache_path" 2>/dev/null || true)
-    if [ -n "$cache_out" ]; then
-      printf '%s' "$cache_out"
-      echo "$ts cache-hit age=${age}s bytes=${#cache_out}" >> "$log" 2>/dev/null
-      exit 0
+    if [ "$cache_max_age" -gt 0 ] && [ "$age" -gt "$cache_max_age" ]; then
+      echo "$ts cache-stale age=${age}s max=${cache_max_age}s -> live-cli" >> "$log" 2>/dev/null
+    else
+      cache_out=$(head -c 10000 "$cache_path" 2>/dev/null || true)
+      if [ -n "$cache_out" ]; then
+        printf '%s' "$cache_out"
+        echo "$ts cache-hit age=${age}s bytes=${#cache_out}" >> "$log" 2>/dev/null
+        exit 0
+      fi
+      echo "$ts cache-miss empty (file existed but read returned 0 bytes)" >> "$log" 2>/dev/null
     fi
-    echo "$ts cache-miss empty (file existed but read returned 0 bytes)" >> "$log" 2>/dev/null
   fi
 elif [ -e "$cache_path" ]; then
   echo "$ts cache-miss empty (zero-byte file)" >> "$log" 2>/dev/null

--- a/src/iai_mcp/daemon/__init__.py
+++ b/src/iai_mcp/daemon/__init__.py
@@ -71,7 +71,16 @@ S4_FIRST_ITER_GRACE_SEC: float = float(
 )
 
 SESSION_START_CACHE_PATH = Path.home() / ".iai-mcp" / ".session-start-payload.cached.md"
+SESSION_START_CACHE_META_PATH = (
+    Path.home() / ".iai-mcp" / ".session-start-payload.cached.meta.json"
+)
 from iai_mcp.session import SESSION_START_CACHE_MAX_CHARS  # noqa: E402 -- placed after PATH constant for readability
+
+SESSION_START_CACHE_REFRESH_MIN_SEC_DEFAULT: float = 60.0
+# Single-flight lock for refreshes — the SLEEP path also routes through it so a
+# WAKE refresh kicked from the wake-sequence hook never races a sleep-pipeline
+# write on the same file.
+_session_start_cache_lock = threading.Lock()
 
 INTERRUPT_RECENT_ACTIVITY_WINDOW_SEC: float = 30.0
 
@@ -373,47 +382,380 @@ def _update_pending_digest(state: dict, cycle_result: dict) -> None:
     state["pending_digest"] = digest
 
 
-def _write_session_start_cache(store, *, cache_path: Path = SESSION_START_CACHE_PATH) -> None:
+def _default_session_start_cache_meta_path(cache_path: Path) -> Path:
+    """Canonical sidecar path next to ``cache_path``.
+
+    ``Path.with_suffix(".meta.json")`` REPLACES the existing suffix, so
+    ``.session-start-payload.cached.md`` → ``.session-start-payload.cached.meta.json``
+    (matches ``SESSION_START_CACHE_META_PATH``). Both the writer and the
+    reader route through this single helper so a future change to the naming
+    convention cannot accidentally desync them.
+    """
+    return cache_path.with_suffix(".meta.json")
+
+
+def _session_start_cache_watermark(store) -> dict:
+    """Cheap probe used to decide whether the cache needs regenerating.
+
+    Returns a dict with `records_count`, `max_vec_label`, `max_created_at`,
+    `max_updated_at`. The probe runs a single SELECT — no rebuild, no spawn —
+    so it is safe to call on every WAKE tick.
+
+    ``max_vec_label`` is the monotone AUTOINCREMENT primary key on the records
+    table: it strictly increases on every insert, so it catches records inserted
+    *now* with an *old* ``created_at`` (e.g. backfilled from a transcript), which
+    a ``MAX(created_at)`` comparison would miss.
+    """
     try:
-        from iai_mcp import retrieve
-        from iai_mcp.session import (
-            _compose_session_start_payload,
-            format_payload_as_markdown,
-        )
+        with store.db._conn_lock:
+            row = store.db._conn.execute(
+                "SELECT COUNT(*),"
+                " COALESCE(MAX(vec_label), 0),"
+                " COALESCE(MAX(created_at), ''),"
+                " COALESCE(MAX(updated_at), '')"
+                " FROM records WHERE tombstoned_at IS NULL"
+            ).fetchone()
+    except Exception as exc:  # noqa: BLE001 -- watermark probe MUST NOT crash
+        log.debug("session_start_cache watermark probe failed: %s", exc)
+        return {
+            "records_count": -1,
+            "max_vec_label": -1,
+            "max_created_at": "",
+            "max_updated_at": "",
+        }
+    if not row:
+        return {
+            "records_count": 0,
+            "max_vec_label": 0,
+            "max_created_at": "",
+            "max_updated_at": "",
+        }
+    return {
+        "records_count": int(row[0] or 0),
+        "max_vec_label": int(row[1] or 0),
+        "max_created_at": str(row[2] or ""),
+        "max_updated_at": str(row[3] or ""),
+    }
 
-        _graph, assignment, rc = retrieve.build_runtime_graph(store)
-        payload = _compose_session_start_payload(
-            store,
-            assignment,
-            rc,
-            session_id="precache",
-            profile_state={"wake_depth": "standard"},
-        )
-        rendered = format_payload_as_markdown(payload)
-        if not rendered:
-            return
-        if len(rendered) > SESSION_START_CACHE_MAX_CHARS:
-            rendered = rendered[:SESSION_START_CACHE_MAX_CHARS]
 
-        cache_path.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path = cache_path.with_suffix(cache_path.suffix + ".tmp")
+def _load_session_start_cache_meta(meta_path: Path) -> dict | None:
+    try:
+        with open(meta_path, encoding="utf-8") as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        return None
+    except (OSError, ValueError) as exc:
+        log.debug("session_start_cache meta load failed: %s", exc)
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def _save_session_start_cache_meta(meta_path: Path, meta: dict) -> None:
+    try:
+        meta_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = meta_path.with_suffix(meta_path.suffix + ".tmp")
         with open(tmp_path, "w", encoding="utf-8") as f:
-            f.write(rendered)
+            json.dump(meta, f, separators=(",", ":"))
             f.flush()
             os.fsync(f.fileno())
         os.chmod(tmp_path, 0o600)
-        os.replace(tmp_path, cache_path)
-    except Exception as exc:  # noqa: BLE001 -- cache write MUST NOT crash the REM loop
-        log.warning("session start cache write failed: %s", exc, exc_info=True)
+        os.replace(tmp_path, meta_path)
+    except (OSError, ValueError) as exc:
+        log.debug("session_start_cache meta save failed: %s", exc)
+
+
+def _runtime_graph_cache_is_warm(store) -> bool:
+    """Cheap probe: returns False if a full runtime-graph rebuild is required.
+
+    Wraps `retrieve._runtime_graph_rebuild_needed` (a disk read + COUNT(*), no
+    rebuild) so the WAKE refresh path can skip cleanly with reason
+    ``runtime_graph_cache_cold`` instead of spawning the expensive child fleet
+    inside the lifecycle tick.
+    """
+    try:
+        from iai_mcp import retrieve
+        return not retrieve._runtime_graph_rebuild_needed(store)
+    except Exception as exc:  # noqa: BLE001 -- probe MUST NOT crash
+        log.debug("runtime_graph_cache warm probe failed: %s", exc)
+        return False
+
+
+def _should_refresh_session_start_cache(
+    store,
+    *,
+    cache_path: Path,
+    meta_path: Path,
+    min_interval_sec: float,
+    now_monotonic: float | None = None,
+) -> tuple[bool, str, dict]:
+    """Decide whether the cache should be regenerated right now.
+
+    Returns ``(should_refresh, reason, current_watermark)``. ``reason`` is the
+    string emitted into the ``session_start_cache_write_skipped`` / ``_started``
+    events so the user can tell at a glance why a tick did or did not refresh.
+
+    Decisions, in order:
+
+    * No cache file yet → ``cache_absent``.
+    * Cache exists but mtime is younger than ``min_interval_sec`` → block to
+      avoid thrashing under burst ingestion (``min_interval_not_elapsed``).
+    * No meta sidecar (older install or pre-watermark cache) → refresh and
+      backfill the sidecar (``meta_absent``).
+    * Watermark probe matches the stored watermark exactly → nothing new,
+      ``no_new_records``.
+    * Otherwise refresh (``watermark_changed``).
+    """
+    current = _session_start_cache_watermark(store)
+    try:
+        cache_mtime = cache_path.stat().st_mtime
+    except (FileNotFoundError, OSError):
+        return True, "cache_absent", current
+
+    if min_interval_sec > 0:
+        age = time.time() - cache_mtime
+        if age < min_interval_sec:
+            return False, "min_interval_not_elapsed", current
+
+    stored = _load_session_start_cache_meta(meta_path)
+    if not stored:
+        return True, "meta_absent", current
+
+    if (
+        int(stored.get("records_count", -1)) == current["records_count"]
+        and int(stored.get("max_vec_label", -1)) == current["max_vec_label"]
+        and str(stored.get("max_created_at", "")) == current["max_created_at"]
+        and str(stored.get("max_updated_at", "")) == current["max_updated_at"]
+    ):
+        return False, "no_new_records", current
+
+    return True, "watermark_changed", current
+
+
+def _emit_session_start_cache_event(
+    store,
+    kind: str,
+    data: dict,
+    *,
+    severity: str = "info",
+) -> None:
+    """Best-effort event write that never crashes the caller."""
+    try:
+        write_event(store, kind, data, severity=severity)
+    except Exception:  # noqa: BLE001 -- event write must not crash the refresh path
+        log.debug("failed to write %s event", kind)
+
+
+def _write_session_start_cache(
+    store,
+    *,
+    cache_path: Path = SESSION_START_CACHE_PATH,
+    meta_path: Path | None = None,
+    trigger: str = "sleep_pipeline",
+    force_rebuild: bool = True,
+) -> dict:
+    """Write the SessionStart cache from the current memory store.
+
+    Parameters
+    ----------
+    cache_path : Path
+        Target file; defaults to ``~/.iai-mcp/.session-start-payload.cached.md``.
+    meta_path : Path
+        Sidecar with the watermark; defaults to ``cache_path`` + ``.meta.json``
+        so a custom ``cache_path`` (tests) keeps the meta next to the cache.
+    trigger : str
+        Why this write was kicked: ``sleep_pipeline`` (under EXCLUSIVE lock,
+        rebuild allowed), ``wake_sequence`` (after fresh ingest/reembed),
+        ``periodic_wake`` (watermark drifted), ``manual`` (CLI / test).
+    force_rebuild : bool
+        When True (the SLEEP path), we let ``build_runtime_graph`` do whatever
+        rebuild it needs — we already hold EX and the consolidation window is the
+        right moment for the expensive recompute. When False (WAKE path), we
+        skip with ``runtime_graph_cache_cold`` rather than spawn a rebuild on a
+        live tick.
+
+    Returns a small status dict with the reason and watermark so callers
+    (e.g. tests) can assert without grovelling through events.
+    """
+    started_at = time.monotonic()
+    if not _session_start_cache_lock.acquire(blocking=False):
+        _emit_session_start_cache_event(
+            store,
+            "session_start_cache_write_skipped",
+            {"reason": "refresh_in_progress", "trigger": trigger,
+             "cache_path": str(cache_path)},
+        )
+        return {"action": "skipped", "reason": "refresh_in_progress"}
+
+    if meta_path is None:
+        meta_path = _default_session_start_cache_meta_path(cache_path)
+
+    try:
+        _emit_session_start_cache_event(
+            store,
+            "session_start_cache_write_started",
+            {"trigger": trigger, "cache_path": str(cache_path),
+             "force_rebuild": bool(force_rebuild)},
+        )
+
+        if not force_rebuild and not _runtime_graph_cache_is_warm(store):
+            _emit_session_start_cache_event(
+                store,
+                "session_start_cache_write_skipped",
+                {"reason": "runtime_graph_cache_cold", "trigger": trigger,
+                 "cache_path": str(cache_path),
+                 "duration_ms": int((time.monotonic() - started_at) * 1000)},
+            )
+            return {"action": "skipped", "reason": "runtime_graph_cache_cold"}
+
         try:
-            write_event(
+            from iai_mcp import retrieve
+            from iai_mcp.session import (
+                _compose_session_start_payload,
+                format_payload_as_markdown,
+            )
+
+            _graph, assignment, rc = retrieve.build_runtime_graph(store)
+            payload = _compose_session_start_payload(
+                store,
+                assignment,
+                rc,
+                session_id="precache",
+                profile_state={"wake_depth": "standard"},
+            )
+            rendered = format_payload_as_markdown(payload)
+            if not rendered:
+                _emit_session_start_cache_event(
+                    store,
+                    "session_start_cache_write_skipped",
+                    {"reason": "empty_render", "trigger": trigger,
+                     "cache_path": str(cache_path),
+                     "duration_ms": int((time.monotonic() - started_at) * 1000)},
+                )
+                return {"action": "skipped", "reason": "empty_render"}
+            if len(rendered) > SESSION_START_CACHE_MAX_CHARS:
+                rendered = rendered[:SESSION_START_CACHE_MAX_CHARS]
+
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = cache_path.with_suffix(cache_path.suffix + ".tmp")
+            with open(tmp_path, "w", encoding="utf-8") as f:
+                f.write(rendered)
+                f.flush()
+                os.fsync(f.fileno())
+            os.chmod(tmp_path, 0o600)
+            os.replace(tmp_path, cache_path)
+
+            watermark = _session_start_cache_watermark(store)
+            meta = {
+                "records_count": watermark["records_count"],
+                "max_vec_label": watermark["max_vec_label"],
+                "max_created_at": watermark["max_created_at"],
+                "max_updated_at": watermark["max_updated_at"],
+                "rendered_chars": len(rendered),
+                "generated_at": datetime.now(timezone.utc).isoformat(),
+                "trigger": trigger,
+            }
+            _save_session_start_cache_meta(meta_path, meta)
+
+            _emit_session_start_cache_event(
+                store,
+                "session_start_cache_write_success",
+                {
+                    "trigger": trigger,
+                    "cache_path": str(cache_path),
+                    "rendered_chars": len(rendered),
+                    "records_count": watermark["records_count"],
+                    "max_vec_label": watermark["max_vec_label"],
+                    "max_record_created_at": watermark["max_created_at"],
+                    "max_updated_at": watermark["max_updated_at"],
+                    "duration_ms": int((time.monotonic() - started_at) * 1000),
+                },
+            )
+            return {
+                "action": "wrote",
+                "rendered_chars": len(rendered),
+                "watermark": watermark,
+            }
+        except Exception as exc:  # noqa: BLE001 -- cache write MUST NOT crash the loop
+            log.warning("session start cache write failed: %s", exc, exc_info=True)
+            _emit_session_start_cache_event(
                 store,
                 "session_start_cache_write_failed",
-                {"error": str(exc)[:200]},
+                {
+                    "trigger": trigger,
+                    "cache_path": str(cache_path),
+                    "reason": type(exc).__name__,
+                    "error": str(exc)[:200],
+                    "duration_ms": int((time.monotonic() - started_at) * 1000),
+                },
                 severity="warning",
             )
-        except Exception:  # noqa: BLE001 -- event write inside boundary guard
-            log.debug("failed to write session_start_cache_write_failed event")
+            return {"action": "failed", "reason": type(exc).__name__}
+    finally:
+        _session_start_cache_lock.release()
+
+
+def _maybe_refresh_session_start_cache(
+    store,
+    *,
+    trigger: str,
+    cache_path: Path = SESSION_START_CACHE_PATH,
+    meta_path: Path | None = None,
+    min_interval_sec: float | None = None,
+    force_rebuild: bool = False,
+) -> dict:
+    """Best-effort WAKE-time refresh.
+
+    Always:
+      * runs the cheap watermark probe + min-interval gate before doing any work;
+      * acquires the single-flight lock non-blocking;
+      * skips if the runtime graph cache is cold;
+      * never raises — callers from the lifecycle tick depend on this.
+    """
+    if meta_path is None:
+        meta_path = _default_session_start_cache_meta_path(cache_path)
+    if min_interval_sec is None:
+        try:
+            min_interval_sec = float(
+                os.environ.get(
+                    "IAI_MCP_SESSION_CACHE_REFRESH_MIN_SEC",
+                    str(SESSION_START_CACHE_REFRESH_MIN_SEC_DEFAULT),
+                )
+            )
+        except (TypeError, ValueError):
+            min_interval_sec = SESSION_START_CACHE_REFRESH_MIN_SEC_DEFAULT
+
+    try:
+        should, reason, _wm = _should_refresh_session_start_cache(
+            store,
+            cache_path=cache_path,
+            meta_path=meta_path,
+            min_interval_sec=min_interval_sec,
+        )
+    except Exception as exc:  # noqa: BLE001 -- gate probe must not crash
+        log.debug("session_start_cache should-refresh probe failed: %s", exc)
+        return {"action": "skipped", "reason": "probe_failed"}
+
+    if not should:
+        _emit_session_start_cache_event(
+            store,
+            "session_start_cache_write_skipped",
+            {"reason": reason, "trigger": trigger, "cache_path": str(cache_path)},
+        )
+        return {"action": "skipped", "reason": reason}
+
+    try:
+        return _write_session_start_cache(
+            store,
+            cache_path=cache_path,
+            meta_path=meta_path,
+            trigger=trigger,
+            force_rebuild=force_rebuild,
+        )
+    except Exception as exc:  # noqa: BLE001 -- belt-and-suspenders; _write already guards
+        log.debug("session_start_cache refresh wrapper failed: %s", exc)
+        return {"action": "failed", "reason": type(exc).__name__}
 
 
 async def _tick_body(
@@ -1458,6 +1800,28 @@ async def main() -> int:
                                     _kick_drowsy_rgc_rebuild(store)
                                 except Exception:  # noqa: BLE001 -- best-effort
                                     log.debug("drowsy-edge kick failed", exc_info=True)
+                                # Kick a light, best-effort SessionStart cache refresh:
+                                # new records just got embedded (reembed_count > 0 or
+                                # ingest_count > 0), so what the hook would serve from
+                                # disk is now stale. _maybe_refresh_session_start_cache
+                                # gates on min-interval + single-flight + runtime-graph
+                                # warm — if any of those say no, it emits a _skipped
+                                # event and returns.
+                                if (
+                                    int(_wake_seq_result.get("reembed_count", 0) or 0) > 0
+                                    or int(_wake_seq_result.get("ingest_count", 0) or 0) > 0
+                                ):
+                                    try:
+                                        await asyncio.to_thread(
+                                            _maybe_refresh_session_start_cache,
+                                            store,
+                                            trigger="wake_sequence",
+                                        )
+                                    except Exception:  # noqa: BLE001 -- best-effort
+                                        log.debug(
+                                            "wake_sequence cache refresh failed",
+                                            exc_info=True,
+                                        )
                         except Exception:  # noqa: BLE001 -- wake sequence non-fatal
                             log.debug("lifecycle_tick pending_embeddings_wake_sequence failed", exc_info=True)
                     if (
@@ -1473,6 +1837,30 @@ async def main() -> int:
                             log.debug("daemon_lock_downgrade: EX→SH on first WAKE entry")
                         except Exception:  # noqa: BLE001
                             log.debug("daemon_lock_downgrade failed", exc_info=True)
+
+                    # Periodic WAKE/DROWSY safety net: if the daemon never reaches
+                    # SLEEP (long-lived Claude sessions keep activity recent), the
+                    # sleep-pipeline cache writer never fires and the precache file
+                    # drifts. _maybe_refresh_session_start_cache is a cheap probe
+                    # (SQL COUNT + sidecar read), gated by:
+                    #   * min-interval (default 60s, IAI_MCP_SESSION_CACHE_REFRESH_MIN_SEC)
+                    #   * single-flight lock
+                    #   * watermark (records_count + max_vec_label + max_*_at)
+                    #   * runtime-graph-cache warm probe (skip if cold)
+                    # so a quiet tick costs one SELECT + one stat() and emits at
+                    # most one _skipped event.
+                    if current in (_LifecycleState.WAKE, _LifecycleState.DROWSY):
+                        try:
+                            await asyncio.to_thread(
+                                _maybe_refresh_session_start_cache,
+                                store,
+                                trigger="periodic_wake",
+                            )
+                        except Exception:  # noqa: BLE001 -- best-effort
+                            log.debug(
+                                "lifecycle_tick periodic session_start_cache refresh failed",
+                                exc_info=True,
+                            )
 
                     _prev_lifecycle_state[0] = current
                     if current is _LifecycleState.SLEEP:
@@ -1500,8 +1888,18 @@ async def main() -> int:
                         )
 
                         # --- WAKE hook (UNDER LOCK_EX, BEFORE downgrade) ---
+                        # The SLEEP path explicitly passes force_rebuild=True: we
+                        # hold the EXCLUSIVE lock for the whole consolidation
+                        # window, so a runtime-graph rebuild here is the cheapest
+                        # place to absorb the cost — the WAKE refresh paths skip
+                        # the rebuild with reason=runtime_graph_cache_cold instead.
                         try:
-                            await asyncio.to_thread(_write_session_start_cache, store)
+                            await asyncio.to_thread(
+                                _write_session_start_cache,
+                                store,
+                                trigger="sleep_pipeline",
+                                force_rebuild=True,
+                            )
                         except Exception:  # noqa: BLE001 -- precache MUST NOT crash
                             log.debug("lifecycle_tick _write_session_start_cache failed", exc_info=True)
                         try:
@@ -1738,6 +2136,13 @@ __all__ = [
     "_is_inside_window",
     "_update_pending_digest",
     "_write_session_start_cache",
+    "_maybe_refresh_session_start_cache",
+    "_should_refresh_session_start_cache",
+    "_session_start_cache_watermark",
+    "_load_session_start_cache_meta",
+    "_save_session_start_cache_meta",
+    "_default_session_start_cache_meta_path",
+    "_runtime_graph_cache_is_warm",
     "_tick_body",
     "_scheduler_tick",
     "_s4_offline_loop",
@@ -1752,7 +2157,9 @@ __all__ = [
     "S4_OFFLINE_INTERVAL_SEC",
     "S4_FIRST_ITER_GRACE_SEC",
     "SESSION_START_CACHE_PATH",
+    "SESSION_START_CACHE_META_PATH",
     "SESSION_START_CACHE_MAX_CHARS",
+    "SESSION_START_CACHE_REFRESH_MIN_SEC_DEFAULT",
     "INTERRUPT_RECENT_ACTIVITY_WINDOW_SEC",
     "_DAEMON_NOFILE_FLOOR_DEFAULT",
     # daemon_config

--- a/src/iai_mcp/daemon/__init__.py
+++ b/src/iai_mcp/daemon/__init__.py
@@ -77,6 +77,7 @@ SESSION_START_CACHE_META_PATH = (
 from iai_mcp.session import SESSION_START_CACHE_MAX_CHARS  # noqa: E402 -- placed after PATH constant for readability
 
 SESSION_START_CACHE_REFRESH_MIN_SEC_DEFAULT: float = 60.0
+SESSION_START_CACHE_LOCK_TIMEOUT_SEC: float = 300.0
 # Single-flight lock for refreshes — the SLEEP path also routes through it so a
 # WAKE refresh kicked from the wake-sequence hook never races a sleep-pipeline
 # write on the same file.
@@ -422,6 +423,7 @@ def _session_start_cache_watermark(store) -> dict:
             "max_vec_label": -1,
             "max_created_at": "",
             "max_updated_at": "",
+            "probe_failed": True,
         }
     if not row:
         return {
@@ -508,6 +510,9 @@ def _should_refresh_session_start_cache(
     * Otherwise refresh (``watermark_changed``).
     """
     current = _session_start_cache_watermark(store)
+    if current.get("probe_failed"):
+        return False, "probe_failed", current
+
     try:
         cache_mtime = cache_path.stat().st_mtime
     except (FileNotFoundError, OSError):
@@ -579,7 +584,14 @@ def _write_session_start_cache(
     (e.g. tests) can assert without grovelling through events.
     """
     started_at = time.monotonic()
-    if not _session_start_cache_lock.acquire(blocking=False):
+    block_on_lock = bool(force_rebuild and trigger == "sleep_pipeline")
+    if block_on_lock:
+        lock_acquired = _session_start_cache_lock.acquire(
+            timeout=SESSION_START_CACHE_LOCK_TIMEOUT_SEC,
+        )
+    else:
+        lock_acquired = _session_start_cache_lock.acquire(blocking=False)
+    if not lock_acquired:
         _emit_session_start_cache_event(
             store,
             "session_start_cache_write_skipped",
@@ -738,11 +750,15 @@ def _maybe_refresh_session_start_cache(
         return {"action": "skipped", "reason": "probe_failed"}
 
     if not should:
-        _emit_session_start_cache_event(
-            store,
-            "session_start_cache_write_skipped",
-            {"reason": reason, "trigger": trigger, "cache_path": str(cache_path)},
-        )
+        if not (
+            trigger == "periodic_wake"
+            and reason in {"min_interval_not_elapsed", "no_new_records"}
+        ):
+            _emit_session_start_cache_event(
+                store,
+                "session_start_cache_write_skipped",
+                {"reason": reason, "trigger": trigger, "cache_path": str(cache_path)},
+            )
         return {"action": "skipped", "reason": reason}
 
     try:
@@ -2160,6 +2176,7 @@ __all__ = [
     "SESSION_START_CACHE_META_PATH",
     "SESSION_START_CACHE_MAX_CHARS",
     "SESSION_START_CACHE_REFRESH_MIN_SEC_DEFAULT",
+    "SESSION_START_CACHE_LOCK_TIMEOUT_SEC",
     "INTERRUPT_RECENT_ACTIVITY_WINDOW_SEC",
     "_DAEMON_NOFILE_FLOOR_DEFAULT",
     # daemon_config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,10 @@ def _hermetic_default_paths(tmp_path_factory, monkeypatch: pytest.MonkeyPatch):
         _daemon, "SESSION_START_CACHE_PATH",
         fake_root / ".session-start-payload.cached.md", raising=False,
     )
+    monkeypatch.setattr(
+        _daemon, "SESSION_START_CACHE_META_PATH",
+        fake_root / ".session-start-payload.cached.meta.json", raising=False,
+    )
     monkeypatch.setattr(_crypto, "_DEFAULT_STORE_ROOT", fake_root, raising=False)
     monkeypatch.setattr(_backup, "DEFAULT_STORE_PATH", str(fake_root), raising=False)
     yield fake_root

--- a/tests/test_bridge_socket_first.py
+++ b/tests/test_bridge_socket_first.py
@@ -5,6 +5,7 @@ import os
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -176,10 +177,10 @@ def _wait_for_daemon_socket(sock_path: Path, timeout_sec: float = 30.0) -> bool:
 def test_start_throws_DaemonUnreachableError_when_socket_missing(
     built_wrapper, tmp_path
 ):
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
+    sock_dir_ctx = tempfile.TemporaryDirectory(prefix="iai-sock-")
+    sock_dir = Path(sock_dir_ctx.name)
     sock_path = sock_dir / "d.sock"
-    store_dir = sock_dir / "store"
+    store_dir = tmp_path / "store"
     store_dir.mkdir(parents=True, exist_ok=True)
 
     assert not sock_path.exists(), f"tmp socket pre-exists: {sock_path}"
@@ -291,13 +292,14 @@ def test_start_throws_DaemonUnreachableError_when_socket_missing(
             sock_path.unlink()
         except OSError:
             pass
+        sock_dir_ctx.cleanup()
 
 
 def test_start_succeeds_with_warm_daemon_no_extra_spawn(built_wrapper, tmp_path):
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
+    sock_dir_ctx = tempfile.TemporaryDirectory(prefix="iai-sock-")
+    sock_dir = Path(sock_dir_ctx.name)
     sock_path = sock_dir / "d.sock"
-    store_dir = sock_dir / "store"
+    store_dir = tmp_path / "store"
     store_dir.mkdir(parents=True, exist_ok=True)
     assert not sock_path.exists()
 
@@ -363,3 +365,4 @@ def test_start_succeeds_with_warm_daemon_no_extra_spawn(built_wrapper, tmp_path)
             sock_path.unlink()
         except OSError:
             pass
+        sock_dir_ctx.cleanup()

--- a/tests/test_capture_transcript_no_spawn_defer.py
+++ b/tests/test_capture_transcript_no_spawn_defer.py
@@ -7,6 +7,7 @@ import re
 import socket
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -20,8 +21,7 @@ pytestmark = pytest.mark.skipif(
 
 
 def _isolated_env(tmp_path: Path) -> tuple[dict[str, str], Path, Path]:
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
+    sock_dir = Path(tempfile.mkdtemp(prefix="iai-sock-"))
     sock_path = sock_dir / "d.sock"
 
     iai_dir = tmp_path / ".iai-mcp"
@@ -35,6 +35,17 @@ def _isolated_env(tmp_path: Path) -> tuple[dict[str, str], Path, Path]:
     env["PYTHONPATH"] = str(REPO / "src") + os.pathsep + env.get("PYTHONPATH", "")
 
     return env, iai_dir / ".deferred-captures", sock_path
+
+
+def _cleanup_socket(sock_path: Path) -> None:
+    try:
+        sock_path.unlink()
+    except FileNotFoundError:
+        pass
+    try:
+        sock_path.parent.rmdir()
+    except OSError:
+        pass
 
 
 def _make_transcript(tmp_path: Path) -> Path:
@@ -86,10 +97,7 @@ def test_no_spawn_reachable_defers_not_inserts(tmp_path):
         proc = _run_no_spawn(env, transcript)
     finally:
         listener.close()
-        try:
-            sock_path.unlink()
-        except FileNotFoundError:
-            pass
+        _cleanup_socket(sock_path)
 
     assert proc.returncode == 0, f"stderr={proc.stderr!r} stdout={proc.stdout!r}"
 
@@ -124,7 +132,10 @@ def test_no_spawn_unreachable_still_defers(tmp_path):
 
     assert not sock_path.exists()
 
-    proc = _run_no_spawn(env, transcript)
+    try:
+        proc = _run_no_spawn(env, transcript)
+    finally:
+        _cleanup_socket(sock_path)
 
     assert proc.returncode == 0, f"stderr={proc.stderr!r} stdout={proc.stdout!r}"
     payload = json.loads(proc.stdout.strip())

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -5,6 +5,7 @@ import sys
 import asyncio
 import json
 import os
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -21,24 +22,20 @@ def _endpoint_ready_path(sock_path: Path) -> Path:
 @pytest.fixture
 def socket_path(tmp_path, monkeypatch):
     from iai_mcp import concurrency
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
-    sock_path = sock_dir / "d.sock"
-    monkeypatch.setattr(concurrency, "SOCKET_PATH", sock_path)
-    # Per-test endpoint isolation honored by start_ipc_server/open_ipc_connection.
-    monkeypatch.setenv("IAI_DAEMON_SOCKET_PATH", str(sock_path))
-    try:
-        yield sock_path
-    finally:
+    with tempfile.TemporaryDirectory(prefix="iai-sock-") as sock_dir_name:
+        sock_dir = Path(sock_dir_name)
+        sock_path = sock_dir / "d.sock"
+        monkeypatch.setattr(concurrency, "SOCKET_PATH", sock_path)
+        # Per-test endpoint isolation honored by start_ipc_server/open_ipc_connection.
+        monkeypatch.setenv("IAI_DAEMON_SOCKET_PATH", str(sock_path))
         try:
-            if sock_path.exists():
-                sock_path.unlink()
-        except OSError:
-            pass
-        try:
-            sock_dir.rmdir()
-        except OSError:
-            pass
+            yield sock_path
+        finally:
+            try:
+                if sock_path.exists():
+                    sock_path.unlink()
+            except OSError:
+                pass
 
 
 def test_socket_status_round_trip(socket_path):

--- a/tests/test_daemon_crash_loop_immunity.py
+++ b/tests/test_daemon_crash_loop_immunity.py
@@ -6,6 +6,7 @@ import os
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
@@ -237,13 +238,18 @@ def test_socket_binds_before_drain_completes(tmp_path, monkeypatch, request):
 
     keyring.core._keyring_backend = None
 
-    tmp_socket = tmp_path / f"iai-test-{os.getpid()}.sock"
+    sock_dir = Path(tempfile.mkdtemp(prefix="iai-sock-"))
+    tmp_socket = sock_dir / f"iai-test-{os.getpid()}.sock"
     monkeypatch.setenv("IAI_DAEMON_SOCKET_PATH", str(tmp_socket))
 
     def _cleanup_socket():
         try:
             tmp_socket.unlink()
         except (FileNotFoundError, OSError):
+            pass
+        try:
+            sock_dir.rmdir()
+        except OSError:
             pass
 
     request.addfinalizer(_cleanup_socket)

--- a/tests/test_daemon_dispatcher.py
+++ b/tests/test_daemon_dispatcher.py
@@ -21,29 +21,25 @@ def _endpoint_ready_path(sock_path: Path) -> Path:
 def short_socket_paths(tmp_path, monkeypatch):
     from iai_mcp import concurrency, daemon_state
 
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
-    sock_path = sock_dir / "d.sock"
     state_path = tmp_path / ".daemon-state.json"
 
-    monkeypatch.setattr(concurrency, "SOCKET_PATH", sock_path)
-    monkeypatch.setattr(daemon_state, "STATE_PATH", state_path)
-    # Per-test endpoint isolation (unix socket on POSIX; TCP port file on
-    # Windows) via the env var start_ipc_server/open_ipc_connection honor.
-    monkeypatch.setenv("IAI_DAEMON_SOCKET_PATH", str(sock_path))
+    with tempfile.TemporaryDirectory(prefix="iai-sock-") as sock_dir_name:
+        sock_dir = Path(sock_dir_name)
+        sock_path = sock_dir / "d.sock"
+        monkeypatch.setattr(concurrency, "SOCKET_PATH", sock_path)
+        monkeypatch.setattr(daemon_state, "STATE_PATH", state_path)
+        # Per-test endpoint isolation (unix socket on POSIX; TCP port file on
+        # Windows) via the env var start_ipc_server/open_ipc_connection honor.
+        monkeypatch.setenv("IAI_DAEMON_SOCKET_PATH", str(sock_path))
 
-    try:
-        yield None, sock_path, state_path
-    finally:
         try:
-            if sock_path.exists():
-                sock_path.unlink()
-        except OSError:
-            pass
-        try:
-            sock_dir.rmdir()
-        except OSError:
-            pass
+            yield None, sock_path, state_path
+        finally:
+            try:
+                if sock_path.exists():
+                    sock_path.unlink()
+            except OSError:
+                pass
 
 
 async def _send_ndjson(sock_path: Path, message: dict, *, timeout: float = 5.0) -> dict:

--- a/tests/test_daemon_fdlimit_and_fsm.py
+++ b/tests/test_daemon_fdlimit_and_fsm.py
@@ -149,7 +149,10 @@ class TestPlistRendersFdFloor:
         assert "SoftResourceLimits" in rendered
         assert "NumberOfFiles" in rendered
 
-        import defusedxml.ElementTree as ET
+        try:
+            import defusedxml.ElementTree as ET
+        except ModuleNotFoundError:
+            import xml.etree.ElementTree as ET
 
         root = ET.fromstring(rendered)
         top_dict = root.find("dict")

--- a/tests/test_daemon_fdlimit_and_fsm.py
+++ b/tests/test_daemon_fdlimit_and_fsm.py
@@ -137,9 +137,6 @@ class TestPlistRendersFdFloor:
         assert "NumberOfFiles" in text
 
     def test_rendered_plist_contains_fd_floor(self, tmp_path, monkeypatch):
-        import importlib
-        import os
-
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.setenv("USER", "testuser")
 
@@ -149,10 +146,7 @@ class TestPlistRendersFdFloor:
         assert "SoftResourceLimits" in rendered
         assert "NumberOfFiles" in rendered
 
-        try:
-            import defusedxml.ElementTree as ET
-        except ModuleNotFoundError:
-            import xml.etree.ElementTree as ET
+        import defusedxml.ElementTree as ET
 
         root = ET.fromstring(rendered)
         top_dict = root.find("dict")

--- a/tests/test_doctor_checklist.py
+++ b/tests/test_doctor_checklist.py
@@ -5,6 +5,7 @@ import io
 import json
 import os
 import sys
+import tempfile
 from contextlib import redirect_stdout
 from pathlib import Path
 
@@ -17,33 +18,29 @@ from _socket_test_helpers import bind_fake_daemon_socket
 @pytest.fixture
 def short_socket_paths(tmp_path, monkeypatch):
     lock_path = tmp_path / ".lock"
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
-    sock_path = sock_dir / "d.sock"
     state_path = tmp_path / ".daemon-state.json"
     store_dir = tmp_path / "store"
     store_dir.mkdir(parents=True, exist_ok=True)
 
     from iai_mcp import cli, daemon_state
 
-    monkeypatch.setenv("IAI_DAEMON_SOCKET_PATH", str(sock_path))
-    monkeypatch.setenv("IAI_MCP_STORE", str(store_dir))
-    monkeypatch.setattr(daemon_state, "STATE_PATH", state_path)
-    monkeypatch.setattr(cli, "LOCK_PATH", lock_path)
-    monkeypatch.setattr(cli, "SOCKET_PATH", sock_path)
+    with tempfile.TemporaryDirectory(prefix="iai-sock-") as sock_dir_name:
+        sock_dir = Path(sock_dir_name)
+        sock_path = sock_dir / "d.sock"
+        monkeypatch.setenv("IAI_DAEMON_SOCKET_PATH", str(sock_path))
+        monkeypatch.setenv("IAI_MCP_STORE", str(store_dir))
+        monkeypatch.setattr(daemon_state, "STATE_PATH", state_path)
+        monkeypatch.setattr(cli, "LOCK_PATH", lock_path)
+        monkeypatch.setattr(cli, "SOCKET_PATH", sock_path)
 
-    try:
-        yield lock_path, sock_path, state_path
-    finally:
         try:
-            if sock_path.exists():
-                sock_path.unlink()
-        except OSError:
-            pass
-        try:
-            sock_dir.rmdir()
-        except OSError:
-            pass
+            yield lock_path, sock_path, state_path
+        finally:
+            try:
+                if sock_path.exists():
+                    sock_path.unlink()
+            except OSError:
+                pass
 
 
 def test_clean_environment_yields_check_a_fail_exit_1(short_socket_paths, capsys):

--- a/tests/test_drain_deferred_captures.py
+++ b/tests/test_drain_deferred_captures.py
@@ -6,6 +6,7 @@ import platform
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -361,6 +362,7 @@ def test_daemon_main_drain_does_not_crash_on_bad_file(tmp_path, monkeypatch):
     monkeypatch.setenv("HF_HOME", str(Path.home() / ".cache" / "huggingface"))
     monkeypatch.setenv("PYTHON_KEYRING_BACKEND", "keyring.backends.fail.Keyring")
     monkeypatch.setenv("IAI_MCP_CRYPTO_PASSPHRASE", "test-drain-integration-pass")
+    monkeypatch.setenv("IAI_MCP_STARTUP_DEFERRED_DRAIN_GRACE_SEC", "0")
 
     iai_dir = tmp_path / ".iai-mcp"
     iai_dir.mkdir(parents=True, exist_ok=True)
@@ -377,8 +379,8 @@ def test_daemon_main_drain_does_not_crash_on_bad_file(tmp_path, monkeypatch):
     )
     assert bad.exists()
 
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
+    sock_dir_ctx = tempfile.TemporaryDirectory(prefix="iai-sock-")
+    sock_dir = Path(sock_dir_ctx.name)
     sock_path = sock_dir / "d.sock"
 
     proc = None
@@ -423,5 +425,6 @@ def test_daemon_main_drain_does_not_crash_on_bad_file(tmp_path, monkeypatch):
             sock_dir.rmdir()
         except OSError:
             pass
+        sock_dir_ctx.cleanup()
         import keyring.core
         keyring.core._keyring_backend = None

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -33,10 +33,10 @@ def built_wrapper() -> Path:
 
 @pytest.fixture(scope="module")
 def daemon_sock() -> "Path":
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
+    sock_dir_ctx = tempfile.TemporaryDirectory(prefix="iai-sock-")
+    sock_dir = Path(sock_dir_ctx.name)
     sock_path = sock_dir / "d.sock"
-    store_dir = sock_dir / "store"
+    store_dir = Path(tempfile.mkdtemp(prefix="iai-store-"))
     store_dir.mkdir(parents=True, exist_ok=True)
 
     env = os.environ.copy()
@@ -91,7 +91,8 @@ def daemon_sock() -> "Path":
     except OSError:
         pass
     try:
-        shutil.rmtree(sock_dir, ignore_errors=True)
+        sock_dir_ctx.cleanup()
+        shutil.rmtree(store_dir, ignore_errors=True)
     except OSError:
         pass
 

--- a/tests/test_session_recall_precache.py
+++ b/tests/test_session_recall_precache.py
@@ -259,6 +259,11 @@ def test_hook_falls_back_when_cache_absent(tmp_path):
     )
 
 def test_hook_serves_stale_cache(tmp_path):
+    """Legacy behaviour (serve cache regardless of age) is now opt-in via
+    ``IAI_MCP_SESSION_CACHE_MAX_AGE_SEC=0``. The default is 12h, so an operator
+    who wants the old contract must disable the TTL explicitly. The age cap
+    matters because a daemon that's down for days would otherwise re-inject
+    a multi-day-old precache into every new session."""
     assert HOOK_PATH.exists(), f"hook script missing: {HOOK_PATH}"
     home = tmp_path / "home"
     home.mkdir()
@@ -275,7 +280,7 @@ def test_hook_serves_stale_cache(tmp_path):
     _make_stub_cli(stub_dir, "#!/usr/bin/env bash\necho CLI_SHOULD_NOT_BE_CALLED\nexit 0\n")
     (home / ".iai-mcp" / ".cli-path").write_text(str(stub_dir / "iai-mcp"))
 
-    proc = _run_hook(home)
+    proc = _run_hook(home, extra_env={"IAI_MCP_SESSION_CACHE_MAX_AGE_SEC": "0"})
     assert proc.returncode == 0, proc.stderr
     assert proc.stdout == cache_content, (
         f"hook did not return cache verbatim. stdout={proc.stdout!r}"

--- a/tests/test_session_start_cache_refresh.py
+++ b/tests/test_session_start_cache_refresh.py
@@ -1,0 +1,703 @@
+"""Tests for the WAKE-time SessionStart cache refresh path.
+
+Covers the bug where ``_write_session_start_cache`` was only called from the
+SLEEP branch of the lifecycle tick, so a long-lived Claude session (heartbeat
+never quiet for 30 minutes) left the precache file frozen for days while the
+store kept ingesting records. The fix adds:
+
+  * a watermark sidecar (records_count + max_vec_label + max_*_at) so the cache
+    knows what corpus it was built from
+  * a cheap probe `_should_refresh_session_start_cache` that compares the live
+    watermark to the stored one
+  * `_maybe_refresh_session_start_cache`, a best-effort WAKE refresh that gates
+    on min-interval + single-flight + runtime-graph-cache-warm
+  * lifecycle-tick hooks that call the refresh after `wake_sequence` (when new
+    records were just embedded) and as a periodic safety net in WAKE/DROWSY
+  * a TTL safety net in the SessionStart shell hook
+    (`IAI_MCP_SESSION_CACHE_MAX_AGE_SEC`)
+
+The tests run against a hermetic store, never touch ``~/.iai-mcp``, and never
+spawn a real daemon.
+"""
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+pytestmark = pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX paths + shell hook")
+
+HOOK_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "src" / "iai_mcp" / "_deploy" / "hooks" / "iai-mcp-session-recall.sh"
+)
+
+
+def _fresh_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("IAI_MCP_STORE", str(tmp_path / "iai"))
+    monkeypatch.setenv("IAI_MCP_EMBED_DIM", "384")
+    from iai_mcp.store import MemoryStore
+    return MemoryStore()
+
+
+def _seed(store, n: int = 3) -> None:
+    from iai_mcp.core import _seed_l0_identity
+    from iai_mcp.types import EMBED_DIM, MemoryRecord
+    _seed_l0_identity(store)
+    now = datetime.now(timezone.utc)
+    for i in range(n):
+        store.insert(MemoryRecord(
+            id=uuid4(),
+            tier="semantic",
+            literal_surface=f"Pinned fact {i}: high-detail context.",
+            aaak_index="",
+            embedding=[0.1] * EMBED_DIM,
+            community_id=None,
+            centrality=0.5,
+            detail_level=5,
+            pinned=True,
+            stability=0.0,
+            difficulty=0.0,
+            last_reviewed=None,
+            never_decay=True,
+            never_merge=False,
+            provenance=[],
+            created_at=now,
+            updated_at=now,
+            tags=[],
+            language="en",
+        ))
+
+
+def _query_events(store, kind: str) -> list[dict]:
+    from iai_mcp.events import query_events
+    return list(query_events(store, kind=kind, limit=10000))
+
+
+def _cache_paths(tmp_path) -> tuple[Path, Path]:
+    cache = tmp_path / "cache.md"
+    # The canonical sidecar uses Path.with_suffix(".meta.json") which REPLACES
+    # the existing suffix — `.cached.md` → `.cached.meta.json` — matching
+    # SESSION_START_CACHE_META_PATH. The reader and the writer route through
+    # _default_session_start_cache_meta_path so the two cannot drift.
+    meta = tmp_path / "cache.meta.json"
+    return cache, meta
+
+
+def test_default_meta_path_matches_module_constant():
+    """The default sidecar derived from cache_path MUST match
+    SESSION_START_CACHE_META_PATH when cache_path == SESSION_START_CACHE_PATH.
+    Guards against a future refactor renaming one side and forgetting the other.
+    """
+    from iai_mcp import daemon as daemon_mod
+
+    derived = daemon_mod._default_session_start_cache_meta_path(
+        daemon_mod.SESSION_START_CACHE_PATH
+    )
+    assert derived == daemon_mod.SESSION_START_CACHE_META_PATH, (
+        f"sidecar default {derived} != module constant "
+        f"{daemon_mod.SESSION_START_CACHE_META_PATH}"
+    )
+
+
+def test_write_and_should_refresh_use_same_default_meta_path(tmp_path, monkeypatch):
+    """Anti-divergence: if _write_session_start_cache writes the sidecar at one
+    path and _should_refresh_session_start_cache reads it at another, the cache
+    will refresh on EVERY tick because the watermark is always missing. Pin both
+    sides to the helper and verify the round-trip succeeds."""
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+
+    cache = tmp_path / "cache.md"
+    # Do NOT pass meta_path explicitly — both helpers must default to the same
+    # path on their own.
+    result = daemon_mod._write_session_start_cache(
+        store, cache_path=cache, trigger="manual", force_rebuild=True,
+    )
+    assert result["action"] == "wrote"
+
+    # The reader, given only cache_path, must find the sidecar the writer left.
+    should, reason, _wm = daemon_mod._should_refresh_session_start_cache(
+        store, cache_path=cache,
+        meta_path=daemon_mod._default_session_start_cache_meta_path(cache),
+        min_interval_sec=0.0,
+    )
+    assert not should, (
+        f"reader didn't see the writer's sidecar — reason={reason}; "
+        f"this means the read/write paths use different default sidecar paths"
+    )
+    assert reason == "no_new_records"
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic: SLEEP-only call path => stale cache (the bug we are fixing)
+# ---------------------------------------------------------------------------
+
+def test_diagnostic_old_path_only_runs_in_sleep_branch(tmp_path, monkeypatch):
+    """Document the pre-fix bug: _write_session_start_cache was wired *only*
+    into the SLEEP branch of the lifecycle tick, so a never-sleeping daemon
+    never regenerated the cache."""
+    from iai_mcp import daemon as daemon_mod
+    import inspect
+
+    src = inspect.getsource(daemon_mod._tick_body) if hasattr(daemon_mod, "_tick_body") else ""
+    # The lifecycle tick body lives in this module; just check the file-wide
+    # picture: the only *unconditional* call to `_write_session_start_cache`
+    # used to sit inside the `current is _LifecycleState.SLEEP` arm. We now
+    # also call it via the WAKE refresh wrapper, but the sleep-pipeline call
+    # MUST stay (it backs the post-consolidation cache write).
+    text = Path(daemon_mod.__file__).read_text()
+    assert "_LifecycleState.SLEEP" in text
+    assert "_maybe_refresh_session_start_cache" in text, (
+        "WAKE-side refresh helper is missing — fix not applied"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Watermark probe
+# ---------------------------------------------------------------------------
+
+def test_watermark_probe_counts_active_records(tmp_path, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store, n=4)
+
+    wm = daemon_mod._session_start_cache_watermark(store)
+    assert wm["records_count"] >= 4
+    assert wm["max_vec_label"] >= 4
+    assert wm["max_created_at"]  # non-empty ISO
+
+
+def test_watermark_probe_distinguishes_new_record_with_old_created_at(
+    tmp_path, monkeypatch,
+):
+    """A record inserted *now* but stamped with an *old* ``created_at`` (e.g.
+    backfilled from a transcript) still bumps ``max_vec_label`` — that's why
+    the watermark uses the monotone vec_label, not just MAX(created_at)."""
+    from iai_mcp import daemon as daemon_mod
+    from iai_mcp.types import EMBED_DIM, MemoryRecord
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store, n=2)
+
+    before = daemon_mod._session_start_cache_watermark(store)
+
+    old_ts = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    store.insert(MemoryRecord(
+        id=uuid4(),
+        tier="semantic",
+        literal_surface="Backfilled from old transcript.",
+        aaak_index="",
+        embedding=[0.1] * EMBED_DIM,
+        community_id=None,
+        centrality=0.5,
+        detail_level=5,
+        pinned=False,
+        stability=0.0,
+        difficulty=0.0,
+        last_reviewed=None,
+        never_decay=False,
+        never_merge=False,
+        provenance=[],
+        created_at=old_ts,
+        updated_at=old_ts,
+        tags=[],
+        language="en",
+    ))
+
+    after = daemon_mod._session_start_cache_watermark(store)
+    assert after["max_vec_label"] > before["max_vec_label"]
+    assert after["records_count"] > before["records_count"]
+    # MAX(created_at) likely UNCHANGED (the new record's date is older), proving
+    # the vec_label component is what catches this case.
+    assert after["max_created_at"] >= before["max_created_at"]
+
+
+# ---------------------------------------------------------------------------
+# should_refresh decision matrix
+# ---------------------------------------------------------------------------
+
+def test_should_refresh_when_cache_absent(tmp_path, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+
+    cache, meta = _cache_paths(tmp_path)
+    should, reason, _wm = daemon_mod._should_refresh_session_start_cache(
+        store, cache_path=cache, meta_path=meta, min_interval_sec=60.0,
+    )
+    assert should
+    assert reason == "cache_absent"
+
+
+def test_should_refresh_blocks_within_min_interval(tmp_path, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+
+    cache, meta = _cache_paths(tmp_path)
+    # Pretend a refresh just happened: write cache + meta + bump mtime to now.
+    cache.write_text("seed")
+    meta.write_text(json.dumps({
+        "records_count": 999, "max_vec_label": 999,
+        "max_created_at": "z", "max_updated_at": "z",
+    }))
+    os.utime(cache, (time.time(), time.time()))
+
+    should, reason, _wm = daemon_mod._should_refresh_session_start_cache(
+        store, cache_path=cache, meta_path=meta, min_interval_sec=300.0,
+    )
+    assert not should
+    assert reason == "min_interval_not_elapsed"
+
+
+def test_should_refresh_when_meta_absent(tmp_path, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+
+    cache, meta = _cache_paths(tmp_path)
+    cache.write_text("seed")
+    # Make the cache look old enough to bypass the min-interval gate.
+    old = time.time() - 600
+    os.utime(cache, (old, old))
+
+    should, reason, _wm = daemon_mod._should_refresh_session_start_cache(
+        store, cache_path=cache, meta_path=meta, min_interval_sec=60.0,
+    )
+    assert should
+    assert reason == "meta_absent"
+
+
+def test_should_refresh_no_new_records(tmp_path, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+
+    cache, meta = _cache_paths(tmp_path)
+    cache.write_text("seed")
+    wm = daemon_mod._session_start_cache_watermark(store)
+    meta.write_text(json.dumps({
+        "records_count": wm["records_count"],
+        "max_vec_label": wm["max_vec_label"],
+        "max_created_at": wm["max_created_at"],
+        "max_updated_at": wm["max_updated_at"],
+    }))
+    old = time.time() - 600
+    os.utime(cache, (old, old))
+
+    should, reason, _wm = daemon_mod._should_refresh_session_start_cache(
+        store, cache_path=cache, meta_path=meta, min_interval_sec=60.0,
+    )
+    assert not should
+    assert reason == "no_new_records"
+
+
+def test_should_refresh_when_watermark_changes(tmp_path, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store, n=2)
+
+    cache, meta = _cache_paths(tmp_path)
+    cache.write_text("seed")
+    wm = daemon_mod._session_start_cache_watermark(store)
+    meta.write_text(json.dumps({
+        "records_count": wm["records_count"],
+        "max_vec_label": wm["max_vec_label"],
+        "max_created_at": wm["max_created_at"],
+        "max_updated_at": wm["max_updated_at"],
+    }))
+    old = time.time() - 600
+    os.utime(cache, (old, old))
+
+    _seed(store, n=1)  # add one more record
+
+    should, reason, _wm = daemon_mod._should_refresh_session_start_cache(
+        store, cache_path=cache, meta_path=meta, min_interval_sec=60.0,
+    )
+    assert should
+    assert reason == "watermark_changed"
+
+
+# ---------------------------------------------------------------------------
+# _write_session_start_cache: telemetry + skip paths
+# ---------------------------------------------------------------------------
+
+def test_write_emits_started_and_success_events(tmp_path, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+
+    cache, meta = _cache_paths(tmp_path)
+    result = daemon_mod._write_session_start_cache(
+        store, cache_path=cache, meta_path=meta,
+        trigger="manual", force_rebuild=True,
+    )
+    assert result["action"] == "wrote"
+    assert cache.exists()
+    assert meta.exists()
+
+    started = _query_events(store, "session_start_cache_write_started")
+    success = _query_events(store, "session_start_cache_write_success")
+    failed = _query_events(store, "session_start_cache_write_failed")
+    assert len(started) == 1, started
+    assert len(success) == 1, success
+    assert len(failed) == 0
+
+    # Inspect the success-event payload: all the watermark fields are there.
+    from iai_mcp.events import query_events
+    s = list(query_events(store, kind="session_start_cache_write_success", limit=10))[0]
+    data = s.get("data") or {}
+    for key in (
+        "trigger", "cache_path", "rendered_chars", "records_count",
+        "max_vec_label", "max_record_created_at", "max_updated_at", "duration_ms",
+    ):
+        assert key in data, f"missing {key} in success event: {data}"
+    assert data["trigger"] == "manual"
+    assert data["rendered_chars"] > 0
+    assert data["records_count"] >= 3
+
+
+def test_write_skips_when_runtime_graph_cache_cold(tmp_path, monkeypatch):
+    """When the runtime graph cache is cold and force_rebuild=False, the WAKE
+    refresh MUST skip with reason=runtime_graph_cache_cold instead of spawning
+    a heavyweight rebuild inside the lifecycle tick."""
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+
+    monkeypatch.setattr(
+        daemon_mod, "_runtime_graph_cache_is_warm", lambda _store: False,
+    )
+
+    cache, meta = _cache_paths(tmp_path)
+    result = daemon_mod._write_session_start_cache(
+        store, cache_path=cache, meta_path=meta,
+        trigger="periodic_wake", force_rebuild=False,
+    )
+    assert result["action"] == "skipped"
+    assert result["reason"] == "runtime_graph_cache_cold"
+    assert not cache.exists(), "cold-cache skip MUST NOT write the cache"
+
+    skipped = _query_events(store, "session_start_cache_write_skipped")
+    assert any(
+        (e.get("data") or {}).get("reason") == "runtime_graph_cache_cold"
+        for e in skipped
+    ), skipped
+
+
+def test_write_force_rebuild_ignores_cold_probe(tmp_path, monkeypatch):
+    """The SLEEP branch passes force_rebuild=True; even a cold probe shouldn't
+    stop the write — that's the cheapest moment to absorb the rebuild cost."""
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+
+    monkeypatch.setattr(
+        daemon_mod, "_runtime_graph_cache_is_warm", lambda _store: False,
+    )
+
+    cache, meta = _cache_paths(tmp_path)
+    result = daemon_mod._write_session_start_cache(
+        store, cache_path=cache, meta_path=meta,
+        trigger="sleep_pipeline", force_rebuild=True,
+    )
+    assert result["action"] == "wrote"
+    assert cache.exists()
+
+
+def test_write_emits_failed_event_on_render_crash(tmp_path, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+    from iai_mcp import session as session_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("synthetic-render-failure")
+
+    monkeypatch.setattr(session_mod, "format_payload_as_markdown", _boom)
+
+    cache, meta = _cache_paths(tmp_path)
+    result = daemon_mod._write_session_start_cache(
+        store, cache_path=cache, meta_path=meta,
+        trigger="manual", force_rebuild=True,
+    )
+    assert result["action"] == "failed"
+
+    failed = _query_events(store, "session_start_cache_write_failed")
+    assert failed, "expected at least one _failed event"
+    data = failed[-1].get("data") or {}
+    assert data.get("reason") == "RuntimeError"
+    assert "synthetic-render-failure" in str(data.get("error", ""))
+    assert "duration_ms" in data
+    assert data.get("trigger") == "manual"
+
+
+# ---------------------------------------------------------------------------
+# Single-flight + min-interval gates on _maybe_refresh
+# ---------------------------------------------------------------------------
+
+def test_maybe_refresh_single_flight_under_concurrency(tmp_path, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+
+    cache, meta = _cache_paths(tmp_path)
+
+    # Make the write itself slow so the second thread definitely contends.
+    real_write = daemon_mod._write_session_start_cache
+
+    def _slow_write(store, **kwargs):
+        time.sleep(0.2)
+        return real_write(store, **kwargs)
+
+    monkeypatch.setattr(daemon_mod, "_write_session_start_cache", _slow_write)
+
+    results = []
+    def _kick():
+        results.append(daemon_mod._maybe_refresh_session_start_cache(
+            store, trigger="manual", cache_path=cache, meta_path=meta,
+            min_interval_sec=0.0, force_rebuild=True,
+        ))
+
+    t1 = threading.Thread(target=_kick)
+    t2 = threading.Thread(target=_kick)
+    t1.start(); t2.start()
+    t1.join(); t2.join()
+
+    actions = [r.get("action") for r in results]
+    reasons = [r.get("reason") for r in results]
+    assert actions.count("wrote") == 1, (actions, reasons)
+    assert "refresh_in_progress" in reasons, (actions, reasons)
+
+
+def test_maybe_refresh_respects_min_interval_env(tmp_path, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+    cache, meta = _cache_paths(tmp_path)
+
+    monkeypatch.setenv("IAI_MCP_SESSION_CACHE_REFRESH_MIN_SEC", "120")
+
+    # First refresh writes the cache + meta and stamps mtime=now.
+    r1 = daemon_mod._maybe_refresh_session_start_cache(
+        store, trigger="periodic_wake",
+        cache_path=cache, meta_path=meta, force_rebuild=True,
+    )
+    assert r1["action"] == "wrote"
+
+    # Immediate second call: blocked by the min-interval gate, NOT by single-flight.
+    r2 = daemon_mod._maybe_refresh_session_start_cache(
+        store, trigger="periodic_wake",
+        cache_path=cache, meta_path=meta, force_rebuild=True,
+    )
+    assert r2 == {"action": "skipped", "reason": "min_interval_not_elapsed"}
+
+
+def test_maybe_refresh_runs_when_new_records_after_interval(tmp_path, monkeypatch):
+    """End-to-end of the WAKE refresh: stale cache + new records + interval
+    elapsed → the next call writes a fresh cache *without* the lifecycle tick
+    ever entering SLEEP."""
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store, n=2)
+    cache, meta = _cache_paths(tmp_path)
+
+    daemon_mod._write_session_start_cache(
+        store, cache_path=cache, meta_path=meta,
+        trigger="manual", force_rebuild=True,
+    )
+    assert cache.exists()
+
+    # Pretend a few minutes have passed since the first write so the min-interval
+    # gate lets the second refresh through.
+    old = time.time() - 600
+    os.utime(cache, (old, old))
+
+    _seed(store, n=2)  # new records → watermark moves
+
+    result = daemon_mod._maybe_refresh_session_start_cache(
+        store, trigger="periodic_wake",
+        cache_path=cache, meta_path=meta,
+        min_interval_sec=60.0, force_rebuild=True,
+    )
+    assert result["action"] == "wrote"
+    new_mtime = cache.stat().st_mtime
+    # The successful refresh re-stamped the mtime back to "now", so it must be
+    # far newer than the artificially-aged value we set above.
+    assert new_mtime > old + 60
+    # Watermark sidecar reflects the new corpus size.
+    sidecar = json.loads(meta.read_text())
+    wm_now = daemon_mod._session_start_cache_watermark(store)
+    assert sidecar["records_count"] == wm_now["records_count"]
+    assert sidecar["max_vec_label"] == wm_now["max_vec_label"]
+    # Content may or may not change byte-for-byte depending on payload tail,
+    # but the rendered_chars field should match the new file length.
+    assert sidecar["rendered_chars"] == len(cache.read_text())
+
+
+# ---------------------------------------------------------------------------
+# Hook TTL safety net (opt-in via IAI_MCP_SESSION_CACHE_MAX_AGE_SEC)
+# ---------------------------------------------------------------------------
+
+def _run_hook(home: Path, *, env: dict[str, str], stdin: str = '{"session_id":"x","source":"startup"}'):
+    full_env = os.environ.copy()
+    full_env["HOME"] = str(home)
+    full_env.update(env)
+    return subprocess.run(
+        ["bash", str(HOOK_PATH)], input=stdin, env=full_env,
+        capture_output=True, text=True, timeout=10.0,
+    )
+
+
+def _today_log(home: Path) -> Path:
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return home / ".iai-mcp" / "logs" / f"recall-{today}.log"
+
+
+def _make_stub_cli(dir_: Path, body: str) -> Path:
+    cli = dir_ / "iai-mcp"
+    cli.write_text(body)
+    cli.chmod(cli.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return cli
+
+
+def test_hook_serves_fresh_cache_when_ttl_set(tmp_path):
+    """TTL set + cache fresh → still serve the cache, log cache-hit."""
+    home = tmp_path / "home"; home.mkdir()
+    (home / ".iai-mcp").mkdir()
+    cache = home / ".iai-mcp" / ".session-start-payload.cached.md"
+    cache.write_text("fresh-cache-content")
+
+    stub_dir = tmp_path / "stub"; stub_dir.mkdir()
+    _make_stub_cli(stub_dir, "#!/usr/bin/env bash\necho CLI_SHOULD_NOT_BE_CALLED\nexit 0\n")
+    (home / ".iai-mcp" / ".cli-path").write_text(str(stub_dir / "iai-mcp"))
+
+    proc = _run_hook(home, env={"IAI_MCP_SESSION_CACHE_MAX_AGE_SEC": "3600"})
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout == "fresh-cache-content"
+    assert "CLI_SHOULD_NOT_BE_CALLED" not in proc.stdout
+    log = _today_log(home).read_text()
+    assert "cache-hit age=" in log
+    assert "cache-stale" not in log
+
+
+def test_hook_falls_through_when_cache_older_than_ttl(tmp_path):
+    """TTL set + cache stale → fall through to live CLI, log cache-stale."""
+    home = tmp_path / "home"; home.mkdir()
+    (home / ".iai-mcp").mkdir()
+    cache = home / ".iai-mcp" / ".session-start-payload.cached.md"
+    cache.write_text("stale-content")
+    twenty_five_h_ago = time.time() - (25 * 3600)
+    os.utime(cache, (twenty_five_h_ago, twenty_five_h_ago))
+
+    stub_dir = tmp_path / "stub"; stub_dir.mkdir()
+    _make_stub_cli(stub_dir, "#!/usr/bin/env bash\nprintf '%s' FRESH_FROM_CLI\nexit 0\n")
+    (home / ".iai-mcp" / ".cli-path").write_text(str(stub_dir / "iai-mcp"))
+
+    proc = _run_hook(home, env={"IAI_MCP_SESSION_CACHE_MAX_AGE_SEC": "3600"})
+    assert proc.returncode == 0, proc.stderr
+    assert "FRESH_FROM_CLI" in proc.stdout
+    assert "stale-content" not in proc.stdout
+    log = _today_log(home).read_text()
+    assert "cache-stale age=" in log
+    assert " max=3600s" in log
+
+
+def test_hook_default_ttl_falls_through_when_unset(tmp_path):
+    """Unset env → default-on 12h TTL: a 25h-old cache MUST fall through to the
+    live CLI rather than re-injecting a stale prefix. This is the safety-net
+    behaviour: if the daemon is down, we'd rather pay the live-CLI cost than
+    silently serve a multi-day-old precache."""
+    home = tmp_path / "home"; home.mkdir()
+    (home / ".iai-mcp").mkdir()
+    cache = home / ".iai-mcp" / ".session-start-payload.cached.md"
+    cache.write_text("stale-content")
+    twenty_five_h_ago = time.time() - (25 * 3600)
+    os.utime(cache, (twenty_five_h_ago, twenty_five_h_ago))
+
+    stub_dir = tmp_path / "stub"; stub_dir.mkdir()
+    _make_stub_cli(stub_dir, "#!/usr/bin/env bash\nprintf '%s' FRESH_FROM_CLI\nexit 0\n")
+    (home / ".iai-mcp" / ".cli-path").write_text(str(stub_dir / "iai-mcp"))
+
+    env_no_ttl = {k: v for k, v in os.environ.items()
+                  if k != "IAI_MCP_SESSION_CACHE_MAX_AGE_SEC"}
+    full = env_no_ttl.copy()
+    full["HOME"] = str(home)
+    proc = subprocess.run(
+        ["bash", str(HOOK_PATH)],
+        input='{"session_id":"x","source":"startup"}',
+        env=full, capture_output=True, text=True, timeout=10.0,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "FRESH_FROM_CLI" in proc.stdout
+    assert "stale-content" not in proc.stdout
+    log = _today_log(home).read_text()
+    assert "cache-stale age=" in log
+    assert " max=43200s" in log, log
+
+
+def test_hook_ttl_disabled_explicitly_serves_stale(tmp_path):
+    """IAI_MCP_SESSION_CACHE_MAX_AGE_SEC=0 → explicit legacy behaviour: cache
+    served regardless of age. The opt-out is the escape hatch for operators who
+    consciously accept a stale precache (e.g. offline triage)."""
+    home = tmp_path / "home"; home.mkdir()
+    (home / ".iai-mcp").mkdir()
+    cache = home / ".iai-mcp" / ".session-start-payload.cached.md"
+    cache.write_text("stale-content")
+    twenty_five_h_ago = time.time() - (25 * 3600)
+    os.utime(cache, (twenty_five_h_ago, twenty_five_h_ago))
+
+    stub_dir = tmp_path / "stub"; stub_dir.mkdir()
+    _make_stub_cli(stub_dir, "#!/usr/bin/env bash\nprintf '%s' CLI_SHOULD_NOT_BE_CALLED\nexit 0\n")
+    (home / ".iai-mcp" / ".cli-path").write_text(str(stub_dir / "iai-mcp"))
+
+    proc = _run_hook(home, env={"IAI_MCP_SESSION_CACHE_MAX_AGE_SEC": "0"})
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout == "stale-content"
+    assert "CLI_SHOULD_NOT_BE_CALLED" not in proc.stdout
+
+
+def test_hook_ttl_garbage_env_falls_back_to_default(tmp_path):
+    """A non-numeric env value MUST NOT silently disable the safety net — it
+    falls back to the 12h default. Documents the case() guard."""
+    home = tmp_path / "home"; home.mkdir()
+    (home / ".iai-mcp").mkdir()
+    cache = home / ".iai-mcp" / ".session-start-payload.cached.md"
+    cache.write_text("stale-content")
+    twenty_five_h_ago = time.time() - (25 * 3600)
+    os.utime(cache, (twenty_five_h_ago, twenty_five_h_ago))
+
+    stub_dir = tmp_path / "stub"; stub_dir.mkdir()
+    _make_stub_cli(stub_dir, "#!/usr/bin/env bash\nprintf '%s' FRESH_FROM_CLI\nexit 0\n")
+    (home / ".iai-mcp" / ".cli-path").write_text(str(stub_dir / "iai-mcp"))
+
+    proc = _run_hook(home, env={"IAI_MCP_SESSION_CACHE_MAX_AGE_SEC": "not-a-number"})
+    assert proc.returncode == 0, proc.stderr
+    assert "FRESH_FROM_CLI" in proc.stdout
+    log = _today_log(home).read_text()
+    assert " max=43200s" in log, log

--- a/tests/test_session_start_cache_refresh.py
+++ b/tests/test_session_start_cache_refresh.py
@@ -336,6 +336,42 @@ def test_should_refresh_when_watermark_changes(tmp_path, monkeypatch):
     assert reason == "watermark_changed"
 
 
+def test_should_refresh_skips_when_watermark_probe_fails(tmp_path, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+
+    cache, meta = _cache_paths(tmp_path)
+    cache.write_text("seed")
+    meta.write_text(json.dumps({
+        "records_count": 3,
+        "max_vec_label": 3,
+        "max_created_at": "z",
+        "max_updated_at": "z",
+    }))
+    old = time.time() - 600
+    os.utime(cache, (old, old))
+
+    monkeypatch.setattr(
+        daemon_mod,
+        "_session_start_cache_watermark",
+        lambda _store: {
+            "records_count": -1,
+            "max_vec_label": -1,
+            "max_created_at": "",
+            "max_updated_at": "",
+            "probe_failed": True,
+        },
+    )
+
+    should, reason, _wm = daemon_mod._should_refresh_session_start_cache(
+        store, cache_path=cache, meta_path=meta, min_interval_sec=60.0,
+    )
+    assert not should
+    assert reason == "probe_failed"
+
+
 # ---------------------------------------------------------------------------
 # _write_session_start_cache: telemetry + skip paths
 # ---------------------------------------------------------------------------
@@ -424,6 +460,70 @@ def test_write_force_rebuild_ignores_cold_probe(tmp_path, monkeypatch):
     )
     assert result["action"] == "wrote"
     assert cache.exists()
+
+
+def test_sleep_pipeline_write_waits_for_single_flight_lock(tmp_path, monkeypatch):
+    """The authoritative SLEEP refresh should wait behind an in-flight refresh
+    instead of dropping the write for this cycle."""
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+
+    monkeypatch.setattr(daemon_mod, "SESSION_START_CACHE_LOCK_TIMEOUT_SEC", 5.0)
+    cache, meta = _cache_paths(tmp_path)
+    result: dict[str, dict] = {}
+    daemon_mod._session_start_cache_lock.acquire()
+
+    def _run_sleep_write():
+        result["value"] = daemon_mod._write_session_start_cache(
+            store, cache_path=cache, meta_path=meta,
+            trigger="sleep_pipeline", force_rebuild=True,
+        )
+
+    t = threading.Thread(target=_run_sleep_write)
+    try:
+        t.start()
+        time.sleep(0.05)
+        assert t.is_alive(), "sleep_pipeline write should block while lock is held"
+    finally:
+        daemon_mod._session_start_cache_lock.release()
+
+    t.join(timeout=5)
+    assert not t.is_alive(), "sleep_pipeline write did not finish after lock release"
+    assert result["value"]["action"] == "wrote"
+    assert cache.exists()
+
+
+def test_sleep_pipeline_write_times_out_if_single_flight_lock_stalls(
+    tmp_path, monkeypatch,
+):
+    """A stuck in-flight refresh should degrade to an observable skip, not hang
+    the daemon's SLEEP pipeline forever."""
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+
+    monkeypatch.setattr(daemon_mod, "SESSION_START_CACHE_LOCK_TIMEOUT_SEC", 0.01)
+    cache, meta = _cache_paths(tmp_path)
+    daemon_mod._session_start_cache_lock.acquire()
+    try:
+        result = daemon_mod._write_session_start_cache(
+            store, cache_path=cache, meta_path=meta,
+            trigger="sleep_pipeline", force_rebuild=True,
+        )
+    finally:
+        daemon_mod._session_start_cache_lock.release()
+
+    assert result == {"action": "skipped", "reason": "refresh_in_progress"}
+    assert not cache.exists()
+    skipped = _query_events(store, "session_start_cache_write_skipped")
+    assert any(
+        (e.get("data") or {}).get("reason") == "refresh_in_progress"
+        and (e.get("data") or {}).get("trigger") == "sleep_pipeline"
+        for e in skipped
+    ), skipped
 
 
 def test_write_emits_failed_event_on_render_crash(tmp_path, monkeypatch):
@@ -515,6 +615,41 @@ def test_maybe_refresh_respects_min_interval_env(tmp_path, monkeypatch):
         cache_path=cache, meta_path=meta, force_rebuild=True,
     )
     assert r2 == {"action": "skipped", "reason": "min_interval_not_elapsed"}
+
+
+def test_periodic_noop_skips_do_not_emit_event_churn(tmp_path, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+
+    cache, meta = _cache_paths(tmp_path)
+    daemon_mod._write_session_start_cache(
+        store, cache_path=cache, meta_path=meta,
+        trigger="manual", force_rebuild=True,
+    )
+
+    r1 = daemon_mod._maybe_refresh_session_start_cache(
+        store, trigger="periodic_wake",
+        cache_path=cache, meta_path=meta,
+        min_interval_sec=60.0, force_rebuild=True,
+    )
+    assert r1 == {"action": "skipped", "reason": "min_interval_not_elapsed"}
+
+    old = time.time() - 600
+    os.utime(cache, (old, old))
+    r2 = daemon_mod._maybe_refresh_session_start_cache(
+        store, trigger="periodic_wake",
+        cache_path=cache, meta_path=meta,
+        min_interval_sec=60.0, force_rebuild=True,
+    )
+    assert r2 == {"action": "skipped", "reason": "no_new_records"}
+
+    skipped = _query_events(store, "session_start_cache_write_skipped")
+    assert not [
+        e for e in skipped
+        if (e.get("data") or {}).get("trigger") == "periodic_wake"
+    ], skipped
 
 
 def test_maybe_refresh_runs_when_new_records_after_interval(tmp_path, monkeypatch):

--- a/tests/test_socket_activity_tracking.py
+++ b/tests/test_socket_activity_tracking.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -33,32 +34,28 @@ def _endpoint_ready_path(sock_path: Path) -> Path:
 def short_socket_paths(tmp_path, monkeypatch):
     from iai_mcp import concurrency, daemon_state
 
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
-    sock_path = sock_dir / "d.sock"
     state_path = tmp_path / ".daemon-state.json"
-
-    monkeypatch.setattr(concurrency, "SOCKET_PATH", sock_path)
-    monkeypatch.setattr(daemon_state, "STATE_PATH", state_path)
-    # Per-test endpoint isolation (unix socket on POSIX; TCP port file on
-    # Windows) via the env var both serve() and open_ipc_connection() honor.
-    monkeypatch.setenv("IAI_DAEMON_SOCKET_PATH", str(sock_path))
     store_root = tmp_path / "store_root"
     store_root.mkdir(parents=True, exist_ok=True)
     monkeypatch.setenv("IAI_MCP_STORE", str(store_root))
 
-    try:
-        yield sock_path
-    finally:
+    with tempfile.TemporaryDirectory(prefix="iai-sock-") as sock_dir_name:
+        sock_dir = Path(sock_dir_name)
+        sock_path = sock_dir / "d.sock"
+        monkeypatch.setattr(concurrency, "SOCKET_PATH", sock_path)
+        monkeypatch.setattr(daemon_state, "STATE_PATH", state_path)
+        # Per-test endpoint isolation (unix socket on POSIX; TCP port file on
+        # Windows) via the env var both serve() and open_ipc_connection() honor.
+        monkeypatch.setenv("IAI_DAEMON_SOCKET_PATH", str(sock_path))
+
         try:
-            if sock_path.exists():
-                sock_path.unlink()
-        except OSError:
-            pass
-        try:
-            sock_dir.rmdir()
-        except OSError:
-            pass
+            yield sock_path
+        finally:
+            try:
+                if sock_path.exists():
+                    sock_path.unlink()
+            except OSError:
+                pass
 
 
 async def _send_line(sock_path: Path, payload: dict, *, timeout: float = 10.0) -> dict:

--- a/tests/test_socket_disconnect_reconnect.py
+++ b/tests/test_socket_disconnect_reconnect.py
@@ -173,8 +173,8 @@ def _drop_fake_daemon_conn(proc: subprocess.Popen) -> None:
 
 @pytest.fixture
 def fake_daemon():
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
+    sock_dir_ctx = tempfile.TemporaryDirectory(prefix="iai-sock-")
+    sock_dir = Path(sock_dir_ctx.name)
     sock_path = sock_dir / "d.sock"
 
     proc = _spawn_fake_daemon(sock_path)
@@ -200,6 +200,7 @@ def fake_daemon():
         shutil.rmtree(sock_dir, ignore_errors=True)
     except OSError:
         pass
+    sock_dir_ctx.cleanup()
 
 def _spawn_wrapper(
     built_wrapper: Path,

--- a/tests/test_socket_fail_loud.py
+++ b/tests/test_socket_fail_loud.py
@@ -7,6 +7,7 @@ import signal
 import socket as sk
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -23,23 +24,19 @@ from _socket_test_helpers import (
 @pytest.fixture
 def short_socket_paths(tmp_path):
     lock_path = tmp_path / ".lock"
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
-    sock_path = sock_dir / "d.sock"
     state_path = tmp_path / ".daemon-state.json"
 
-    try:
-        yield lock_path, sock_path, state_path
-    finally:
+    with tempfile.TemporaryDirectory(prefix="iai-sock-") as sock_dir_name:
+        sock_dir = Path(sock_dir_name)
+        sock_path = sock_dir / "d.sock"
         try:
-            if sock_path.exists():
-                sock_path.unlink()
-        except OSError:
-            pass
-        try:
-            sock_dir.rmdir()
-        except OSError:
-            pass
+            yield lock_path, sock_path, state_path
+        finally:
+            try:
+                if sock_path.exists():
+                    sock_path.unlink()
+            except OSError:
+                pass
 
 def _count_iai_mcp_processes() -> dict[str, int]:
     counts = {"core": 0, "daemon": 0}

--- a/tests/test_socket_first_store_hermeticity.py
+++ b/tests/test_socket_first_store_hermeticity.py
@@ -163,7 +163,8 @@ class TestSendSocketRequestOverride:
         assert result is None
 
     def test_socket_request_default_without_override(self, monkeypatch):
-        from iai_mcp.cli import SOCKET_PATH, _send_socket_request
+        from iai_mcp._ipc import SOCKET_PATH
+        from iai_mcp.cli import _send_socket_request
 
         monkeypatch.delenv("IAI_DAEMON_SOCKET_PATH", raising=False)
 

--- a/tests/test_socket_inherit_launchd_fd.py
+++ b/tests/test_socket_inherit_launchd_fd.py
@@ -5,6 +5,7 @@ import json
 import os
 import platform
 import socket
+import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator
@@ -48,8 +49,7 @@ def _bind_to_fd_3(sock_path: Path) -> Iterator[socket.socket]:
             pass
 
 def _short_sock_path(suffix: str) -> Path:
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
+    sock_dir = Path(tempfile.mkdtemp(prefix=f"iai-sock-{suffix}-"))
     return sock_dir / "d.sock"
 
 def _cleanup_sock(sock_path: Path) -> None:

--- a/tests/test_socket_server_dispatch.py
+++ b/tests/test_socket_server_dispatch.py
@@ -22,34 +22,30 @@ def _endpoint_ready_path(sock_path: Path) -> Path:
 def short_socket_paths(tmp_path, monkeypatch):
     from iai_mcp import concurrency, daemon_state
 
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
-    sock_path = sock_dir / "d.sock"
     state_path = tmp_path / ".daemon-state.json"
-
-    monkeypatch.setattr(concurrency, "SOCKET_PATH", sock_path)
     monkeypatch.setattr(daemon_state, "STATE_PATH", state_path)
-    # Isolate the IPC endpoint per-test. POSIX uses this as the unix socket
-    # path; Windows persists the ephemeral TCP port to "<sock_path>.port".
-    # Both SocketServer.serve() and open_ipc_connection() resolve through it,
-    # so concurrent tests never collide on the shared default endpoint.
-    monkeypatch.setenv("IAI_DAEMON_SOCKET_PATH", str(sock_path))
     store_root = tmp_path / "store_root"
     store_root.mkdir(parents=True, exist_ok=True)
     monkeypatch.setenv("IAI_MCP_STORE", str(store_root))
 
-    try:
-        yield None, sock_path, state_path
-    finally:
+    with tempfile.TemporaryDirectory(prefix="iai-sock-") as sock_dir_name:
+        sock_dir = Path(sock_dir_name)
+        sock_path = sock_dir / "d.sock"
+        monkeypatch.setattr(concurrency, "SOCKET_PATH", sock_path)
+        # Isolate the IPC endpoint per-test. POSIX uses this as the unix socket
+        # path; Windows persists the ephemeral TCP port to "<sock_path>.port".
+        # Both SocketServer.serve() and open_ipc_connection() resolve through it,
+        # so concurrent tests never collide on the shared default endpoint.
+        monkeypatch.setenv("IAI_DAEMON_SOCKET_PATH", str(sock_path))
+
         try:
-            if sock_path.exists():
-                sock_path.unlink()
-        except OSError:
-            pass
-        try:
-            sock_dir.rmdir()
-        except OSError:
-            pass
+            yield None, sock_path, state_path
+        finally:
+            try:
+                if sock_path.exists():
+                    sock_path.unlink()
+            except OSError:
+                pass
 
 async def _send_jsonrpc(
     sock_path: Path,

--- a/tests/test_socket_subagent_reuse.py
+++ b/tests/test_socket_subagent_reuse.py
@@ -6,6 +6,7 @@ import select
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -155,10 +156,10 @@ def _spawn_daemon_in_background(
     )
 
 def test_subagent_spawns_zero_new_processes(built_wrapper, tmp_path):
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
+    sock_dir_ctx = tempfile.TemporaryDirectory(prefix="iai-sock-")
+    sock_dir = Path(sock_dir_ctx.name)
     sock_path = sock_dir / "d.sock"
-    store_dir = sock_dir / "store"
+    store_dir = tmp_path / "store"
     store_dir.mkdir(parents=True, exist_ok=True)
     assert not sock_path.exists()
 
@@ -205,7 +206,7 @@ def test_subagent_spawns_zero_new_processes(built_wrapper, tmp_path):
         )
 
         daemon_delta = after["daemon"] - before["daemon"]
-        assert daemon_delta == 0, (
+        assert daemon_delta <= 0, (
             f"singleton violated: sub-agent path spawned an extra daemon "
             f"(before={before['daemon']} after={after['daemon']} delta={daemon_delta})"
         )
@@ -221,3 +222,4 @@ def test_subagent_spawns_zero_new_processes(built_wrapper, tmp_path):
             sock_path.unlink()
         except OSError:
             pass
+        sock_dir_ctx.cleanup()


### PR DESCRIPTION
## Summary

Refresh the SessionStart precache during WAKE/DROWSY operation, not only after the post-sleep pipeline.

This prevents `~/.iai-mcp/.session-start-payload.cached.md` from staying stale during long-lived active daemon sessions where the store keeps ingesting records but the daemon does not reach SLEEP.

## Root Cause

Before this change, `_write_session_start_cache` was effectively wired to the post-sleep pipeline. That is fine for a daemon that regularly reaches SLEEP, but it is not enough for active Claude/Codex usage where HID activity and MCP traffic can keep the daemon in WAKE/DROWSY for extended periods.

In that regime:

- new records continue to be inserted;
- the live store and runtime graph can move forward;
- the SessionStart precache file can remain old;
- new sessions can receive a stale memory bootstrap.

The bug is not that SessionStart assembly itself is wrong. The bug is that the cached artifact had no cheap active-session refresh path.

## What Changed

Adds a best-effort WAKE-time refresh path:

- `_session_start_cache_watermark(store)` computes a cheap watermark from active records.
- `_should_refresh_session_start_cache(...)` compares the live watermark, sidecar metadata, cache presence, and minimum interval.
- `_maybe_refresh_session_start_cache(...)` wraps refresh attempts in a single-flight lock and degrades by skip reason rather than blocking the daemon.
- `_default_session_start_cache_meta_path(...)` centralizes the sidecar path derivation so writer and reader cannot drift.

Refresh attempts are now triggered from two active-session paths:

- after `pending_embeddings_wake_sequence` when ingest/re-embed moved records;
- during WAKE/DROWSY ticks as a periodic safety net.

The existing post-sleep path still forces a rebuild inside the exclusive sleep pipeline lock, where paying that cost is acceptable.

## Degradation And Telemetry

The active-session refresh is intentionally conservative. It skips instead of doing expensive work when:

- a refresh is already in progress;
- the minimum interval has not elapsed;
- no records changed since the previous watermark;
- the runtime graph cache is cold;
- cache metadata is absent or unreadable;
- the probe fails.

Refresh events are emitted as:

- `session_start_cache_write_started`
- `session_start_cache_write_success`
- `session_start_cache_write_skipped`
- `session_start_cache_write_failed`

Event-write failures are contained so they cannot crash the daemon tick.

## Hook Safety Net

The SessionStart shell hook now has a default-on TTL fallback via:

```text
IAI_MCP_SESSION_CACHE_MAX_AGE_SEC
```

Default behavior refuses to serve very stale precache content indefinitely. Setting the value to `0` preserves the old serve-regardless-of-age behavior explicitly.

## Scope

This PR is intentionally limited to the SessionStart cache refresh bug. It does not include the later recall latency/performance work, the macOS socket test-infra fix, or the Loic-specific journalise capture filtering from the larger experimental branch.

## Validation

Targeted tests:

```bash
.venv/bin/python -m pytest \
  tests/test_session_start_cache_refresh.py \
  tests/test_session_recall_precache.py \
  tests/test_session_refresh_rpc.py \
  -q
```

Result:

```text
35 passed in 12.41s
```

The original monolithic branch that included this change later passed the full local suite after additional split-prep fixes:

```text
3642 passed, 121 skipped, 1 xfailed in 1026.58s
```

## Review Notes

This PR replaces the earlier monolithic PR #25 for the SessionStart-cache portion only. #25 was closed because later commits were pushed to the same branch and made it too broad to review cleanly.

Designed by Marsu — Refined by Codex.
