### PR TITLE
daemon: auto-clear expired sleep quarantine at boot

### DIFF
--- a/src/iai_mcp/daemon/__init__.py
+++ b/src/iai_mcp/daemon/__init__.py
@@ -1147,6 +1147,20 @@ async def main() -> int:
         _idle_detector = _IdleDetector()
         _sleep_pipeline = _SleepPipeline(store=store)
 
+        # Eagerly clear a long-expired quarantine at boot. Auto-recovery
+        # otherwise only fires when a sleep cycle is next attempted, so a daemon
+        # that never reaches a sleep window (e.g. pinned in WAKE with active
+        # sessions) would carry a zombie quarantine entry indefinitely and keep
+        # `doctor` (l) reporting a quarantine that expired days ago.
+        try:
+            if _sleep_pipeline.recover_expired_quarantine():
+                log.warning(
+                    "sleep_quarantine_boot_recovered: expired quarantine "
+                    "cleared at boot"
+                )
+        except Exception as _q_exc:  # noqa: BLE001 -- boot recovery must never wedge startup
+            log.debug("quarantine boot-recover failed: %s", _q_exc)
+
         from pathlib import Path as _PathS2
         # Boot normalization for a crash mid-SLEEP: lifecycle_state.json can be
         # left at current_state=SLEEP with sleep_cycle_progress=None -- an

--- a/src/iai_mcp/lilli/cycle/sleep_pipeline/__init__.py
+++ b/src/iai_mcp/lilli/cycle/sleep_pipeline/__init__.py
@@ -208,6 +208,24 @@ class SleepPipeline:
     def reset_quarantine(self) -> None:
         self._clear_quarantine(reason="manual_reset")
 
+    def recover_expired_quarantine(self) -> bool:
+        """Eagerly clear an expired (or malformed) quarantine.
+
+        Normally an expired quarantine is only cleared the next time a sleep
+        cycle is attempted (``run`` -> ``_check_and_maybe_auto_recover_quarantine``).
+        A daemon that never reaches a sleep window — e.g. pinned in WAKE with
+        active sessions — would otherwise carry a zombie quarantine entry in
+        ``lifecycle_state.json`` indefinitely, which keeps ``doctor`` (l)
+        reporting a long-expired quarantine. Calling this at daemon boot makes
+        the entry self-heal regardless of sleep scheduling.
+
+        Returns True if a quarantine entry was present and has now been cleared
+        (expired or malformed), False otherwise (none present, or still active).
+        """
+        had_quarantine = self._load_quarantine() is not None
+        still_active = self._check_and_maybe_auto_recover_quarantine()
+        return had_quarantine and not still_active
+
 
     def _load_progress(self) -> Any:
         progress = self._load_state_record().get("sleep_cycle_progress")

--- a/tests/test_sleep_pipeline.py
+++ b/tests/test_sleep_pipeline.py
@@ -433,6 +433,59 @@ def test_pipeline_reset_quarantine_clears(
         SleepStep.DREAM_DECAY,
     )
 
+def test_recover_expired_quarantine_clears_without_sleep_cycle(
+    pipeline: SleepPipeline,
+    state_path: Path,
+):
+    # An expired quarantine must be clearable WITHOUT attempting a sleep cycle
+    # (the daemon calls this at boot). Without it, a daemon that never sleeps
+    # carries a zombie quarantine entry indefinitely.
+    now = datetime.now(timezone.utc)
+    record = default_state()
+    record["quarantine"] = {
+        "until_ts": (now - timedelta(hours=1)).isoformat(),
+        "reason": "sleep step 3 (DREAM_DECAY) failed 3x",
+        "since_ts": (now - timedelta(hours=25)).isoformat(),
+    }
+    save_state(record, state_path)
+
+    cleared = pipeline.recover_expired_quarantine()
+
+    assert cleared is True
+    assert load_state(state_path)["quarantine"] is None
+    assert pipeline.is_quarantined() is False
+
+
+def test_recover_expired_quarantine_keeps_active_quarantine(
+    pipeline: SleepPipeline,
+    state_path: Path,
+):
+    # An ACTIVE quarantine must survive the boot-time recovery probe.
+    now = datetime.now(timezone.utc)
+    record = default_state()
+    record["quarantine"] = {
+        "until_ts": (now + timedelta(hours=12)).isoformat(),
+        "reason": "still cooling down",
+        "since_ts": now.isoformat(),
+    }
+    save_state(record, state_path)
+
+    cleared = pipeline.recover_expired_quarantine()
+
+    assert cleared is False
+    assert load_state(state_path)["quarantine"] is not None
+    assert pipeline.is_quarantined() is True
+
+
+def test_recover_expired_quarantine_noop_when_absent(
+    pipeline: SleepPipeline,
+    state_path: Path,
+):
+    save_state(default_state(), state_path)
+    assert pipeline.recover_expired_quarantine() is False
+    assert load_state(state_path)["quarantine"] is None
+
+
 def test_pipeline_force_run_ignores_quarantine(
     pipeline: SleepPipeline,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Problem

An expired sleep-cycle quarantine is only cleared when a sleep cycle is *next attempted* (`SleepPipeline.run` → `_check_and_maybe_auto_recover_quarantine`, line ~397). A daemon that never reaches a sleep window — e.g. pinned in WAKE with active sessions — therefore carries a zombie quarantine entry in `lifecycle_state.json` indefinitely.

Observed: a daemon still reporting

```
[WARN] (l) sleep cycle quarantine   quarantine expired (until=2026-06-27T...); reason=sleep step 3 (DREAM_DECAY) failed 3x
```

three days after the TTL elapsed, because no sleep cycle had run in the interim. `is_quarantined()` correctly returns `False` for it, but never tidies the stale dict.

## Fix

Add `SleepPipeline.recover_expired_quarantine()` — a thin public wrapper over the existing `_check_and_maybe_auto_recover_quarantine()` that returns whether it cleared an expired/malformed entry — and call it **once at daemon boot**, right after the pipeline is constructed (alongside the existing lifecycle boot-normalization). Failures are swallowed so boot can never wedge on it.

Active quarantines and the sleep-cycle entry path are unchanged.

## Verification

New tests in `test_sleep_pipeline.py`:
- `test_recover_expired_quarantine_clears_without_sleep_cycle` — expired entry cleared without running a cycle.
- `test_recover_expired_quarantine_keeps_active_quarantine` — active entry survives.
- `test_recover_expired_quarantine_noop_when_absent` — no-op when none present.

Full file: 29 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)