### PR TITLE
fix: remove sub-second jitter from age-penalty scoring

### DIFF
--- a/src/iai_mcp/pipeline.py
+++ b/src/iai_mcp/pipeline.py
@@ -163,13 +163,18 @@ def _aaak_overlap(cue_text: str, aaak_index: str) -> float:
     return len(cue_set & idx_set) / len(cue_set | idx_set)
 
 
-def _age_penalty(created_at: datetime) -> float:
-    now = datetime.now(timezone.utc)
+def _age_penalty(created_at: datetime, now: datetime) -> float:
     if created_at.tzinfo is None:
         created_at = created_at.replace(tzinfo=timezone.utc)
-    days = (now - created_at).total_seconds() / 86400.0
-    if days < 0:
+    # Round to whole seconds: AGE_HALF_LIFE_DAYS is a days-scale constant, so
+    # sub-second creation-time jitter (e.g. between records seeded in a tight
+    # loop) carries no real signal here but is fine-grained enough to break
+    # float-equality ties between otherwise-identical records, non-reproducibly,
+    # since it depends on the exact instant `now` happens to be read.
+    seconds = round((now - created_at).total_seconds())
+    if seconds < 0:
         return 0.0
+    days = seconds / 86400.0
     return min(1.0, days / AGE_HALF_LIFE_DAYS)
 
 
@@ -735,6 +740,8 @@ def _recall_core(
 
     corrector_base_score: dict[str, float] = {}
 
+    _scoring_now = datetime.now(timezone.utc)
+
     scored: list[tuple[float, UUID, float, float, float, float, float, float]] = []
     if reachable_indices.size:
         from iai_mcp.hebbian_structure import structural_similarity
@@ -747,7 +754,7 @@ def _recall_core(
             cos = float(shared_cos[i])
             aaak = _aaak_overlap(cue, rec.aaak_index)
             deg = float(degree.get(str(cid), 0))
-            age = _age_penalty(rec.created_at)
+            age = _age_penalty(rec.created_at, _scoring_now)
             if log_max_deg > 0.0:
                 deg_norm = log(1.0 + deg) / log_max_deg
             else:

--- a/tests/test_rank_vectorized.py
+++ b/tests/test_rank_vectorized.py
@@ -179,7 +179,7 @@ def test_R4_empty_reachable_returns_empty_hits(tmp_path: Path):
 
 def test_R5_tie_break_deterministic_by_uuid(tmp_path: Path, monkeypatch):
     import iai_mcp.pipeline as _p
-    monkeypatch.setattr(_p, "_age_penalty", lambda _ts: 0.0)
+    monkeypatch.setattr(_p, "_age_penalty", lambda _ts, _now: 0.0)
 
     store = MemoryStore(path=tmp_path / "lancedb")
     store.root = tmp_path


### PR DESCRIPTION
## Summary
- \`_age_penalty()\` re-read the wall clock (\`datetime.now()\`) separately for every candidate record inside the scoring loop, and again on every separate \`recall_for_response\` call. Since \`AGE_HALF_LIFE_DAYS = 30.0\`, sub-second timing jitter between records seeded microseconds apart (e.g. in a tight test-setup loop) carries no real signal, but it's fine-grained enough to break float-equality ties between otherwise score-identical records — and non-reproducibly so, since it depends on the exact instant each call happens to read the clock.
- This caused flaky tie-break ordering when comparing two logically-equivalent \`recall_for_response\` calls (e.g. \`profile_state={}\` vs. \`profile_state={"literal_preservation": "medium"}\`, which should resolve identically).
- Fix: \`_age_penalty\` now takes \`now\` as a parameter, computed once per \`recall_for_response\` call instead of once per record, and rounds the elapsed time to whole seconds before dividing by the half-life. This removes the meaningless sub-second noise while preserving real day-scale age differentiation.
- Also updated \`tests/test_rank_vectorized.py\`'s \`test_R5_tie_break_deterministic_by_uuid\` monkeypatch to match the new two-arg signature — this test already existed specifically to pin down deterministic tie-breaking, which validates the fix direction.

## Test plan
- [x] Previously-flaky \`test_empty_profile_state_falls_back_to_medium_scale\`: 15/15 passed locally (was failing ~60% of runs before the fix)
- [x] Full \`tests/test_pipeline_knob_modulates_w_degree.py\`: 8/8 passed
- [x] \`test_R5_tie_break_deterministic_by_uuid\` (run with \`--perf\`): passed