### PR TITLE
fix(socket): bound concurrent memory recall dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,8 @@ Measured on an Apple M2 Max (64 GB). The harnesses are the proof — run them yo
 |---|---|---|
 | `IAI_MCP_STORE` | `~/.iai-mcp/` | Data directory |
 | `IAI_MCP_PYTHON` | — | Absolute path to the venv Python (for the MCP host config) |
+| `IAI_MCP_RECALL_CONCURRENCY` | `2` | Maximum cued `memory_recall` calls dispatched concurrently by the socket daemon |
+| `IAI_MCP_RECALL_SLOT_WAIT_SEC` | `0.25` | How long an overflow cued recall waits for a slot before returning `_degraded: recall_busy` |
 
 The old `IAI_MCP_EMBED_MODEL` knob is gone — the embedder is a single built-in English-only model. There are many internal tuning knobs (`IAI_MCP_*`), but you shouldn't need to touch them.
 

--- a/src/iai_mcp/cli/__init__.py
+++ b/src/iai_mcp/cli/__init__.py
@@ -130,8 +130,8 @@ def _send_jsonrpc_request(
         finally:
             try:
                 writer.close()
-                await writer.wait_closed()
-            except OSError:
+                await asyncio.wait_for(writer.wait_closed(), timeout=0.25)
+            except (OSError, asyncio.TimeoutError):
                 pass
 
     try:
@@ -162,8 +162,8 @@ def _send_socket_request(req: dict, *, timeout: float = 30.0) -> dict | None:
         finally:
             try:
                 writer.close()
-                await writer.wait_closed()
-            except OSError:
+                await asyncio.wait_for(writer.wait_closed(), timeout=0.25)
+            except (OSError, asyncio.TimeoutError):
                 pass
 
     return asyncio.run(_runner())

--- a/src/iai_mcp/socket_server.py
+++ b/src/iai_mcp/socket_server.py
@@ -21,6 +21,25 @@ ERR_INVALID_PARAMS = -32602
 ERR_PARSE_ERROR = -32700
 
 IDLE_SECS_DEFAULT = 1800
+RECALL_BUSY_REASON = "recall_busy"
+RECALL_CONCURRENCY_DEFAULT = 2
+RECALL_SLOT_WAIT_SEC_DEFAULT = 0.25
+
+
+def _env_int(name: str, default: int, *, minimum: int = 1) -> int:
+    try:
+        value = int(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        value = default
+    return max(minimum, value)
+
+
+def _env_float(name: str, default: float, *, minimum: float = 0.0) -> float:
+    try:
+        value = float(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        value = default
+    return max(minimum, value)
 
 
 def _inherit_activated_socket() -> socket.socket | None:
@@ -73,10 +92,43 @@ class SocketServer:
         if idle_secs is None:
             idle_secs = IDLE_SECS_DEFAULT
         self.idle_secs = idle_secs
+        self._recall_slots = asyncio.Semaphore(
+            _env_int("IAI_MCP_RECALL_CONCURRENCY", RECALL_CONCURRENCY_DEFAULT)
+        )
+        self._recall_slot_wait_sec = _env_float(
+            "IAI_MCP_RECALL_SLOT_WAIT_SEC",
+            RECALL_SLOT_WAIT_SEC_DEFAULT,
+        )
         self.last_activity_ts: float = time.monotonic()
         self.active_connections: int = 0
         self.shutdown_event: asyncio.Event = asyncio.Event()
         self._state = state
+
+    async def _dispatch_jsonrpc_method(self, method: str, params: dict) -> Any:
+        from iai_mcp.core import dispatch
+
+        if method != "memory_recall" or "cue" not in params:
+            return await asyncio.to_thread(dispatch, self.store, method, params)
+
+        try:
+            await asyncio.wait_for(
+                self._recall_slots.acquire(),
+                timeout=max(self._recall_slot_wait_sec, 0.001),
+            )
+        except asyncio.TimeoutError:
+            return {
+                "hits": [],
+                "anti_hits": [],
+                "activation_trace": [],
+                "budget_used": 0,
+                "_degraded": True,
+                "_reason": RECALL_BUSY_REASON,
+            }
+
+        try:
+            return await asyncio.to_thread(dispatch, self.store, method, params)
+        finally:
+            self._recall_slots.release()
 
     async def handle(
         self,
@@ -157,10 +209,7 @@ class SocketServer:
                 # here, so they no longer keep the daemon awake.
                 self.last_activity_ts = time.monotonic()
                 try:
-                    from iai_mcp.core import dispatch
-                    result = await asyncio.to_thread(
-                        dispatch, self.store, method, params,
-                    )
+                    result = await self._dispatch_jsonrpc_method(method, params)
                     resp = {"jsonrpc": "2.0", "id": req_id, "result": result}
                 except UnknownMethodError as e:
                     resp = {

--- a/tests/test_iai_recall_fail_fast.py
+++ b/tests/test_iai_recall_fail_fast.py
@@ -111,6 +111,7 @@ def _hermetic_env(monkeypatch, tmp_path: Path):
     monkeypatch.setenv("HOME", str(fake_home))
     monkeypatch.setenv("IAI_MCP_STORE", str(tmp_path / "store"))
     monkeypatch.delenv("IAI_DAEMON_SOCKET_PATH", raising=False)
+    monkeypatch.delenv("IAI_RECALL_READ_TIMEOUT", raising=False)
     yield
 
 

--- a/tests/test_socket_server_dispatch.py
+++ b/tests/test_socket_server_dispatch.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import os
 import tempfile
+import threading
 from pathlib import Path
 
 import pytest
@@ -139,6 +140,65 @@ def test_memory_recall_routed_over_socket(short_socket_paths):
     assert resp["id"] == 1, resp
     assert "result" in resp, resp
     assert "hits" in resp["result"], resp["result"]
+
+
+def test_memory_recall_socket_concurrency_limit_returns_busy(
+    short_socket_paths,
+    monkeypatch,
+):
+    _, sock_path, _ = short_socket_paths
+    from iai_mcp import core
+    from iai_mcp.store import MemoryStore
+
+    monkeypatch.setenv("IAI_MCP_RECALL_CONCURRENCY", "1")
+    monkeypatch.setenv("IAI_MCP_RECALL_SLOT_WAIT_SEC", "0.02")
+
+    slow_started = threading.Event()
+    release_slow = threading.Event()
+    calls: list[str] = []
+
+    def _dispatch(store, method, params):
+        assert method == "memory_recall"
+        cue = params["cue"]
+        calls.append(cue)
+        if cue == "slow":
+            slow_started.set()
+            assert release_slow.wait(timeout=2.0)
+        return {"hits": [], "_recall_latency_ms": 0.1, "cue": cue}
+
+    monkeypatch.setattr(core, "dispatch", _dispatch)
+    store = MemoryStore()
+
+    async def _runner(sock_path, store):
+        slow_task = asyncio.create_task(
+            _send_jsonrpc(
+                sock_path,
+                "memory_recall",
+                {"cue": "slow", "budget_tokens": 100},
+                req_id=11,
+                timeout=2.0,
+            )
+        )
+        assert await asyncio.to_thread(slow_started.wait, 2.0)
+        busy = await _send_jsonrpc(
+            sock_path,
+            "memory_recall",
+            {"cue": "busy", "budget_tokens": 100},
+            req_id=12,
+            timeout=2.0,
+        )
+        release_slow.set()
+        slow = await slow_task
+        return slow, busy
+
+    slow, busy = asyncio.run(_with_socket_server(sock_path, store, _runner))
+
+    assert slow["result"]["cue"] == "slow"
+    assert busy["result"]["hits"] == []
+    assert busy["result"]["_degraded"] is True
+    assert busy["result"]["_reason"] == "recall_busy"
+    assert calls == ["slow"]
+
 
 def test_session_start_payload_routed(short_socket_paths):
     _, sock_path, _ = short_socket_paths


### PR DESCRIPTION
## Problem

`memory_recall` is the most expensive MCP request path, and the socket daemon previously treated concurrent cued recalls like any other JSON-RPC method: every request could immediately enter `dispatch()` in a worker thread.

That is fine for isolated calls, but it becomes fragile during bursty client behavior. A few simultaneous recall requests can pile up expensive recall work, compete for CPU, and make the daemon slower at serving the very client traffic that should keep it responsive. In the worst case, overload looks like a hang rather than an honest degraded response.

There was also a smaller fail-fast issue on the CLI side: socket cleanup called `writer.wait_closed()` without a bound. If the peer or platform got stuck during close, a path that was supposed to fail quickly could still wait too long.

## Proposed solution

This PR adds a narrow backpressure layer only around cued `memory_recall` dispatches:

- allow a small number of cued recalls to run concurrently (`IAI_MCP_RECALL_CONCURRENCY`, default `2`);
- wait briefly for a recall slot (`IAI_MCP_RECALL_SLOT_WAIT_SEC`, default `0.25`);
- if no slot is available, return an explicit degraded empty recall with `_reason: recall_busy`;
- keep non-recall methods, and malformed / cue-less recall validation, on the existing dispatch path;
- bound CLI socket `wait_closed()` cleanup to keep fail-fast behavior actually bounded.

The intent is to make overload explicit and cheap instead of letting recall work queue unboundedly behind the socket server.

## Safety and behavior

A burst of more than two cued recalls within the slot wait window can now receive:

```json
{"hits": [], "_degraded": true, "_reason": "recall_busy"}
```

That is intentional. Normal single-client recall remains unchanged, while overload degrades honestly as an empty recall instead of silently accumulating background work.

The response shape follows the existing degraded recall pattern (`hits: []`, `_degraded: true`, `_reason: ...`), so current clients continue to handle it like a no-match / degraded recall. The new test also verifies that the overflow request never reaches `dispatch()`, which is the important backpressure invariant.

## Scope

This is independent of #38 and #39. It does not include the older personal/noise-filtering branch work, nor the old core/store/top_k changes from the historical branch. Those were either already upstreamed, split into earlier PRs, or intentionally left out.

Only source, tests, and README documentation for the new operator knobs are included.

## Verification

- `.venv/bin/python -m py_compile src/iai_mcp/socket_server.py src/iai_mcp/cli/__init__.py`
- `git diff --check`
- `.venv/bin/python -m pytest tests/test_socket_server_dispatch.py tests/test_iai_recall_fail_fast.py -q`
  - `15 passed in 2.90s`
- `env -u IAI_RECALL_READ_TIMEOUT .venv/bin/python -m pytest tests/test_socket_server_dispatch.py tests/test_iai_recall_fail_fast.py tests/test_socket_activity_tracking.py tests/test_socket_disconnect_reconnect.py tests/test_socket_fail_loud.py tests/test_socket_first_store_hermeticity.py tests/test_socket_inherit_launchd_fd.py tests/test_socket_subagent_reuse.py tests/test_cli_daemon.py tests/test_cli_subprocess_daemon_down.py tests/test_client_surfaces_daemon_down.py tests/test_recall_daemon_down_degrade.py tests/test_mcp_tools.py tests/test_daemon_dispatcher.py -q`
  - `103 passed, 6 warnings in 20.89s`
- `env -u IAI_RECALL_READ_TIMEOUT .venv/bin/python -m pytest -m "not perf and not slow and not live" --ignore=tests/test_embedder_numeric_parity.py -q`
  - `3609 passed, 32 skipped, 87 deselected, 1 xfailed, 375 warnings in 840.54s (0:14:00)`
- `env -u IAI_RECALL_READ_TIMEOUT .venv/bin/python -m pytest tests/test_embedder_numeric_parity.py -q -s`
  - `4 passed, 1 skipped in 284.99s (0:04:44)`

## Cross-check

Reviewed with Claude before publishing. Claude's verdict was: correct, well-scoped, low-regression, ship as a standalone PR. Claude specifically checked the cue-less validation path, semaphore lifecycle, degraded response shape, Python 3.11 semaphore behavior, env guards, and the `IAI_RECALL_READ_TIMEOUT` hermeticity guard.

## Upstream check before publish

Immediately before opening this PR:

- latest release was still `v1.2.1` (`2026-07-01T06:03:21Z`)
- `origin/main` was `88a0f0d Release v1.2.1`
- open public PRs were only #38 and #39
- #38 and #39 were mergeable, green, and had no comments or reviews

## Attribution

Designed by Marsu — Refined by Codex.

Co-Authored-By: Codex <codex@openai.com>