### PR TITLE
Windows: watchdog self-kill must os._exit, not no-op sys.exit from a bg thread

### DIFF
--- a/src/iai_mcp/daemon/_watchdog.py
+++ b/src/iai_mcp/daemon/_watchdog.py
@@ -593,7 +593,14 @@ def _self_kill(reason: str, kind: str) -> None:
     if hasattr(signal, "SIGKILL"):
         os.kill(os.getpid(), signal.SIGKILL)
     else:
-        sys.exit(1)
+        # Windows has no SIGKILL. The watchdog runs in a background thread
+        # (name="iai-liveness-watchdog", daemon=True), so sys.exit() would only
+        # raise SystemExit in *this* thread and leave the wedged daemon process
+        # alive -- and Task Scheduler's IgnoreNew policy then silently refuses to
+        # start a replacement. os._exit() terminates the whole process
+        # immediately from any thread, bypassing interpreter shutdown that could
+        # itself hang on the same wedge we are trying to escape.
+        os._exit(1)
 
 
 def _capture_blackbox(

--- a/tests/test_daemon_watchdog.py
+++ b/tests/test_daemon_watchdog.py
@@ -509,6 +509,38 @@ def test_self_kill_direct_breadcrumb_failure_still_kills(tmp_path, monkeypatch):
     assert kill_calls == [(os.getpid(), signal.SIGKILL)]
 
 
+def test_self_kill_uses_os_exit_when_sigkill_unavailable(monkeypatch):
+    """Windows path: with no signal.SIGKILL, _self_kill must terminate the whole
+    process via os._exit -- which works from the background watchdog thread --
+    and must NOT fall back to sys.exit, which only unwinds the calling thread and
+    leaves a wedged daemon alive (Task Scheduler's IgnoreNew policy then refuses
+    to start a replacement). Unlike the SIGKILL tests above, this is NOT gated on
+    the platform: it simulates the no-SIGKILL branch so the Windows path -- which
+    previously had zero coverage, which is how the no-op self-kill shipped -- is
+    exercised on every runner.
+    """
+    import sys as _sys
+
+    # Simulate Windows: the signal module exposes no SIGKILL.
+    monkeypatch.delattr(signal, "SIGKILL", raising=False)
+
+    exit_calls: list[int] = []
+    monkeypatch.setattr(daemon.os, "_exit", lambda code: exit_calls.append(code))
+    monkeypatch.setattr(
+        daemon.os,
+        "kill",
+        lambda *a, **k: pytest.fail("os.kill must not run when SIGKILL is absent"),
+    )
+    monkeypatch.setattr(
+        _sys,
+        "exit",
+        lambda *a, **k: pytest.fail("sys.exit is a no-op from the watchdog thread"),
+    )
+
+    daemon._self_kill("wedge", daemon.DAEMON_WEDGE_KILL)
+    assert exit_calls == [1]
+
+
 def test_probe_returns_false_when_no_socket(tmp_path, monkeypatch):
     sock_path = str(tmp_path / "absent.sock")
     # Isolate the endpoint so the probe can't reach a real daemon on this box.


### PR DESCRIPTION
## Problem

The liveness watchdog can detect a wedged daemon but fails to actually kill it on Windows, so the daemon stays down until a manual `taskkill`.

The watchdog runs in a background daemon thread (`name="iai-liveness-watchdog"`, `daemon/__init__.py`). When it decides to kill, `_self_kill()` in `daemon/_watchdog.py` branches on `hasattr(signal, "SIGKILL")`:

```python
if hasattr(signal, "SIGKILL"):
    os.kill(os.getpid(), signal.SIGKILL)   # POSIX: signals the whole process
else:
    sys.exit(1)                            # Windows: NO-OP from a bg thread
```

On Windows there is no `SIGKILL`, so it falls to `sys.exit(1)` — which only raises `SystemExit` in the **calling thread**. From the background watchdog thread that unwinds the thread, not the process, so the wedged daemon keeps running. Task Scheduler's `<MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>` then treats the task as still "Running" and silently refuses to start a replacement, so the daemon stays down until someone kills the zombie by hand.

Observed in the wild: watchdog logs `daemon_wedge_kill pid=<pid>` (intent recorded) but the process with that pid is still alive minutes later.

## Fix

Use `os._exit(1)` on the no-`SIGKILL` path. It terminates the whole process immediately from any thread and bypasses interpreter shutdown — which is what you want here, since normal cleanup could itself hang on the same wedge the watchdog is escaping. POSIX behavior (`SIGKILL`) is unchanged.

## Test

The three existing `_self_kill` tests are all gated on `@_REQUIRES_SIGKILL`, so they **skip on Windows** — which is precisely why the no-op path shipped uncaught. The new test simulates the no-`SIGKILL` branch (via `monkeypatch.delattr(signal, "SIGKILL")`) so it runs on **every** platform, and asserts `_self_kill` calls `os._exit` and never `sys.exit`/`os.kill`. Verified both ways: passes on the fix, fails against the pre-fix source with `Failed: sys.exit is a no-op from the watchdog thread`.

Windows-only behavior change; POSIX paths are unaffected.
