### PR TITLE
doctor: WARN checks no longer count as FAIL or drive the exit code

### DIFF
--- a/src/iai_mcp/doctor/__init__.py
+++ b/src/iai_mcp/doctor/__init__.py
@@ -553,10 +553,18 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         print(hint)
         print()
     print_checklist(results)
-    fail_count = sum(1 for r in results if not r.passed)
+    # A WARN is advisory: it renders as [WARN] and must NOT count as a FAIL or
+    # drive the exit code (otherwise e.g. the (x) collapsed-timestamp advisory
+    # prints "1/25 FAIL ... Exit 1" with zero [FAIL] rows on screen). Only a
+    # genuine non-passing, non-WARN check is a hard fail.
+    fail_count = sum(1 for r in results if not r.passed and r.status != "WARN")
+    warn_count = sum(1 for r in results if r.status == "WARN")
 
     if fail_count == 0:
-        print("\nAll checks passed. Exit 0.")
+        if warn_count:
+            print(f"\nAll checks passed ({warn_count} warning(s)). Exit 0.")
+        else:
+            print("\nAll checks passed. Exit 0.")
         return 0
 
     if not apply:
@@ -603,7 +611,11 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     print("\nRe-running checks ...")
     final_results = run_diagnosis()
     print_checklist(final_results)
-    final_fails = [r.name for r in final_results if not r.passed]
+    # WARNs are advisory and have no repair action, so they must not keep the
+    # exit code at 2 — only genuine non-WARN fails count as "still broken".
+    final_fails = [
+        r.name for r in final_results if not r.passed and r.status != "WARN"
+    ]
     if not final_fails:
         print(f"\nFIXED. All {len(final_results)} checks pass. Exit 0.")
         return 0

--- a/tests/test_doctor_checklist.py
+++ b/tests/test_doctor_checklist.py
@@ -150,6 +150,43 @@ def test_all_pass_returns_exit_0(short_socket_paths, monkeypatch, capsys):
     assert "All checks passed" in out
 
 
+def test_warn_does_not_count_as_fail_or_drive_exit(short_socket_paths, monkeypatch, capsys):
+    # A WARN check renders as [WARN] but historically carried passed=False, so it
+    # was counted toward fail_count and forced Exit 1 — printing "N/M FAIL" with
+    # zero [FAIL] rows on screen. A WARN is advisory: all-real-checks-pass must
+    # yield Exit 0 and an explicit warning count.
+    from iai_mcp import doctor
+
+    forced = [
+        doctor.CheckResult(name, True, "synthetic pass") for name in (
+            "(a) daemon process alive",
+            "(b) socket file fresh",
+            "(c) lock file healthy",
+            "(d) no orphan iai_mcp.core procs",
+            "(e) daemon state file valid",
+        )
+    ]
+    forced.append(
+        doctor.CheckResult(
+            "(x) no collapsed-timestamp groups",
+            False,
+            "1 group(s) with >= 5 records at one timestamp",
+            status="WARN",
+        )
+    )
+    monkeypatch.setattr(doctor, "run_diagnosis", lambda: forced)
+
+    args = argparse.Namespace(apply=False, yes=False)
+    rc = doctor.cmd_doctor(args)
+    out = capsys.readouterr().out
+
+    assert rc == 0, f"WARN must not drive a non-zero exit; got rc={rc}\n{out}"
+    assert "All checks passed" in out
+    assert "1 warning" in out
+    assert "[WARN]" in out
+    assert "FAIL. Run with --apply" not in out  # no spurious FAIL summary line
+
+
 def test_apply_without_yes_warns_when_yes_alone(short_socket_paths, monkeypatch, capsys):
     from iai_mcp import doctor
 


### PR DESCRIPTION
## Problem

`CheckResult` distinguishes `status == "WARN"` (advisory) from `FAIL`, and `print_checklist` renders them as `[WARN]`. But the exit-code tally counted them as failures:

```python
fail_count = sum(1 for r in results if not r.passed)   # WARNs have passed=False
```

So an advisory like (x) collapsed-timestamps produced self-contradicting output:

```
[WARN] (x) no collapsed-timestamp groups   ... run 'iai-mcp migrate --rederive-timestamps' to repair
1/25 FAIL. Run with --apply to attempt recovery. Exit 1.
```

— "1/25 FAIL ... Exit 1" with **zero `[FAIL]` rows on screen**, and a non-zero exit for a purely advisory condition that has no repair action (so `--apply` then reports `Exit 2` "still broken" against something it can never fix).

## Fix

Classify a hard fail as `not r.passed and r.status != "WARN"` in both the summary tally and the post-`--apply` recheck. When only WARNs remain:

```
All checks passed (1 warning(s)). Exit 0.
```

WARNs still render as `[WARN]`; no check definitions change.

## Note for maintainers

This **changes exit-code semantics**: `doctor` previously returned 1 whenever any WARN was present (e.g. collapsed timestamps, no HID idle source, CLI not on PATH); it now returns 0 when all *hard* checks pass. That matches the `[WARN]` rendering and the advisory wording, but if you intend a specific WARN to gate CI, the alternative is to promote it to a real `FAIL`. Happy to adjust.

## Verification

- New test `test_warn_does_not_count_as_fail_or_drive_exit`: an only-WARN result yields Exit 0, "1 warning", and no `FAIL` summary line.
- `tests/test_doctor_checklist.py`: 14 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)