### PR TITLE
fix(store): preserve structural metadata in SQL paths

### DIFF
--- a/src/iai_mcp/hippo/_recall.py
+++ b/src/iai_mcp/hippo/_recall.py
@@ -17,7 +17,7 @@ _DIRECT_RECENCY_SQL = (
     " stability, difficulty, last_reviewed, never_decay, never_merge,"
     " provenance_json, created_at, updated_at, tags_json, language,"
     " s5_trust_score, profile_modulation_gain_json, schema_version,"
-    " hv_tier, structure_hv_payload,"
+    " structure_hv, hv_tier, structure_hv_payload,"
     " COALESCE(embedding_pending, 0) AS embedding_pending"
     " FROM records WHERE tombstoned_at IS NULL ORDER BY created_at DESC"
 )
@@ -29,7 +29,7 @@ _DIRECT_RECENCY_SQL_LIMITED = (
     " stability, difficulty, last_reviewed, never_decay, never_merge,"
     " provenance_json, created_at, updated_at, tags_json, language,"
     " s5_trust_score, profile_modulation_gain_json, schema_version,"
-    " hv_tier, structure_hv_payload,"
+    " structure_hv, hv_tier, structure_hv_payload,"
     " COALESCE(embedding_pending, 0) AS embedding_pending"
     " FROM records WHERE tombstoned_at IS NULL ORDER BY created_at DESC"
     " LIMIT ?"

--- a/src/iai_mcp/migrate/_reembed.py
+++ b/src/iai_mcp/migrate/_reembed.py
@@ -61,6 +61,7 @@ def _records_schema_at_dim(dim: int) -> pa.Schema:
             ("valence", pa.float32()),
             ("hv_tier", pa.string()),
             ("structure_hv_payload", pa.binary()),
+            ("embedding_pending", pa.int32()),
         ]
     )
 
@@ -146,6 +147,11 @@ def _stage_record_to_table(
         s5_trust_score=rec.s5_trust_score,
         profile_modulation_gain=rec.profile_modulation_gain,
         schema_version=rec.schema_version,
+        hv_tier=rec.hv_tier,
+        structure_hv_payload=rec.structure_hv_payload,
+        # Keep pending rows pending even though this pass writes a target-dim
+        # placeholder embedding; the normal pending drain owns readiness flips.
+        embedding_pending=rec.embedding_pending,
     )
     target_tbl.add([store._to_row(new_rec)])
 

--- a/src/iai_mcp/store/_store.py
+++ b/src/iai_mcp/store/_store.py
@@ -1044,7 +1044,7 @@ class MemoryStore:
         " stability, difficulty, last_reviewed, never_decay, never_merge,"
         " provenance_json, created_at, updated_at, tags_json, language,"
         " s5_trust_score, profile_modulation_gain_json, schema_version,"
-        " hv_tier, structure_hv_payload,"
+        " structure_hv, hv_tier, structure_hv_payload,"
         " COALESCE(embedding_pending, 0) AS embedding_pending"
     )
 
@@ -1539,6 +1539,7 @@ class MemoryStore:
             "drawer": getattr(r, "drawer", None),
             "hv_tier": r.hv_tier,
             "structure_hv_payload": bytes(r.structure_hv_payload or b""),
+            "embedding_pending": int(r.embedding_pending),
         }
 
     def _maybe_tag_schema_bypass(self, record: MemoryRecord) -> None:

--- a/tests/test_migrate_reembed_crash_safe.py
+++ b/tests/test_migrate_reembed_crash_safe.py
@@ -110,6 +110,61 @@ def test_successful_migration_promotes_old_to_records(tmp_path, monkeypatch):
     assert store.db.open_table("records").count_rows() >= 19
 
 
+def test_migration_preserves_structural_metadata_and_pending_flag(
+    tmp_path,
+    monkeypatch,
+):
+    from iai_mcp.types import MemoryRecord, STRUCTURE_HV_BYTES
+
+    src = _DimEmbedder(384)
+    target = _DimEmbedder(1024)
+    store = _fresh_store(tmp_path, 384, monkeypatch)
+    rid = uuid4()
+    now = datetime.now(timezone.utc)
+    structure_hv = b"\x02" * STRUCTURE_HV_BYTES
+    structure_payload = b'{"source":"migration-test"}'
+    rec = MemoryRecord(
+        id=rid,
+        tier="episodic",
+        literal_surface="Pending structured record survives reembed migration.",
+        aaak_index="",
+        embedding=src.embed("Pending structured record survives reembed migration."),
+        structure_hv=structure_hv,
+        community_id=None,
+        centrality=0.0,
+        detail_level=1,
+        pinned=False,
+        stability=0.5,
+        difficulty=0.3,
+        last_reviewed=now,
+        never_decay=False,
+        never_merge=False,
+        provenance=[],
+        created_at=now,
+        updated_at=now,
+        tags=["test"],
+        language="en",
+        s5_trust_score=0.5,
+        profile_modulation_gain={},
+        schema_version=4,
+        hv_tier="sparse_vsa",
+        structure_hv_payload=structure_payload,
+        embedding_pending=1,
+    )
+    store.insert(rec)
+
+    from iai_mcp.migrate import migrate_reembed_to_current_dim
+    migrate_reembed_to_current_dim(store, target)
+
+    migrated = store.get(rid)
+    assert migrated is not None
+    assert len(migrated.embedding) == target.DIM
+    assert migrated.structure_hv == structure_hv
+    assert migrated.hv_tier == "sparse_vsa"
+    assert migrated.structure_hv_payload == structure_payload
+    assert migrated.embedding_pending == 1
+
+
 def test_mid_migration_kill_preserves_old_table(tmp_path, monkeypatch):
     src = _DimEmbedder(384)
     store = _fresh_store(tmp_path, 384, monkeypatch)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 import pytest
 
 from iai_mcp.store import MemoryStore
-from iai_mcp.types import EMBED_DIM, MemoryRecord
+from iai_mcp.types import EMBED_DIM, STRUCTURE_HV_BYTES, MemoryRecord
 
 
 def _make(
@@ -100,6 +100,71 @@ def test_persistence_across_store_instances(tmp_path):
     got = store2.get(r.id)
     assert got is not None
     assert got.literal_surface == "persistent fact"
+
+
+def test_sql_record_projection_preserves_structure_and_pending(tmp_path):
+    store = MemoryStore(path=tmp_path)
+    structure_hv = b"\x01" * STRUCTURE_HV_BYTES
+    payload = b'{"tier":"sparse"}'
+    rec = _make(text="structured pending record")
+    rec.structure_hv = structure_hv
+    rec.hv_tier = "sparse_vsa"
+    rec.structure_hv_payload = payload
+    rec.embedding_pending = 1
+    store.insert(rec)
+
+    batch = store.get_batch([rec.id])
+
+    got = batch[rec.id]
+    assert got.structure_hv == structure_hv
+    assert got.hv_tier == "sparse_vsa"
+    assert got.structure_hv_payload == payload
+    assert got.embedding_pending == 1
+
+
+def test_direct_recency_projection_preserves_structure_metadata(tmp_path):
+    from iai_mcp.hippo._recall import direct_recency_rows_from_store
+
+    store = MemoryStore(path=tmp_path)
+    structure_hv = b"\x03" * STRUCTURE_HV_BYTES
+    payload = b'{"source":"direct-recency"}'
+    rec = _make(text="direct recency structured record")
+    rec.structure_hv = structure_hv
+    rec.hv_tier = "sparse_vsa"
+    rec.structure_hv_payload = payload
+    rec.embedding_pending = 1
+    store.insert(rec)
+
+    rows = direct_recency_rows_from_store(tmp_path, limit=1)
+
+    assert rows
+    row = rows[0]
+    assert row["id"] == str(rec.id)
+    assert bytes(row["structure_hv"]) == structure_hv
+    assert row["hv_tier"] == "sparse_vsa"
+    assert bytes(row["structure_hv_payload"]) == payload
+    assert int(row["embedding_pending"]) == 1
+
+
+def test_recent_pending_markers_preserve_structure_metadata(tmp_path):
+    store = MemoryStore(path=tmp_path)
+    structure_hv = b"\x04" * STRUCTURE_HV_BYTES
+    payload = b'{"source":"pending-markers"}'
+    rec = _make(text="pending marker structured record")
+    rec.structure_hv = structure_hv
+    rec.hv_tier = "sparse_vsa"
+    rec.structure_hv_payload = payload
+    rec.embedding_pending = 1
+    store.insert(rec)
+
+    markers = store.recent_pending_markers(n=5)
+
+    assert markers
+    got = next(marker for marker in markers if marker.id == rec.id)
+    assert got.structure_hv == structure_hv
+    assert got.hv_tier == "sparse_vsa"
+    assert got.structure_hv_payload == payload
+    assert got.embedding_pending == 1
 
 
 def test_uuid_literal_accepts_uuid_and_canonical_str():


### PR DESCRIPTION
## Problem

Several SQL-backed read and maintenance paths were not preserving the full structural metadata that newer recall paths rely on.

The concrete failure mode is subtle: records can carry structural fields such as `structure_hv`, `hv_tier`, and `structure_hv_payload`, and they can also be marked `embedding_pending` while a safe re-embed or migration is still in progress. Some explicit SQL projections returned only the older semantic fields, so structural recall and daemon-down fallback paths could see incomplete records.

There was also a write-path risk: normal `MemoryStore.insert()` row writes could lose the caller's `embedding_pending` value by falling back to the database default. During reembed staging, a placeholder target-dimension embedding can exist before the row is actually ready; if `embedding_pending` is lost, downstream readers may treat the row as ready too early.

## Proposed solution

This PR makes the SQL paths preserve the same structural metadata contract as the higher-level store APIs:

- include `structure_hv` in explicit SQL projections used by `get_batch`, `recent_pending_markers`, and direct recency / daemon-down reads;
- preserve `embedding_pending` on normal row writes instead of relying on the database default;
- carry `hv_tier`, `structure_hv_payload`, and `embedding_pending` through reembed staging.

The goal is not to change recall ranking. It is to make every read path see the same record shape, especially during degraded or migration paths where these SQL projections are used directly.

## Safety and behavior

Pending rows remain pending during reembed migration even if the migration writes a target-dimension placeholder embedding. The normal pending drain remains responsible for flipping readiness once the real embedding is available.

This keeps the crash-safe migration behavior intact: staging can make progress without accidentally advertising incomplete rows as ready.

## Scope

Based on `v1.2.1` / current `origin/main` (`88a0f0d`). This is independent of the daemon startup and socket-concurrency PRs.

## Verification

- `.venv/bin/python -m py_compile src/iai_mcp/store/_store.py src/iai_mcp/hippo/_recall.py src/iai_mcp/migrate/_reembed.py`
- `git diff --check`
- `.venv/bin/python -m pytest tests/test_store.py::test_sql_record_projection_preserves_structure_and_pending tests/test_store.py::test_direct_recency_projection_preserves_structure_metadata tests/test_store.py::test_recent_pending_markers_preserve_structure_metadata tests/test_migrate_reembed_crash_safe.py::test_migration_preserves_structural_metadata_and_pending_flag -q`
- `.venv/bin/python -m pytest tests/test_store.py tests/test_store_get_batch.py tests/test_migrate_reembed_crash_safe.py -q`
- `.venv/bin/python -m pytest tests/test_semantic_degraded_path.py tests/test_schema_v2.py tests/test_tem_store.py tests/test_direct_recency_read.py -q`
- `env -u IAI_RECALL_READ_TIMEOUT .venv/bin/python -m pytest -m "not perf and not slow and not live" --ignore=tests/test_embedder_numeric_parity.py`
  - `3611 passed, 32 skipped, 87 deselected, 1 xfailed`
- `env -u IAI_RECALL_READ_TIMEOUT .venv/bin/python -m pytest tests/test_embedder_numeric_parity.py -q -s`
  - `4 passed, 1 skipped`

## Cross-check

Reviewed with Claude before publishing. Claude approved this as a standalone PR and specifically asked that the PR description call out the write-path `embedding_pending` fix, because that is the part most likely to be missed in a metadata-only looking patch.

## Attribution

Designed by Marsu — Refined by Codex.

Co-Authored-By: Codex <codex@openai.com>