### PR TITLE
Fix/episodic capture timestamp and dedup guard

### DIFF
--- a/src/iai_mcp/migrate/_timestamps.py
+++ b/src/iai_mcp/migrate/_timestamps.py
@@ -70,6 +70,12 @@ def _find_transcript_ts(
                     # the hash matches what was actually stored as literal_surface.
                     msg = obj.get("message")
                     msg = msg if isinstance(msg, dict) else obj
+                    # Internal events (e.g. queue-operation) can carry the same
+                    # text as the real user/assistant turn but appear earlier
+                    # in the file; skip them so the real turn's timestamp wins.
+                    role = obj.get("type") or msg.get("role", "")
+                    if role not in {"user", "assistant"}:
+                        continue
                     content = msg.get("content", "")
                     if isinstance(content, list):
                         parts = []

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -529,6 +529,59 @@ def test_migrate_rederive_content_hash_fallback_matches_nested_message(tmp_path)
         assert ts != collapsed_ts
 
 
+def test_migrate_rederive_skips_internal_event_duplicate(tmp_path):
+    """An internal queue-operation line earlier in the transcript must not win
+    the content-hash match over the real user turn with the same text —
+    otherwise rederive re-derives the same already-collapsed timestamp.
+    Mirrors a real collapsed group: several duplicate episodic records sharing
+    both the collapsed created_at and identical literal_surface content."""
+    from iai_mcp.migrate import migrate_rederive_collapsed_timestamps
+    from iai_mcp.store import MemoryStore
+
+    store = MemoryStore(path=tmp_path)
+    session_id = "sess-internal-dup"
+    transcript_root = tmp_path / "transcripts"
+
+    collapsed_ts = datetime(2026, 6, 20, 21, 11, 0, 188000, tzinfo=timezone.utc)
+    text = "Duplicate task-notification payload"
+
+    # No source_uuid recorded in provenance — forces the content-hash fallback.
+    # Group size >= 3 to qualify as a collapsed-timestamp candidate.
+    records = [_make_episodic_record(text, session_id, "", collapsed_ts) for _ in range(3)]
+    for r in records:
+        store.insert(r)
+
+    real_ts_str = "2026-06-20T21:11:00.723000Z"
+    transcript_entries = [
+        # Internal event carrying the same text, earlier in the file, at the
+        # collapsed timestamp — must be skipped.
+        {
+            "type": "queue-operation",
+            "timestamp": "2026-06-20T21:11:00.188000Z",
+            "sessionId": session_id,
+            "message": {"content": text},
+        },
+        # The real user turn, a moment later, at the correct timestamp.
+        {
+            "type": "user",
+            "timestamp": real_ts_str,
+            "sessionId": session_id,
+            "uuid": str(uuid4()),
+            "message": {"role": "user", "content": text},
+        },
+    ]
+    _write_fake_transcript(transcript_root, session_id, transcript_entries)
+
+    result = migrate_rederive_collapsed_timestamps(store, transcript_root=transcript_root)
+
+    assert result["records_updated"] == 3
+    expected_ts = datetime(2026, 6, 20, 21, 11, 0, 723000, tzinfo=timezone.utc)
+    for r in records:
+        updated = store.get(r.id)
+        assert updated.created_at != collapsed_ts
+        assert updated.created_at == expected_ts
+
+
 def test_migrate_rederive_writes_event(tmp_path):
     """A migration_rederive_timestamps event is written after a non-dry run."""
     from iai_mcp.events import query_events


### PR DESCRIPTION
## Summary

  - Fix `_find_transcript_ts`'s content-hash fallback in `migrate --rederive-timestamps` so it no longer matches an internal transcript event (e.g. `queue-operation`) ahead of the real `user`/`assistant` turn when both carry identical text.
  - Add a regression test reproducing a real collapsed-timestamp group where this caused the migration to silently re-derive the same already-collapsed timestamp on every run.

## Motivation

  `iai-mcp doctor`'s collapsed-timestamp check can report groups that `migrate --rederive-timestamps` never clears, even though the migration reports`records_updated` > 0 each run. Root cause: the migration's content-hash matcher scans transcript lines top-to-bottom and returns on the first hash match, with no filter on line type. When an internal event (e.g. `queue-operation`) carries the same duplicated text as the real turn and appears earlier in the transcript file, the matcher locks onto it and returns its timestamp instead — which is the same collapsed value the record already has. The write is a no-op, but the function still counts it as updated.

  The original capture path (`capture_deferred_captures` in `capture.py`) already filters transcript lines to `type/role in {"user", "assistant"}` before considering them; the migration's independent matcher never had that guard.

## Changes

  - `src/iai_mcp/migrate/_timestamps.py`: filter candidate transcript lines to `user`/`assistant` type/role before content-hash comparison, mirroring the existing guard in `capture.py`.
  - `tests/test_migrate.py`: new test `test_migrate_rederive_skips_internal_event_duplicate` — builds a collapsed group of 3 duplicate episodic records with no `source_uuid` (forcing content-hash fallback) against a transcript containing an earlier `queue-operation` line and a later real `user` line with identical text, and asserts the migration resolves to the real turn's timestamp, not the collapsed one.

## Test plan

  - [x] `pytest tests/test_migrate.py` — 25 passed
  - [x] Confirmed the new test fails against the pre-fix matcher and passes with the fix
  - [x] `ruff check` / `ruff format --check` on changed files show only pre-existing findings already present on `main`, unrelated to this diff

  No bench re-run included — this is a data-repair migration correctness fix, not a retrieval/capture/consolidation performance change.

## Note

  This doesn't fully resolve `doctor`'s collapsed-timestamp warning for groups that are true duplicate records (same content+provenance) rather than distinct turns sharing a bad timestamp — those still need `migrate --dedupe-episodic` to collapse the duplicates themselves. This PR only fixes the matcher so rederive stops silently no-op'ing on genuinely distinct turns that happen to share text with an internal event.
