### PR TITLE
tests: redirect USERPROFILE so sleep-cycle test stops polluting real lifecycle state (Windows)

### DIFF
--- a/tests/test_cli_maintenance_sleep_cycle.py
+++ b/tests/test_cli_maintenance_sleep_cycle.py
@@ -27,6 +27,13 @@ def _make_args(**kwargs) -> argparse.Namespace:
 @pytest.fixture
 def iai_root(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
+    # Path.home() / os.path.expanduser("~") consults USERPROFILE on Windows, NOT
+    # HOME. Without this, the reload below recomputes LIFECYCLE_STATE_PATH back
+    # to the REAL home on Windows, so save_state(..., LIFECYCLE_STATE_PATH) and
+    # the CLI under test write quarantine/progress into the developer's live
+    # ~/.iai-mcp/lifecycle_state.json (POSIX CI is unaffected, which is why this
+    # leak went unnoticed). Redirect home cross-platform.
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.setenv("HF_HOME", str(tmp_path / "hf"))
     monkeypatch.setenv(
         "PYTHON_KEYRING_BACKEND", "keyring.backends.fail.Keyring"


### PR DESCRIPTION
## Problem

`tests/test_cli_maintenance_sleep_cycle.py`'s `iai_root` fixture isolates `HOME` and then `importlib.reload`s `lifecycle_state`, which recomputes the module constant:

```python
LIFECYCLE_STATE_PATH = Path.home() / ".iai-mcp" / "lifecycle_state.json"
```

On POSIX, `Path.home()` honours `HOME`, so the reload redirects it under `tmp_path` and CI is clean. On **Windows**, `Path.home()` / `os.path.expanduser("~")` consults **USERPROFILE**, not `HOME` — so after the reload `LIFECYCLE_STATE_PATH` still points at the developer's *real* home.

The tests then `save_state(record, LIFECYCLE_STATE_PATH)` — seeding a quarantine, and (in the failure test) running a step patched to raise — writing into the live `~/.iai-mcp/lifecycle_state.json`. On a dev box with a persistent home and a running daemon, this leaves a real `sleep step N (...) failed 3x` quarantine that `doctor (l)` then reports for days. (This is exactly how a stale `DREAM_DECAY failed 3x` quarantine appeared on my machine.)

## Fix

Set `USERPROFILE` alongside `HOME` in the fixture so `Path.home()` redirects to `tmp_path` on every platform. Verified: with the env var set + reload, `LIFECYCLE_STATE_PATH` resolves under the temp dir on Windows; without it, the real home.

Test-only change; 10 passed.

## Note

Other fixtures across the suite use the same `setenv("HOME", ...)` isolation idiom and have the same latent Windows gap. This PR fixes the one that actually writes lifecycle state; a follow-up could add a shared `redirect_home(monkeypatch, path)` conftest helper that sets both vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)