### PR TITLE
tests: route remaining daemon sockets through short mkdtemp dirs (macOS CI)

### DIFF
--- a/tests/test_capture_transcript_no_spawn.py
+++ b/tests/test_capture_transcript_no_spawn.py
@@ -5,6 +5,7 @@ import os
 import platform
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -37,8 +38,10 @@ def _count_iai_mcp_processes() -> dict[str, int]:
 
 
 def _isolated_env(tmp_path: Path) -> tuple[dict[str, str], Path]:
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
+    # AF_UNIX paths are capped at ~104 chars on macOS; the pytest tmp_path under
+    # /private/var/folders/.../pytest-of-runner/... overflows it. A short
+    # mkdtemp dir keeps the socket path within the limit.
+    sock_dir = Path(tempfile.mkdtemp(prefix="iai-sock-"))
     sock_path = sock_dir / "d.sock"
 
     iai_dir = tmp_path / ".iai-mcp"

--- a/tests/test_concurrent_wrapper_spawn.py
+++ b/tests/test_concurrent_wrapper_spawn.py
@@ -7,6 +7,7 @@ import select
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -37,8 +38,11 @@ def test_launchagent(tmp_path):
     if os.environ.get("IAI_MCP_SKIP_LAUNCHCTL_TESTS") == "1":
         pytest.skip("IAI_MCP_SKIP_LAUNCHCTL_TESTS=1")
 
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
+    # AF_UNIX paths are capped at ~104 chars on macOS; the pytest tmp_path under
+    # /private/var/folders/.../pytest-of-runner/... overflows it. A short
+    # mkdtemp dir keeps the socket path within the limit. (Cleaned in teardown
+    # below via sock_dir.rmdir().)
+    sock_dir = Path(tempfile.mkdtemp(prefix="iai-sock-"))
     sock_path = sock_dir / "d.sock"
     if sock_path.exists():
         sock_path.unlink()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import plistlib
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -23,8 +24,10 @@ def _short_socket_paths(tmp_path, monkeypatch):
     import os
     from iai_mcp import concurrency
     lock_path = tmp_path / ".lock"
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
+    # AF_UNIX paths are capped at ~104 chars on macOS; the pytest tmp_path under
+    # /private/var/folders/.../pytest-of-runner/... overflows it. A short
+    # mkdtemp dir keeps the socket path within the limit.
+    sock_dir = Path(tempfile.mkdtemp(prefix="iai-sock-"))
     sock_path = sock_dir / "d.sock"
     monkeypatch.setattr(concurrency, "SOCKET_PATH", sock_path)
     return lock_path, sock_path, sock_dir

--- a/tests/test_doctor_apply_recovery.py
+++ b/tests/test_doctor_apply_recovery.py
@@ -6,6 +6,7 @@ import os
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -23,8 +24,11 @@ def isolated_daemon_paths(tmp_path, monkeypatch):
     store_dir = iai_dir / "store"
     store_dir.mkdir(parents=True, exist_ok=True)
 
-    sock_dir = tmp_path / "sock"
-    sock_dir.mkdir(parents=True, exist_ok=True)
+    # AF_UNIX paths are capped at ~104 chars on macOS; the pytest tmp_path under
+    # /private/var/folders/.../pytest-of-runner/... overflows it. A short
+    # mkdtemp dir keeps the socket path within the limit. (Cleaned in teardown
+    # below via sock_dir.rmdir().)
+    sock_dir = Path(tempfile.mkdtemp(prefix="iai-sock-"))
     sock_path = sock_dir / "d.sock"
 
     real_hf_home = Path.home() / ".cache" / "huggingface"


### PR DESCRIPTION
## Problem

Four socket fixtures still build their AF_UNIX path under pytest's `tmp_path` (`sock_dir = tmp_path / "sock"`). On macOS that path lives under `/private/var/folders/.../pytest-of-runner/pytest-N/<test-name>0/`, which — once `/sock/d.sock` is appended — can exceed the ~104-char `sun_path` limit and raise `OSError: AF_UNIX path too long`.

These are the files **not** covered by #31 (which fixes the same root cause across the other ~14 socket fixtures):

- `tests/test_capture_transcript_no_spawn.py`
- `tests/test_concurrent_wrapper_spawn.py`
- `tests/test_daemon.py`
- `tests/test_doctor_apply_recovery.py`

This PR is complementary to #31 — disjoint file set, no overlap.

## Fix

Route each through `tempfile.mkdtemp(prefix="iai-sock-")`, matching the pattern already used elsewhere. Fixtures that `rmdir`'d `sock_dir` in teardown continue to do so (now removing the mkdtemp dir); the daemon-down helpers never bind the socket, so only an empty temp dir is created and the OS reclaims it.

## Scope

POSIX-only test paths; no production code touched. Files compile and collect cleanly. Runtime behaviour is verified by the macOS CI job (the platform the bug manifests on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)