### PR TITLE
fix(daemon): defer startup drains behind MCP activity

### DIFF
--- a/src/iai_mcp/daemon/__init__.py
+++ b/src/iai_mcp/daemon/__init__.py
@@ -61,6 +61,12 @@ VALID_TRANSITIONS: dict[str, set[str]] = {
 }
 
 TICK_INTERVAL_SEC: int = 30
+# Read once at import so spawned daemon processes can override it via env.
+STARTUP_DEFERRED_DRAIN_GRACE_SEC: float = float(
+    os.environ.get("IAI_MCP_STARTUP_DEFERRED_DRAIN_GRACE_SEC", "20.0")
+)
+CAPTURE_QUEUE_RETRY_PENDING_KEY: str = "_capture_queue_drain_retry_pending"
+CAPTURE_QUEUE_LAST_RETRY_KEY: str = "_capture_queue_drain_last_retry_at"
 
 DEFAULT_CYCLE_COUNT: int = 4
 
@@ -158,6 +164,104 @@ def _raise_fd_limit() -> None:
 def _should_drain_on_drowsy_edge(prev, current) -> bool:
     from iai_mcp.lifecycle_state import LifecycleState as _L
     return prev is _L.WAKE and current is _L.DROWSY
+
+
+def _mcp_recent_activity(mcp_socket, *, window_sec: float) -> bool:
+    if mcp_socket is None:
+        return False
+    try:
+        return (time.monotonic() - float(mcp_socket.last_activity_ts)) < window_sec
+    except Exception:  # noqa: BLE001 -- activity probe must never crash scheduling
+        return False
+
+
+def _capture_queue_pending_count(capture_queue) -> int | None:
+    try:
+        return int(capture_queue.pending_count())
+    except Exception:  # noqa: BLE001 -- telemetry only
+        return None
+
+
+def _set_capture_queue_retry_state(
+    state: dict,
+    *,
+    pending: bool,
+    pending_count: int | None = None,
+) -> None:
+    state[CAPTURE_QUEUE_RETRY_PENDING_KEY] = bool(pending)
+    state[CAPTURE_QUEUE_LAST_RETRY_KEY] = datetime.now(timezone.utc).isoformat()
+    if pending_count is not None:
+        state["_capture_queue_pending_count"] = pending_count
+
+
+def _drain_capture_queue_once(
+    store,
+    capture_queue,
+    capture_handler,
+    *,
+    phase: str,
+) -> dict:
+    ingested = int(capture_queue.ingest_pending(capture_handler))
+    pending_count = _capture_queue_pending_count(capture_queue)
+    payload = {"phase": phase, "ingested": ingested}
+    if pending_count is not None:
+        payload["pending_count"] = pending_count
+    if ingested > 0:
+        write_event(store, "capture_queue_drained", payload, severity="info")
+    return {
+        "ingested": ingested,
+        "pending_count": pending_count,
+        "pending": bool(pending_count) if pending_count is not None else False,
+    }
+
+
+async def _retry_capture_queue_drain_if_due(
+    store: MemoryStore,
+    state: dict,
+    *,
+    capture_queue=None,
+    capture_handler: Callable[[dict], None] | None = None,
+    mcp_socket: SocketServer | None = None,
+) -> None:
+    if (
+        capture_queue is None
+        or capture_handler is None
+        or not state.get(CAPTURE_QUEUE_RETRY_PENDING_KEY)
+    ):
+        return
+    if _mcp_recent_activity(mcp_socket, window_sec=STARTUP_DEFERRED_DRAIN_GRACE_SEC):
+        return
+    try:
+        result = await asyncio.to_thread(
+            _drain_capture_queue_once,
+            store,
+            capture_queue,
+            capture_handler,
+            phase="tick_retry",
+        )
+        _set_capture_queue_retry_state(
+            state,
+            pending=bool(result.get("pending")),
+            pending_count=result.get("pending_count"),
+        )
+        await asyncio.to_thread(save_state, state)
+    except Exception as exc:  # noqa: BLE001 -- tick retry must never crash daemon
+        _set_capture_queue_retry_state(state, pending=True)
+        log.warning("capture queue retry drain failed: %s", exc, exc_info=True)
+        try:
+            await asyncio.to_thread(
+                write_event,
+                store,
+                "capture_queue_drain_failed",
+                {"phase": "tick_retry", "error": str(exc)[:200]},
+                severity="warning",
+            )
+        except Exception:  # noqa: BLE001 -- event write inside boundary guard
+            log.debug("capture_queue_drain_failed retry event write failed")
+        try:
+            await asyncio.to_thread(save_state, state)
+        except (OSError, ValueError) as save_exc:
+            log.debug("save_state after capture queue retry failure failed: %s", save_exc)
 
 
 # Idle-countdown decisions. The lifecycle tick translates these into FSM events.
@@ -622,13 +726,19 @@ def _write_session_start_cache(
             return {"action": "skipped", "reason": "runtime_graph_cache_cold"}
 
         try:
-            from iai_mcp import retrieve
             from iai_mcp.session import (
                 _compose_session_start_payload,
                 format_payload_as_markdown,
             )
 
-            _graph, assignment, rc = retrieve.build_runtime_graph(store)
+            if force_rebuild:
+                from iai_mcp import retrieve
+
+                _graph, assignment, rc = retrieve.build_runtime_graph(store)
+            else:
+                from iai_mcp import runtime_graph_cache as _rgc
+
+                assignment, rc, _max_degree, _source = _rgc.load_recall_structural(store)
             payload = _compose_session_start_payload(
                 store,
                 assignment,
@@ -779,6 +889,8 @@ async def _tick_body(
     state: dict,
     *,
     mcp_socket: SocketServer | None = None,
+    capture_queue=None,
+    capture_handler: Callable[[dict], None] | None = None,
 ) -> None:
     try:
         from iai_mcp.daemon_state import (
@@ -892,6 +1004,18 @@ async def _tick_body(
         log.debug("edges buffer periodic flush skipped: %s", str(e)[:120])
 
 
+    try:
+        await _retry_capture_queue_drain_if_due(
+            store,
+            state,
+            capture_queue=capture_queue,
+            capture_handler=capture_handler,
+            mcp_socket=mcp_socket,
+        )
+    except Exception:  # noqa: BLE001 -- retry boundary must not affect tick
+        log.debug("tick step capture_queue_retry failed", exc_info=True)
+
+
     if state.get("scheduler_paused") is True:
         try:
             await asyncio.to_thread(
@@ -960,11 +1084,19 @@ async def _scheduler_tick(
     *,
     tick_body: Callable[..., Awaitable[None]] | None = None,
     mcp_socket: SocketServer | None = None,
+    capture_queue=None,
+    capture_handler: Callable[[dict], None] | None = None,
 ) -> None:
     body = tick_body or _tick_body
     while True:
         try:
-            await body(store, state, mcp_socket=mcp_socket)
+            await body(
+                store,
+                state,
+                mcp_socket=mcp_socket,
+                capture_queue=capture_queue,
+                capture_handler=capture_handler,
+            )
         except TypeError:
             try:
                 await body(store, state)
@@ -1301,11 +1433,14 @@ async def main() -> int:
         except Exception:  # noqa: BLE001 -- boot MUST NOT block on wake-handler
             log.debug("wake signal consume failed", exc_info=True)
 
+        _capture_queue = None
+        _capture_handler = None
         try:
             from iai_mcp.capture import capture_turn as _capture_turn
             from iai_mcp.capture_queue import CaptureQueue
 
             _capture_queue = CaptureQueue()
+
             def _capture_handler(record: dict) -> None:
                 kwargs = {
                     "cue": record.get("cue", ""),
@@ -1315,24 +1450,13 @@ async def main() -> int:
                     "role": record.get("role", "user"),
                 }
                 _capture_turn(store, **kwargs)
-
-            ingested = await asyncio.to_thread(
-                _capture_queue.ingest_pending, _capture_handler,
-            )
-            if ingested > 0:
-                write_event(
-                    store,
-                    "capture_queue_drained",
-                    {"phase": "startup", "ingested": ingested},
-                    severity="info",
-                )
-        except Exception as exc:  # noqa: BLE001 -- never block boot on queue drain
-            log.warning("capture queue drain failed at startup: %s", exc, exc_info=True)
+        except Exception as exc:  # noqa: BLE001 -- never block boot on queue init
+            log.warning("capture queue init failed at startup: %s", exc, exc_info=True)
             try:
                 write_event(
                     store,
                     "capture_queue_drain_failed",
-                    {"phase": "startup", "error": str(exc)[:200]},
+                    {"phase": "startup_init", "error": str(exc)[:200]},
                     severity="warning",
                 )
             except Exception:  # noqa: BLE001 -- event write inside boundary guard
@@ -1419,14 +1543,12 @@ async def main() -> int:
 
             async def _boot_preload() -> None:
                 try:
-                    from iai_mcp import retrieve as _retrieve_preload
-                    # build_runtime_graph already persists the cache internally
-                    # (with the full node_payload) on a miss. The previous extra
-                    # save(..., node_payload=None, ...) here overwrote that good
-                    # cache with a payload-less one (forcing a pandas re-read on
-                    # the next hit) — so we just warm the cache and drop it.
+                    # WAKE boot must not stream the whole Hippo store. The recall
+                    # hot path is ANN-first and only needs the structural overlay
+                    # or last-good snapshot; expensive rebuilds belong to sleep /
+                    # drowsy paths.
                     await asyncio.to_thread(
-                        _retrieve_preload.build_runtime_graph, store,
+                        _rgc_mod.load_recall_structural, store,
                     )
                 except Exception as _exc:  # noqa: BLE001 -- preload MUST NOT crash daemon
                     log.debug("boot_preload failed: %s", _exc, exc_info=True)
@@ -1442,11 +1564,92 @@ async def main() -> int:
             except Exception:  # noqa: BLE001
                 pass
 
+        if _capture_queue is not None and _capture_handler is not None:
+            async def _capture_queue_drain_and_report() -> None:
+                try:
+                    if STARTUP_DEFERRED_DRAIN_GRACE_SEC > 0:
+                        await asyncio.sleep(STARTUP_DEFERRED_DRAIN_GRACE_SEC)
+                    if _mcp_recent_activity(
+                        mcp_socket,
+                        window_sec=STARTUP_DEFERRED_DRAIN_GRACE_SEC,
+                    ):
+                        pending_count = _capture_queue_pending_count(_capture_queue)
+                        retry_pending = pending_count is None or pending_count > 0
+                        _set_capture_queue_retry_state(
+                            state,
+                            pending=retry_pending,
+                            pending_count=pending_count,
+                        )
+                        await asyncio.to_thread(save_state, state)
+                        payload = {
+                            "reason": "recent_mcp_activity",
+                            "retry_pending": retry_pending,
+                        }
+                        if pending_count is not None:
+                            payload["pending_count"] = pending_count
+                        await asyncio.to_thread(
+                            write_event,
+                            store,
+                            "capture_queue_drain_startup_skipped",
+                            payload,
+                            severity="info",
+                        )
+                        return
+                    result = await asyncio.to_thread(
+                        _drain_capture_queue_once,
+                        store,
+                        _capture_queue,
+                        _capture_handler,
+                        phase="startup",
+                    )
+                    _set_capture_queue_retry_state(
+                        state,
+                        pending=bool(result.get("pending")),
+                        pending_count=result.get("pending_count"),
+                    )
+                    await asyncio.to_thread(save_state, state)
+                except Exception as exc:  # noqa: BLE001 -- never block socket serving
+                    _set_capture_queue_retry_state(state, pending=True)
+                    log.warning("capture queue drain failed at startup: %s", exc, exc_info=True)
+                    try:
+                        await asyncio.to_thread(save_state, state)
+                    except (OSError, ValueError) as save_exc:
+                        log.debug(
+                            "save_state after startup capture queue failure failed: %s",
+                            save_exc,
+                        )
+                    try:
+                        await asyncio.to_thread(
+                            write_event,
+                            store,
+                            "capture_queue_drain_failed",
+                            {"phase": "startup", "error": str(exc)[:200]},
+                            severity="warning",
+                        )
+                    except Exception:  # noqa: BLE001 -- event write inside boundary guard
+                        log.debug("capture_queue_drain_failed event write failed")
+
+            asyncio.create_task(_capture_queue_drain_and_report())
+
         try:
             from iai_mcp.capture import drain_deferred_captures as _drain
 
             async def _drain_and_report() -> None:
                 try:
+                    if STARTUP_DEFERRED_DRAIN_GRACE_SEC > 0:
+                        await asyncio.sleep(STARTUP_DEFERRED_DRAIN_GRACE_SEC)
+                    if _mcp_recent_activity(
+                        mcp_socket,
+                        window_sec=STARTUP_DEFERRED_DRAIN_GRACE_SEC,
+                    ):
+                        await asyncio.to_thread(
+                            write_event,
+                            store,
+                            "deferred_drain_startup_skipped",
+                            {"reason": "recent_mcp_activity"},
+                            severity="info",
+                        )
+                        return
                     drain_counts = await asyncio.to_thread(_drain, store)
                     if drain_counts.get("files_drained") or drain_counts.get(
                         "files_failed"
@@ -1570,7 +1773,13 @@ async def main() -> int:
         )
 
         tick_task = asyncio.create_task(
-            _scheduler_tick(store, state, mcp_socket=mcp_socket)
+            _scheduler_tick(
+                store,
+                state,
+                mcp_socket=mcp_socket,
+                capture_queue=_capture_queue,
+                capture_handler=_capture_handler,
+            )
         )
         audit_task = asyncio.create_task(
             continuous_audit(store, shutdown)

--- a/tests/test_daemon_tick_yields_to_mcp_activity.py
+++ b/tests/test_daemon_tick_yields_to_mcp_activity.py
@@ -103,3 +103,99 @@ def test_tick_body_works_with_none_mcp_socket(tick_env, monkeypatch):
     asyncio.run(daemon_mod._tick_body(store, state, mcp_socket=None))
 
     assert "last_tick_at" in state
+
+
+def test_mcp_recent_activity_probe():
+    from iai_mcp import daemon as daemon_mod
+
+    recent = types.SimpleNamespace(last_activity_ts=time.monotonic() - 2.0)
+    stale = types.SimpleNamespace(last_activity_ts=time.monotonic() - 120.0)
+
+    assert daemon_mod._mcp_recent_activity(recent, window_sec=30.0) is True
+    assert daemon_mod._mcp_recent_activity(stale, window_sec=30.0) is False
+    assert daemon_mod._mcp_recent_activity(None, window_sec=30.0) is False
+
+
+def test_capture_queue_retry_waits_for_quiet_socket(tick_env, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+
+    store, _ = tick_env
+    writes: list = []
+    handled: list = []
+
+    class _FakeCaptureQueue:
+        calls = 0
+
+        def ingest_pending(self, handler):
+            self.calls += 1
+            handler({"literal_surface": "queued"})
+            return 1
+
+        def pending_count(self):
+            return 0
+
+    monkeypatch.setattr(daemon_mod, "write_event", lambda *a, **kw: writes.append((a, kw)))
+    monkeypatch.setattr(daemon_mod, "save_state", lambda state: None)
+
+    state = {daemon_mod.CAPTURE_QUEUE_RETRY_PENDING_KEY: True}
+    queue = _FakeCaptureQueue()
+    recent_socket = types.SimpleNamespace(last_activity_ts=time.monotonic())
+
+    asyncio.run(
+        daemon_mod._retry_capture_queue_drain_if_due(
+            store,
+            state,
+            capture_queue=queue,
+            capture_handler=handled.append,
+            mcp_socket=recent_socket,
+        )
+    )
+
+    assert queue.calls == 0
+    assert handled == []
+    assert state[daemon_mod.CAPTURE_QUEUE_RETRY_PENDING_KEY] is True
+    assert writes == []
+
+
+def test_capture_queue_retry_drains_when_socket_is_quiet(tick_env, monkeypatch):
+    from iai_mcp import daemon as daemon_mod
+
+    store, _ = tick_env
+    writes: list = []
+    handled: list = []
+
+    class _FakeCaptureQueue:
+        calls = 0
+
+        def ingest_pending(self, handler):
+            self.calls += 1
+            handler({"literal_surface": "queued"})
+            return 1
+
+        def pending_count(self):
+            return 0
+
+    monkeypatch.setattr(daemon_mod, "write_event", lambda *a, **kw: writes.append((a, kw)))
+    monkeypatch.setattr(daemon_mod, "save_state", lambda state: None)
+
+    state = {daemon_mod.CAPTURE_QUEUE_RETRY_PENDING_KEY: True}
+    queue = _FakeCaptureQueue()
+    stale_socket = types.SimpleNamespace(last_activity_ts=time.monotonic() - 120.0)
+
+    asyncio.run(
+        daemon_mod._retry_capture_queue_drain_if_due(
+            store,
+            state,
+            capture_queue=queue,
+            capture_handler=handled.append,
+            mcp_socket=stale_socket,
+        )
+    )
+
+    assert queue.calls == 1
+    assert handled == [{"literal_surface": "queued"}]
+    assert state[daemon_mod.CAPTURE_QUEUE_RETRY_PENDING_KEY] is False
+    assert state["_capture_queue_pending_count"] == 0
+    assert writes
+    assert writes[0][0][1] == "capture_queue_drained"
+    assert writes[0][0][2]["phase"] == "tick_retry"

--- a/tests/test_session_start_cache_refresh.py
+++ b/tests/test_session_start_cache_refresh.py
@@ -441,6 +441,58 @@ def test_write_skips_when_runtime_graph_cache_cold(tmp_path, monkeypatch):
     ), skipped
 
 
+def test_write_wake_refresh_uses_structural_cache_not_runtime_rebuild(
+    tmp_path, monkeypatch,
+):
+    """A warm WAKE refresh should format from the structural cache and must not
+    call retrieve.build_runtime_graph on the daemon hot path."""
+    from iai_mcp import daemon as daemon_mod
+    from iai_mcp import retrieve as retrieve_mod
+    from iai_mcp import runtime_graph_cache as rgc_mod
+    from iai_mcp import session as session_mod
+
+    store = _fresh_store(tmp_path, monkeypatch)
+    _seed(store)
+
+    monkeypatch.setattr(
+        daemon_mod, "_runtime_graph_cache_is_warm", lambda _store: True,
+    )
+    monkeypatch.setattr(
+        retrieve_mod,
+        "build_runtime_graph",
+        lambda _store: (_ for _ in ()).throw(
+            AssertionError("WAKE refresh must not rebuild runtime graph")
+        ),
+    )
+    calls: list[str] = []
+
+    def _load_recall_structural(_store):
+        calls.append("load_recall_structural")
+        return {}, {}, 0, "normal"
+
+    monkeypatch.setattr(rgc_mod, "load_recall_structural", _load_recall_structural)
+    monkeypatch.setattr(
+        session_mod,
+        "_compose_session_start_payload",
+        lambda *_a, **_kw: {"l0": [], "l1": [], "wake_depth": "standard"},
+    )
+    monkeypatch.setattr(
+        session_mod,
+        "format_payload_as_markdown",
+        lambda _payload: "cached wake payload",
+    )
+
+    cache, meta = _cache_paths(tmp_path)
+    result = daemon_mod._write_session_start_cache(
+        store, cache_path=cache, meta_path=meta,
+        trigger="periodic_wake", force_rebuild=False,
+    )
+
+    assert result["action"] == "wrote"
+    assert calls == ["load_recall_structural"]
+    assert cache.read_text() == "cached wake payload"
+
+
 def test_write_force_rebuild_ignores_cold_probe(tmp_path, monkeypatch):
     """The SLEEP branch passes force_rebuild=True; even a cold probe shouldn't
     stop the write — that's the cheapest moment to absorb the rebuild cost."""


### PR DESCRIPTION
## Problem

The daemon still had too much work on its startup hot path. On a store with deferred captures or capture-queue backlog, startup could begin draining work before the MCP socket was ready and before the daemon knew whether a client was actively trying to connect.

That is risky for MCP clients because the process can look started while the useful interface is not yet responsive. In practice, the expensive startup work competes with first MCP traffic, which can turn a normal client launch into a slow or disconnected handshake.

There was a second related hot-path issue: WAKE / boot SessionStart refresh could force a full runtime-graph rebuild. That is useful work, but it is the wrong moment to pay for it if the daemon is trying to become responsive.

## Proposed solution

This PR narrows startup to the minimum needed to serve MCP promptly:

- start serving the MCP socket before running capture-queue or deferred-capture drains;
- only run startup drains once MCP traffic has been quiet long enough;
- persist retry markers when startup drains are skipped or fail, so the scheduler can retry later instead of silently dropping work;
- keep WAKE / boot SessionStart refresh on the structural runtime-graph cache instead of forcing a full runtime graph rebuild on the hot path.

The important trade-off is intentional: startup responsiveness wins over immediate background cleanup. The cleanup is still durable and retried; it is just moved out of the client-facing startup window.

## Safety and behavior

On a genuinely cold boot with no structural overlay or snapshot, `load_recall_structural()` can return the `cold_degrade` empty assignment instead of building the graph immediately. That is deliberate here. The first recall or a later sleep/drowsy path can pay the rebuild cost, while daemon startup and MCP serving stay responsive.

Startup drain failures and skips remain observable through events such as `capture_queue_drain_failed`, `capture_queue_drain_startup_skipped`, and `deferred_drain_startup_skipped`.

## Scope

This is rebased on `v1.2.1` (`88a0f0d`). `v1.2.1` already includes the macOS socket CI fix and the WAKE SessionStart refresh from the earlier PRs, so this PR is intentionally limited to the remaining daemon startup responsiveness work.

## Verification

- `python -m py_compile src/iai_mcp/daemon/__init__.py`
- `git diff --check`
- `pytest tests/test_daemon_tick_yields_to_mcp_activity.py tests/test_session_start_cache_refresh.py -q`
  - `33 passed`
- `pytest tests/test_capture_queue.py tests/test_socket_server_dispatch.py tests/test_daemon_crash_loop_immunity.py -q`
  - `31 passed`
- `env -u IAI_RECALL_READ_TIMEOUT pytest -m "not perf and not slow and not live" --ignore=tests/test_embedder_numeric_parity.py`
  - `3612 passed, 32 skipped, 87 deselected, 1 xfailed`
- `env -u IAI_RECALL_READ_TIMEOUT pytest tests/test_embedder_numeric_parity.py -q -s`
  - `4 passed, 1 skipped`

## Cross-check

Reviewed with Claude before publishing. The review agreed with keeping startup responsive, preserving deferred work through retry markers, and avoiding forced graph rebuilds on the daemon hot path.

## Attribution

Designed by Marsu — Refined by Codex.

Co-Authored-By: Codex <codex@openai.com>