### PR TITLE
doctor: Windows-safe pid liveness in check (a) and heartbeat scanner

### DIFF
--- a/src/iai_mcp/doctor/_lifecycle_checks.py
+++ b/src/iai_mcp/doctor/_lifecycle_checks.py
@@ -65,44 +65,66 @@ def check_a_daemon_alive() -> CheckResult:
             f"daemon_pid={pid!r} is not a valid PID (corrupt state?)",
         )
 
+    # os.kill(pid, 0) is the POSIX liveness idiom, but on Windows os.kill
+    # rejects signal 0 with OSError [WinError 87] (invalid parameter), so a
+    # perfectly healthy daemon reports "liveness probe failed". Skip the probe
+    # there and rely on the psutil refinement below, which both confirms the
+    # pid exists and that it is actually an iai_mcp.daemon. Mirrors
+    # iai_mcp.lifecycle_lock._is_pid_alive and the platform split already used
+    # by check_b for the Windows TCP transport.
+    if platform.system() != "Windows":
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return CheckResult(
+                "(a) daemon process alive",
+                False,
+                f"PID {pid} in state but no process found",
+            )
+        except PermissionError:
+            return CheckResult(
+                "(a) daemon process alive",
+                False,
+                f"PID {pid} exists but is not owned by this user",
+            )
+        except OSError as e:
+            return CheckResult(
+                "(a) daemon process alive",
+                False,
+                f"liveness probe failed: {type(e).__name__}: {e}",
+            )
+
     try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
+        import psutil
+    except ImportError as e:
+        return CheckResult(
+            "(a) daemon process alive",
+            False,
+            f"could not verify PID {pid}: psutil unavailable ({e})",
+        )
+
+    try:
+        proc = psutil.Process(pid)
+        cmdline = " ".join(proc.cmdline() or [])
+    except psutil.NoSuchProcess:
         return CheckResult(
             "(a) daemon process alive",
             False,
             f"PID {pid} in state but no process found",
         )
-    except PermissionError:
-        return CheckResult(
-            "(a) daemon process alive",
-            False,
-            f"PID {pid} exists but is not owned by this user",
-        )
-    except OSError as e:
-        return CheckResult(
-            "(a) daemon process alive",
-            False,
-            f"liveness probe failed: {type(e).__name__}: {e}",
-        )
-
-    try:
-        import psutil
-
-        proc = psutil.Process(pid)
-        cmdline = " ".join(proc.cmdline() or [])
-        if "iai_mcp.daemon" not in cmdline:
-            return CheckResult(
-                "(a) daemon process alive",
-                False,
-                f"PID {pid} is NOT iai_mcp.daemon (got: {proc.name()!r})",
-            )
     except Exception as e:  # noqa: BLE001 — psutil edge cases all roll up here
         logger.debug("check_a: psutil verify PID %d failed: %s", pid, e)
         return CheckResult(
             "(a) daemon process alive",
             False,
             f"could not verify PID {pid}: {type(e).__name__}: {e}",
+        )
+
+    if "iai_mcp.daemon" not in cmdline:
+        return CheckResult(
+            "(a) daemon process alive",
+            False,
+            f"PID {pid} is NOT iai_mcp.daemon (got: {proc.name()!r})",
         )
 
     return CheckResult(

--- a/src/iai_mcp/heartbeat_scanner.py
+++ b/src/iai_mcp/heartbeat_scanner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import platform
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
@@ -35,6 +36,24 @@ class HeartbeatEntry:
 def _is_pid_alive(pid: int) -> bool:
     if pid <= 0:
         return False
+
+    # os.kill(pid, 0) is the POSIX liveness idiom, but on Windows os.kill
+    # rejects signal 0 with OSError [WinError 87] (invalid parameter). Left
+    # unguarded it escapes scan() (which only narrows OSError on the glob, not
+    # the per-pid probe) and surfaces as a doctor (m) heartbeat-scanner FAIL.
+    # The pid here is a wrapper process (Claude/Codex), not the daemon, so this
+    # is a plain existence probe with no cmdline filtering. Mirrors the
+    # platform split in iai_mcp.lifecycle_lock._is_pid_alive.
+    if platform.system() == "Windows":
+        try:
+            import psutil
+        except ImportError:
+            return True
+        try:
+            return psutil.pid_exists(pid)
+        except Exception:  # noqa: BLE001 -- defensive against psutil backend quirks
+            return True
+
     try:
         os.kill(pid, 0)
     except ProcessLookupError:


### PR DESCRIPTION
## Problem

Two `os.kill(pid, 0)` liveness probes were left unguarded after the Windows port. On Windows `os.kill` rejects signal 0 with `OSError [WinError 87] (The parameter is incorrect)`, so on a perfectly healthy daemon `iai-mcp doctor` reports:

```
[FAIL] (a) daemon process alive    liveness probe failed: OSError: [WinError 87] The parameter is incorrect
[FAIL] (m) heartbeat scanner       could not scan ...\wrappers: OSError: [WinError 87] The parameter is incorrect
```

- **check (a)** — `os.kill(pid, 0)` raises before the psutil refinement runs.
- **(m) heartbeat scanner** — `_is_pid_alive` raises *inside* `HeartbeatScanner.scan()` (which only narrows `OSError` around the glob, not the per-pid probe), so it escapes as `could not scan wrappers`.

`check_b` was already given the Windows TCP-transport treatment; this brings (a) and the heartbeat scanner in line.

## Fix

Mirror the platform split already used by `lifecycle_lock._is_pid_alive`:

- **Windows** → use `psutil` (`pid_exists` for the wrapper probe; `Process().cmdline()` for the daemon-identity check).
- **POSIX** → unchanged `os.kill(pid, 0)`.

check (a) also handles `psutil.NoSuchProcess` explicitly so a dead pid reads `no process found` rather than the generic `could not verify`.

## Verification

- On Windows the live daemon now reports `[PASS] (a) ... PID <n> (iai_mcp.daemon)` and `[PASS] (m) heartbeat scanner n=… fresh`.
- POSIX behaviour is unchanged (guards are Windows-only). `tests/test_doctor_checklist.py` and `tests/test_heartbeat_scanner.py` pass (24 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)