### PR TITLE
Deflake centrality-child RSS isolation proof (best-of-N per arm)

### DIFF
--- a/tests/test_runtime_graph_centrality_child.py
+++ b/tests/test_runtime_graph_centrality_child.py
@@ -516,15 +516,25 @@ def test_parent_rss_lower_with_centrality_child(store: MemoryStore):
     the detection child to also run in-process (so detection arenas AND the
     betweenness intermediate are reserved in the parent); the isolated arm uses
     the real spawn-context children for both. Each arm subtracts a fresh settled
-    baseline so it only measures the resident growth it itself retains.
+    baseline so it only measures the resident growth it itself retains, and is
+    sampled n_samples times with the minimum taken (see below) so one-sided
+    measurement noise can't invert the comparison.
     """
     import iai_mcp.community as _cm
 
     n_records = 3000
+    # Best-of-N de-noise: settled-RSS noise is one-sided — transient allocations
+    # and allocator arena retention only ever *inflate* the measured resident
+    # delta, never deflate it below what the arm genuinely keeps. So the minimum
+    # delta across repeated identical builds is the cleanest estimate of each
+    # arm's true retained footprint, and comparing the minima removes the
+    # single-sample spikes that made this proof flip intermittently (a ~3MB blip
+    # on a ~65MB delta was enough to invert it on some CI runs).
+    n_samples = 3
 
-    def _build_arm(seed_base: int, in_parent: bool) -> int:
-        s = MemoryStore(path=store.root / f"arm-{seed_base}-{in_parent}")
-        s.root = store.root / f"arm-root-{seed_base}-{in_parent}"
+    def _build_arm(seed_base: int, in_parent: bool, rep: int) -> int:
+        s = MemoryStore(path=store.root / f"arm-{seed_base}-{in_parent}-{rep}")
+        s.root = store.root / f"arm-root-{seed_base}-{in_parent}-{rep}"
         s.root.mkdir(parents=True, exist_ok=True)
         _seed_store(s, n=n_records, seed_base=seed_base)
 
@@ -552,18 +562,26 @@ def test_parent_rss_lower_with_centrality_child(store: MemoryStore):
             settled = _settled_rss_bytes()
         return settled - baseline
 
-    in_parent_delta = _build_arm(seed_base=20_000, in_parent=True)
-    gc.collect()
-    _settled_rss_bytes()
+    def _min_delta(seed_base: int, in_parent: bool) -> int:
+        best: int | None = None
+        for rep in range(n_samples):
+            gc.collect()
+            _settled_rss_bytes()
+            delta = _build_arm(seed_base, in_parent, rep)
+            best = delta if best is None else min(best, delta)
+        assert best is not None
+        return best
 
-    isolated_delta = _build_arm(seed_base=60_000, in_parent=False)
+    in_parent_delta = _min_delta(seed_base=20_000, in_parent=True)
+    isolated_delta = _min_delta(seed_base=60_000, in_parent=False)
 
     print(
         f"\n[centrality-rss] in_parent_delta={in_parent_delta / 1e6:.1f}MB "
-        f"isolated_delta={isolated_delta / 1e6:.1f}MB"
+        f"isolated_delta={isolated_delta / 1e6:.1f}MB (min of {n_samples})"
     )
     assert isolated_delta < in_parent_delta, (
-        f"centrality child isolation did not lower the parent footprint: "
+        f"centrality child isolation did not lower the parent footprint "
+        f"(min of {n_samples}): "
         f"in_parent_delta={in_parent_delta / 1e6:.1f}MB "
         f"isolated_delta={isolated_delta / 1e6:.1f}MB"
     )


### PR DESCRIPTION
## Problem

`test_parent_rss_lower_with_centrality_child` flakes on macOS CI. Recent failure:

```
AssertionError: centrality child isolation did not lower the parent footprint:
in_parent_delta=64.9MB isolated_delta=68.0MB
```

That's a ~3MB inversion on a ~65MB measurement — allocator noise, not a real regression. The test already flags itself as allocator-sensitive (`skipif(platform.system() != "Darwin", reason="settled-RSS isolation proof calibrated on this host's allocator")`), and it passes on the overwhelming majority of runs; a single noisy sample per arm is enough to flip the `isolated_delta < in_parent_delta` assertion.

## Fix

Settled-RSS noise is **one-sided**: transient allocations and allocator arena retention only ever *inflate* the measured resident delta — they never make an arm report *less* than it genuinely keeps resident. So the **minimum** delta across repeated identical builds is the cleanest estimate of each arm's true retained footprint.

Sample each arm `n_samples = 3` times (fresh store per rep, same deterministic corpus) and compare the minima. This removes the single-sample spikes that cause the intermittent inversion while preserving the proof's intent — the isolated arm must still genuinely retain less than the in-parent arm.

Pure test change; no production code is touched. The extra builds add a small amount of runtime to this one Darwin-only test.

## Verification

This test is `skipif != Darwin`, so it can't run off macOS — I verified the module compiles and still collects cleanly, and rely on this PR's macOS CI run for the behavioral check. If the isolation savings turn out to be genuinely marginal at `n_records=3000` (rather than noise), the min-of-3 comparison will surface that deterministically instead of flaking.
