### PR TITLE
Linux: Idle sensing feature similar to HID idleness in macOS

### DIFF
--- a/src/iai_mcp/doctor/_lifecycle_checks.py
+++ b/src/iai_mcp/doctor/_lifecycle_checks.py
@@ -524,17 +524,12 @@ def check_n_hid_idle_source() -> CheckResult:
     detector = IdleDetector()
     status = detector.status()
 
-    idle_str = (
-        f"{status.hid_idle_sec}s"
-        if status.hid_idle_sec is not None
-        else "unavailable"
-    )
     signals_str = (
         ",".join(status.available_signals) if status.available_signals else "none"
     )
 
     if "logind" in status.available_signals:
-        logind_str = (
+        idle_str = (
             f"{status.hid_idle_sec}s"
             if status.hid_idle_sec is not None
             else "not idle"
@@ -542,10 +537,15 @@ def check_n_hid_idle_source() -> CheckResult:
         return CheckResult(
             name="(n) HID idle source",
             passed=True,
-            detail=f"logind IdleHint: {logind_str}, available: {signals_str}",
+            detail=f"logind IdleHint: {idle_str}, available: {signals_str}",
             status="PASS",
         )
 
+    idle_str = (
+        f"{status.hid_idle_sec}s"
+        if status.hid_idle_sec is not None
+        else "unavailable"
+    )
     pmset_str = "recent-sleep" if status.pmset_recent_sleep else "clean"
     detail = (
         f"HIDIdleTime: {idle_str}, pmset: {pmset_str}, available: {signals_str}"

--- a/src/iai_mcp/doctor/_lifecycle_checks.py
+++ b/src/iai_mcp/doctor/_lifecycle_checks.py
@@ -524,17 +524,31 @@ def check_n_hid_idle_source() -> CheckResult:
     detector = IdleDetector()
     status = detector.status()
 
-    hid_str = (
+    idle_str = (
         f"{status.hid_idle_sec}s"
         if status.hid_idle_sec is not None
         else "unavailable"
     )
-    pmset_str = "recent-sleep" if status.pmset_recent_sleep else "clean"
     signals_str = (
         ",".join(status.available_signals) if status.available_signals else "none"
     )
+
+    if "logind" in status.available_signals:
+        logind_str = (
+            f"{status.hid_idle_sec}s"
+            if status.hid_idle_sec is not None
+            else "not idle"
+        )
+        return CheckResult(
+            name="(n) HID idle source",
+            passed=True,
+            detail=f"logind IdleHint: {logind_str}, available: {signals_str}",
+            status="PASS",
+        )
+
+    pmset_str = "recent-sleep" if status.pmset_recent_sleep else "clean"
     detail = (
-        f"HIDIdleTime: {hid_str}, pmset: {pmset_str}, available: {signals_str}"
+        f"HIDIdleTime: {idle_str}, pmset: {pmset_str}, available: {signals_str}"
     )
 
     if "HIDIdleTime" in status.available_signals:

--- a/src/iai_mcp/doctor/_lifecycle_checks.py
+++ b/src/iai_mcp/doctor/_lifecycle_checks.py
@@ -536,14 +536,14 @@ def check_n_hid_idle_source() -> CheckResult:
     )
     pmset_str = "recent-sleep" if status.pmset_recent_sleep else "clean"
 
-    if "logind" in status.available_signals:
-        detail = f"logind IdleHint: {idle_str('not idle')}, available: {signals_str}"
-        result_status = "PASS"
-    elif "HIDIdleTime" in status.available_signals:
+    if "HIDIdleTime" in status.available_signals:
         detail = (
             f"HIDIdleTime: {idle_str('unavailable')}, pmset: {pmset_str}, "
             f"available: {signals_str}"
         )
+        result_status = "PASS"
+    elif "logind" in status.available_signals:
+        detail = f"logind IdleHint: {idle_str('not idle')}, available: {signals_str}"
         result_status = "PASS"
     else:
         detail = (

--- a/src/iai_mcp/doctor/_lifecycle_checks.py
+++ b/src/iai_mcp/doctor/_lifecycle_checks.py
@@ -524,47 +524,37 @@ def check_n_hid_idle_source() -> CheckResult:
     detector = IdleDetector()
     status = detector.status()
 
+    def idle_str(none_label: str) -> str:
+        return (
+            f"{status.hid_idle_sec}s"
+            if status.hid_idle_sec is not None
+            else none_label
+        )
+
     signals_str = (
         ",".join(status.available_signals) if status.available_signals else "none"
     )
 
     if "logind" in status.available_signals:
-        idle_str = (
-            f"{status.hid_idle_sec}s"
-            if status.hid_idle_sec is not None
-            else "not idle"
+        detail = f"logind IdleHint: {idle_str('not idle')}, available: {signals_str}"
+        result_status = "PASS"
+    else:
+        pmset_str = "recent-sleep" if status.pmset_recent_sleep else "clean"
+        detail = (
+            f"HIDIdleTime: {idle_str('unavailable')}, pmset: {pmset_str}, "
+            f"available: {signals_str}"
         )
-        return CheckResult(
-            name="(n) HID idle source",
-            passed=True,
-            detail=f"logind IdleHint: {idle_str}, available: {signals_str}",
-            status="PASS",
-        )
+        if "HIDIdleTime" in status.available_signals:
+            result_status = "PASS"
+        else:
+            detail = f"{detail}; L6 will fall back to heartbeat-idle only"
+            result_status = "WARN"
 
-    idle_str = (
-        f"{status.hid_idle_sec}s"
-        if status.hid_idle_sec is not None
-        else "unavailable"
-    )
-    pmset_str = "recent-sleep" if status.pmset_recent_sleep else "clean"
-    detail = (
-        f"HIDIdleTime: {idle_str}, pmset: {pmset_str}, available: {signals_str}"
-    )
-
-    if "HIDIdleTime" in status.available_signals:
-        return CheckResult(
-            name="(n) HID idle source",
-            passed=True,
-            detail=detail,
-            status="PASS",
-        )
     return CheckResult(
         name="(n) HID idle source",
         passed=True,
-        detail=(
-            f"{detail}; L6 will fall back to heartbeat-idle only"
-        ),
-        status="WARN",
+        detail=detail,
+        status=result_status,
     )
 
 

--- a/src/iai_mcp/doctor/_lifecycle_checks.py
+++ b/src/iai_mcp/doctor/_lifecycle_checks.py
@@ -534,21 +534,23 @@ def check_n_hid_idle_source() -> CheckResult:
     signals_str = (
         ",".join(status.available_signals) if status.available_signals else "none"
     )
+    pmset_str = "recent-sleep" if status.pmset_recent_sleep else "clean"
 
     if "logind" in status.available_signals:
         detail = f"logind IdleHint: {idle_str('not idle')}, available: {signals_str}"
         result_status = "PASS"
-    else:
-        pmset_str = "recent-sleep" if status.pmset_recent_sleep else "clean"
+    elif "HIDIdleTime" in status.available_signals:
         detail = (
             f"HIDIdleTime: {idle_str('unavailable')}, pmset: {pmset_str}, "
             f"available: {signals_str}"
         )
-        if "HIDIdleTime" in status.available_signals:
-            result_status = "PASS"
-        else:
-            detail = f"{detail}; L6 will fall back to heartbeat-idle only"
-            result_status = "WARN"
+        result_status = "PASS"
+    else:
+        detail = (
+            f"HIDIdleTime: {idle_str('unavailable')}, pmset: {pmset_str}, "
+            f"available: {signals_str}; L6 will fall back to heartbeat-idle only"
+        )
+        result_status = "WARN"
 
     return CheckResult(
         name="(n) HID idle source",

--- a/src/iai_mcp/doctor/_lifecycle_checks.py
+++ b/src/iai_mcp/doctor/_lifecycle_checks.py
@@ -521,36 +521,7 @@ def check_l_sleep_cycle_status() -> CheckResult:
 def check_n_hid_idle_source() -> CheckResult:
     from iai_mcp.idle_detector import IdleDetector
 
-    detector = IdleDetector()
-    status = detector.status()
-
-    def idle_str(none_label: str) -> str:
-        return (
-            f"{status.hid_idle_sec}s"
-            if status.hid_idle_sec is not None
-            else none_label
-        )
-
-    signals_str = (
-        ",".join(status.available_signals) if status.available_signals else "none"
-    )
-    pmset_str = "recent-sleep" if status.pmset_recent_sleep else "clean"
-
-    if "HIDIdleTime" in status.available_signals:
-        detail = (
-            f"HIDIdleTime: {idle_str('unavailable')}, pmset: {pmset_str}, "
-            f"available: {signals_str}"
-        )
-        result_status = "PASS"
-    elif "logind" in status.available_signals:
-        detail = f"logind IdleHint: {idle_str('not idle')}, available: {signals_str}"
-        result_status = "PASS"
-    else:
-        detail = (
-            f"HIDIdleTime: {idle_str('unavailable')}, pmset: {pmset_str}, "
-            f"available: {signals_str}; L6 will fall back to heartbeat-idle only"
-        )
-        result_status = "WARN"
+    detail, result_status = IdleDetector().describe()
 
     return CheckResult(
         name="(n) HID idle source",

--- a/src/iai_mcp/idle_detector.py
+++ b/src/iai_mcp/idle_detector.py
@@ -210,12 +210,15 @@ class IdleDetector:
         """Platform dispatcher for OS-level idle time.
 
         Senses the current OS and queries whichever idle source it
-        supports, so callers never need their own platform checks. Returns
-        ``(idle_seconds, source_name)``. ``source_name`` is set whenever the
-        underlying source was reachable, even if ``idle_seconds`` is ``None``
-        (session not currently idle) -- this lets callers distinguish
-        "signal available" from "signal unavailable" without knowing which
-        platform they're on.
+        supports. Returns ``(idle_seconds, source_name)``. Functional
+        consumers that only need ``idle_seconds`` (e.g. ``sleep_eligible``)
+        are fully platform-agnostic -- they never inspect ``source_name``.
+        ``source_name`` itself is a platform-specific label (``"HIDIdleTime"``,
+        ``"logind"``), set whenever the underlying source was reachable even
+        if ``idle_seconds`` is ``None`` (session not currently idle); it
+        exists for diagnostic/reporting consumers (``status()``,
+        ``describe()``), which is also where any source-name-specific
+        formatting belongs -- not in a caller of this class.
         """
         system = platform.system()
         if system == "Darwin":
@@ -260,6 +263,44 @@ class IdleDetector:
             pmset_recent_sleep=pmset_seen,
             available_signals=signals,
         )
+
+
+    def describe(self) -> tuple[str, str]:
+        """Human-readable ``(detail, status)`` for doctor's idle-source
+        health check. Callers don't need to know which platform-specific
+        backend (HIDIdleTime, logind, ...) is actually in use -- that
+        knowledge stays here, next to the platform dispatch itself.
+        """
+        status = self.status()
+
+        def idle_str(none_label: str) -> str:
+            return (
+                f"{status.hid_idle_sec}s"
+                if status.hid_idle_sec is not None
+                else none_label
+            )
+
+        signals_str = (
+            ",".join(status.available_signals) if status.available_signals else "none"
+        )
+        pmset_str = "recent-sleep" if status.pmset_recent_sleep else "clean"
+
+        if "HIDIdleTime" in status.available_signals:
+            detail = (
+                f"HIDIdleTime: {idle_str('unavailable')}, pmset: {pmset_str}, "
+                f"available: {signals_str}"
+            )
+            return detail, "PASS"
+        if "logind" in status.available_signals:
+            detail = (
+                f"logind IdleHint: {idle_str('not idle')}, available: {signals_str}"
+            )
+            return detail, "PASS"
+        detail = (
+            f"HIDIdleTime: {idle_str('unavailable')}, pmset: {pmset_str}, "
+            f"available: {signals_str}; L6 will fall back to heartbeat-idle only"
+        )
+        return detail, "WARN"
 
 
 def _parse_pmset_timestamp(line: str) -> datetime | None:

--- a/src/iai_mcp/idle_detector.py
+++ b/src/iai_mcp/idle_detector.py
@@ -147,35 +147,39 @@ class IdleDetector:
         except json.JSONDecodeError:
             return None
 
-    def _logind_session_path(self) -> str | None:
+    def _logind_session_paths(self) -> list[str]:
         # Enumerate sessions rather than resolving "the calling process's own
         # session" (e.g. via GetSessionByPID): the daemon runs as a systemd
         # user service, not attached to any interactive session's cgroup, so
-        # a self-lookup by PID never resolves. Instead, find the caller's
-        # user's own seat-attached (interactive, non-headless) session.
+        # a self-lookup by PID never resolves. Instead, find every one of the
+        # caller's user's seat-attached (interactive, non-headless) sessions
+        # -- there can be more than one on real multi-seat hardware, and
+        # picking just one arbitrarily risks reading the wrong seat's idle
+        # state while another seat is actively in use.
         payload = self._busctl_json(
             "--system", "call",
             "org.freedesktop.login1", "/org/freedesktop/login1",
             "org.freedesktop.login1.Manager", "ListSessions",
         )
         if not isinstance(payload, dict):
-            return None
+            return []
         try:
             entries = payload["data"][0]
         except (KeyError, IndexError, TypeError):
-            return None
+            return []
         if not isinstance(entries, list):
-            return None
+            return []
 
         target_uid = os.getuid()
+        paths: list[str] = []
         for entry in entries:
             try:
                 _session_id, uid, _user, seat, path = entry
             except (ValueError, TypeError):
                 continue
             if uid == target_uid and seat:
-                return path
-        return None
+                paths.append(path)
+        return paths
 
     def _logind_get_property(self, session_path: str, prop: str) -> object | None:
         payload = self._busctl_json(
@@ -199,11 +203,22 @@ class IdleDetector:
         now_usec = int(datetime.now(timezone.utc).timestamp() * 1_000_000)
         return max(0, (now_usec - idle_since_usec) // 1_000_000)
 
-    def logind_idle_time_sec(self) -> int | None:
-        session_path = self._logind_session_path()
-        if session_path is None:
+    def _logind_aggregate_idle(self, session_paths: list[str]) -> int | None:
+        # "Idle" means every seat-attached session is idle -- a single
+        # active seat means the user isn't idle overall, regardless of how
+        # long any other seat has been untouched.
+        if not session_paths:
             return None
-        return self._logind_idle_from_session(session_path)
+        idle_times: list[int] = []
+        for path in session_paths:
+            idle_sec = self._logind_idle_from_session(path)
+            if idle_sec is None:
+                return None
+            idle_times.append(idle_sec)
+        return min(idle_times)
+
+    def logind_idle_time_sec(self) -> int | None:
+        return self._logind_aggregate_idle(self._logind_session_paths())
 
 
     def os_idle_time_sec(self) -> tuple[int | None, str | None]:
@@ -225,10 +240,10 @@ class IdleDetector:
             idle_sec = self.hid_idle_time_sec()
             return idle_sec, ("HIDIdleTime" if idle_sec is not None else None)
         if system == "Linux":
-            session_path = self._logind_session_path()
-            if session_path is None:
+            session_paths = self._logind_session_paths()
+            if not session_paths:
                 return None, None
-            return self._logind_idle_from_session(session_path), "logind"
+            return self._logind_aggregate_idle(session_paths), "logind"
         return None, None
 
 

--- a/src/iai_mcp/idle_detector.py
+++ b/src/iai_mcp/idle_detector.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import platform
 import re
@@ -23,12 +24,6 @@ _BUSCTL_TIMEOUT_SEC = 5
 _PMSET_TAIL_LINES = 200
 
 _HID_IDLE_RE = re.compile(r'"HIDIdleTime"\s*=\s*(\d+)')
-
-_LOGIND_SESSION_PATH_RE = re.compile(r'"(/org/freedesktop/login1/session/[^"]+)"')
-
-_LOGIND_BOOL_RE = re.compile(r"\bb\s+(true|false)\b")
-
-_LOGIND_UINT64_RE = re.compile(r"\bt\s+(\d+)")
 
 _PMSET_SLEEP_MARKERS = ("System Sleep", "Display is turned off")
 
@@ -129,72 +124,76 @@ class IdleDetector:
         return False
 
 
+    def _busctl_json(self, *args: str) -> object | None:
+        try:
+            result = subprocess.run(
+                [_BUSCTL_BIN, "--json=short", *args],
+                capture_output=True,
+                text=True,
+                timeout=_BUSCTL_TIMEOUT_SEC,
+                check=False,
+            )
+        except FileNotFoundError:
+            return None
+        except subprocess.TimeoutExpired:
+            return None
+        except OSError:
+            return None
+
+        if result.returncode != 0:
+            return None
+        try:
+            return json.loads(result.stdout or "")
+        except json.JSONDecodeError:
+            return None
+
     def _logind_session_path(self) -> str | None:
+        # Enumerate sessions rather than resolving "the calling process's own
+        # session" (e.g. via GetSessionByPID): the daemon runs as a systemd
+        # user service, not attached to any interactive session's cgroup, so
+        # a self-lookup by PID never resolves. Instead, find the caller's
+        # user's own seat-attached (interactive, non-headless) session.
+        payload = self._busctl_json(
+            "--system", "call",
+            "org.freedesktop.login1", "/org/freedesktop/login1",
+            "org.freedesktop.login1.Manager", "ListSessions",
+        )
+        if not isinstance(payload, dict):
+            return None
         try:
-            result = subprocess.run(
-                [
-                    _BUSCTL_BIN, "--system", "call",
-                    "org.freedesktop.login1", "/org/freedesktop/login1",
-                    "org.freedesktop.login1.Manager", "GetSessionByPID",
-                    "u", str(os.getpid()),
-                ],
-                capture_output=True,
-                text=True,
-                timeout=_BUSCTL_TIMEOUT_SEC,
-                check=False,
-            )
-        except FileNotFoundError:
+            entries = payload["data"][0]
+        except (KeyError, IndexError, TypeError):
             return None
-        except subprocess.TimeoutExpired:
-            return None
-        except OSError:
+        if not isinstance(entries, list):
             return None
 
-        if result.returncode != 0:
-            return None
-        match = _LOGIND_SESSION_PATH_RE.search(result.stdout or "")
-        return match.group(1) if match else None
+        target_uid = os.getuid()
+        for entry in entries:
+            try:
+                _session_id, uid, _user, seat, path = entry
+            except (ValueError, TypeError):
+                continue
+            if uid == target_uid and seat:
+                return path
+        return None
 
-    def _logind_get_property(self, session_path: str, prop: str) -> str | None:
-        try:
-            result = subprocess.run(
-                [
-                    _BUSCTL_BIN, "--system", "get-property",
-                    "org.freedesktop.login1", session_path,
-                    "org.freedesktop.login1.Session", prop,
-                ],
-                capture_output=True,
-                text=True,
-                timeout=_BUSCTL_TIMEOUT_SEC,
-                check=False,
-            )
-        except FileNotFoundError:
+    def _logind_get_property(self, session_path: str, prop: str) -> object | None:
+        payload = self._busctl_json(
+            "--system", "get-property",
+            "org.freedesktop.login1", session_path,
+            "org.freedesktop.login1.Session", prop,
+        )
+        if not isinstance(payload, dict):
             return None
-        except subprocess.TimeoutExpired:
-            return None
-        except OSError:
-            return None
-
-        if result.returncode != 0:
-            return None
-        return result.stdout or ""
+        return payload.get("data")
 
     def _logind_idle_from_session(self, session_path: str) -> int | None:
-        hint_out = self._logind_get_property(session_path, "IdleHint")
-        if hint_out is None:
-            return None
-        hint_match = _LOGIND_BOOL_RE.search(hint_out)
-        if hint_match is None or hint_match.group(1) != "true":
+        idle_hint = self._logind_get_property(session_path, "IdleHint")
+        if idle_hint is not True:
             return None
 
-        since_out = self._logind_get_property(session_path, "IdleSinceHint")
-        if since_out is None:
-            return None
-        since_match = _LOGIND_UINT64_RE.search(since_out)
-        if since_match is None:
-            return None
-        idle_since_usec = int(since_match.group(1))
-        if idle_since_usec <= 0:
+        idle_since_usec = self._logind_get_property(session_path, "IdleSinceHint")
+        if not isinstance(idle_since_usec, int) or idle_since_usec <= 0:
             return None
 
         now_usec = int(datetime.now(timezone.utc).timestamp() * 1_000_000)

--- a/src/iai_mcp/idle_detector.py
+++ b/src/iai_mcp/idle_detector.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import platform
 import re
 import subprocess
 from dataclasses import dataclass, field
@@ -10,13 +12,23 @@ _IOREG_BIN = "/usr/sbin/ioreg"
 
 _PMSET_BIN = "/usr/bin/pmset"
 
+_BUSCTL_BIN = "/usr/bin/busctl"
+
 _IOREG_TIMEOUT_SEC = 5
 
 _PMSET_TIMEOUT_SEC = 10
 
+_BUSCTL_TIMEOUT_SEC = 5
+
 _PMSET_TAIL_LINES = 200
 
 _HID_IDLE_RE = re.compile(r'"HIDIdleTime"\s*=\s*(\d+)')
+
+_LOGIND_SESSION_PATH_RE = re.compile(r'"(/org/freedesktop/login1/session/[^"]+)"')
+
+_LOGIND_BOOL_RE = re.compile(r"\bb\s+(true|false)\b")
+
+_LOGIND_UINT64_RE = re.compile(r"\bt\s+(\d+)")
 
 _PMSET_SLEEP_MARKERS = ("System Sleep", "Display is turned off")
 
@@ -117,29 +129,135 @@ class IdleDetector:
         return False
 
 
+    def _logind_session_path(self) -> str | None:
+        try:
+            result = subprocess.run(
+                [
+                    _BUSCTL_BIN, "--system", "call",
+                    "org.freedesktop.login1", "/org/freedesktop/login1",
+                    "org.freedesktop.login1.Manager", "GetSessionByPID",
+                    "u", str(os.getpid()),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=_BUSCTL_TIMEOUT_SEC,
+                check=False,
+            )
+        except FileNotFoundError:
+            return None
+        except subprocess.TimeoutExpired:
+            return None
+        except OSError:
+            return None
+
+        if result.returncode != 0:
+            return None
+        match = _LOGIND_SESSION_PATH_RE.search(result.stdout or "")
+        return match.group(1) if match else None
+
+    def _logind_get_property(self, session_path: str, prop: str) -> str | None:
+        try:
+            result = subprocess.run(
+                [
+                    _BUSCTL_BIN, "--system", "get-property",
+                    "org.freedesktop.login1", session_path,
+                    "org.freedesktop.login1.Session", prop,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=_BUSCTL_TIMEOUT_SEC,
+                check=False,
+            )
+        except FileNotFoundError:
+            return None
+        except subprocess.TimeoutExpired:
+            return None
+        except OSError:
+            return None
+
+        if result.returncode != 0:
+            return None
+        return result.stdout or ""
+
+    def _logind_idle_from_session(self, session_path: str) -> int | None:
+        hint_out = self._logind_get_property(session_path, "IdleHint")
+        if hint_out is None:
+            return None
+        hint_match = _LOGIND_BOOL_RE.search(hint_out)
+        if hint_match is None or hint_match.group(1) != "true":
+            return None
+
+        since_out = self._logind_get_property(session_path, "IdleSinceHint")
+        if since_out is None:
+            return None
+        since_match = _LOGIND_UINT64_RE.search(since_out)
+        if since_match is None:
+            return None
+        idle_since_usec = int(since_match.group(1))
+        if idle_since_usec <= 0:
+            return None
+
+        now_usec = int(datetime.now(timezone.utc).timestamp() * 1_000_000)
+        return max(0, (now_usec - idle_since_usec) // 1_000_000)
+
+    def logind_idle_time_sec(self) -> int | None:
+        session_path = self._logind_session_path()
+        if session_path is None:
+            return None
+        return self._logind_idle_from_session(session_path)
+
+
+    def os_idle_time_sec(self) -> tuple[int | None, str | None]:
+        """Platform dispatcher for OS-level idle time.
+
+        Senses the current OS and queries whichever idle source it
+        supports, so callers never need their own platform checks. Returns
+        ``(idle_seconds, source_name)``. ``source_name`` is set whenever the
+        underlying source was reachable, even if ``idle_seconds`` is ``None``
+        (session not currently idle) -- this lets callers distinguish
+        "signal available" from "signal unavailable" without knowing which
+        platform they're on.
+        """
+        system = platform.system()
+        if system == "Darwin":
+            idle_sec = self.hid_idle_time_sec()
+            return idle_sec, ("HIDIdleTime" if idle_sec is not None else None)
+        if system == "Linux":
+            session_path = self._logind_session_path()
+            if session_path is None:
+                return None, None
+            return self._logind_idle_from_session(session_path), "logind"
+        return None, None
+
+
     def sleep_eligible(self, heartbeat_idle_30min: bool) -> bool:
         if heartbeat_idle_30min:
             return True
 
-        hid_idle = self.hid_idle_time_sec()
-        if hid_idle is not None and hid_idle >= _HID_IDLE_THRESHOLD_SEC:
+        idle_sec, _source = self.os_idle_time_sec()
+        if idle_sec is not None and idle_sec >= _HID_IDLE_THRESHOLD_SEC:
             return True
 
-        return self.pmset_recent_sleep()
+        if platform.system() == "Darwin":
+            return self.pmset_recent_sleep()
+        return False
 
 
     def status(self) -> IdleStatus:
-        hid_idle = self.hid_idle_time_sec()
-        pmset_seen = self.pmset_recent_sleep()
+        idle_sec, source = self.os_idle_time_sec()
 
         signals: list[str] = []
-        if hid_idle is not None:
-            signals.append("HIDIdleTime")
-        if _pmset_responsive():
-            signals.append("pmset")
+        if source is not None:
+            signals.append(source)
+
+        pmset_seen = False
+        if platform.system() == "Darwin":
+            pmset_seen = self.pmset_recent_sleep()
+            if _pmset_responsive():
+                signals.append("pmset")
 
         return IdleStatus(
-            hid_idle_sec=hid_idle,
+            hid_idle_sec=idle_sec,
             pmset_recent_sleep=pmset_seen,
             available_signals=signals,
         )

--- a/src/iai_mcp/idle_detector.py
+++ b/src/iai_mcp/idle_detector.py
@@ -217,9 +217,6 @@ class IdleDetector:
             idle_times.append(idle_sec)
         return min(idle_times)
 
-    def logind_idle_time_sec(self) -> int | None:
-        return self._logind_aggregate_idle(self._logind_session_paths())
-
 
     def os_idle_time_sec(self) -> tuple[int | None, str | None]:
         """Platform dispatcher for OS-level idle time.

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -97,6 +97,27 @@ def test_doctor_row_n_hid_idle_source_macos() -> None:
     assert "HIDIdleTime" in result.detail
 
 
+def test_doctor_row_n_hid_idle_source_linux_logind() -> None:
+    fake_status = IdleStatus(
+        hid_idle_sec=None,
+        pmset_recent_sleep=False,
+        available_signals=["logind"],
+    )
+
+    with patch(
+        "iai_mcp.idle_detector.IdleDetector.status",
+        return_value=fake_status,
+    ):
+        from iai_mcp.doctor import check_n_hid_idle_source
+
+        result = check_n_hid_idle_source()
+
+    assert result.status == "PASS"
+    assert result.passed is True
+    assert "logind IdleHint: not idle" in result.detail
+    assert "available: logind" in result.detail
+
+
 def test_doctor_row_n_hid_idle_source_missing() -> None:
     fake_status = IdleStatus(
         hid_idle_sec=None,

--- a/tests/test_idle_detector.py
+++ b/tests/test_idle_detector.py
@@ -231,18 +231,18 @@ def _busctl_property_json(type_code: str, value: object) -> str:
     return json.dumps({"type": type_code, "data": value})
 
 
-def test_logind_session_path_picks_own_uid_seat_session() -> None:
+def test_logind_session_paths_picks_own_uid_seat_session() -> None:
     fake = _completed_process(
         stdout=_busctl_list_sessions_json(
             [("c2", _OWN_UID, "testuser", "seat0", "/org/freedesktop/login1/session/c2")]
         )
     )
     with patch("iai_mcp.idle_detector.subprocess.run", return_value=fake):
-        result = IdleDetector()._logind_session_path()
-    assert result == "/org/freedesktop/login1/session/c2"
+        result = IdleDetector()._logind_session_paths()
+    assert result == ["/org/freedesktop/login1/session/c2"]
 
 
-def test_logind_session_path_skips_other_uids_and_headless_sessions() -> None:
+def test_logind_session_paths_skips_other_uids_and_headless_sessions() -> None:
     # Another user's graphical session and our own headless (no-seat) SSH
     # session must both be skipped in favor of our own seat-attached one.
     fake = _completed_process(
@@ -261,28 +261,54 @@ def test_logind_session_path_skips_other_uids_and_headless_sessions() -> None:
         )
     )
     with patch("iai_mcp.idle_detector.subprocess.run", return_value=fake):
-        result = IdleDetector()._logind_session_path()
-    assert result == "/org/freedesktop/login1/session/c2"
+        result = IdleDetector()._logind_session_paths()
+    assert result == ["/org/freedesktop/login1/session/c2"]
 
 
-def test_logind_session_path_returns_none_when_no_matching_session() -> None:
+def test_logind_session_paths_returns_all_matching_seats() -> None:
+    # Real multi-seat hardware: two seat-attached sessions for the same
+    # user. Both must be returned -- picking only one risks reading the
+    # wrong seat's idle state while the other is actively in use.
+    fake = _completed_process(
+        stdout=_busctl_list_sessions_json(
+            [
+                (
+                    "c2", _OWN_UID, "testuser",
+                    "seat0", "/org/freedesktop/login1/session/c2",
+                ),
+                (
+                    "c4", _OWN_UID, "testuser",
+                    "seat1", "/org/freedesktop/login1/session/c4",
+                ),
+            ]
+        )
+    )
+    with patch("iai_mcp.idle_detector.subprocess.run", return_value=fake):
+        result = IdleDetector()._logind_session_paths()
+    assert result == [
+        "/org/freedesktop/login1/session/c2",
+        "/org/freedesktop/login1/session/c4",
+    ]
+
+
+def test_logind_session_paths_returns_empty_when_no_matching_session() -> None:
     fake = _completed_process(
         stdout=_busctl_list_sessions_json(
             [("c1", _OWN_UID + 1, "otheruser", "seat0", "/org/freedesktop/login1/session/c1")]
         )
     )
     with patch("iai_mcp.idle_detector.subprocess.run", return_value=fake):
-        result = IdleDetector()._logind_session_path()
-    assert result is None
+        result = IdleDetector()._logind_session_paths()
+    assert result == []
 
 
-def test_logind_session_path_returns_none_when_busctl_missing() -> None:
+def test_logind_session_paths_returns_empty_when_busctl_missing() -> None:
     with patch(
         "iai_mcp.idle_detector.subprocess.run",
         side_effect=FileNotFoundError(2, "No such file"),
     ):
-        result = IdleDetector()._logind_session_path()
-    assert result is None
+        result = IdleDetector()._logind_session_paths()
+    assert result == []
 
 
 def test_logind_idle_time_sec_returns_none_when_not_idle() -> None:
@@ -327,6 +353,87 @@ def test_logind_idle_time_sec_returns_none_when_session_not_found() -> None:
     with patch("iai_mcp.idle_detector.subprocess.run", return_value=fake):
         result = IdleDetector().logind_idle_time_sec()
     assert result is None
+
+
+def test_logind_idle_time_sec_not_idle_if_any_seat_is_active() -> None:
+    # Two seat-attached sessions: seat0 has been idle for a long time, but
+    # seat1 is actively in use. Overall must report "not idle" -- a single
+    # active seat means the user isn't idle, no matter how long the other
+    # seat has sat untouched.
+    idle_since_usec = int(
+        (datetime.now(timezone.utc) - timedelta(seconds=7200)).timestamp() * 1_000_000
+    )
+    fake_sessions = _completed_process(
+        stdout=_busctl_list_sessions_json(
+            [
+                (
+                    "c2", _OWN_UID, "testuser",
+                    "seat0", "/org/freedesktop/login1/session/c2",
+                ),
+                (
+                    "c4", _OWN_UID, "testuser",
+                    "seat1", "/org/freedesktop/login1/session/c4",
+                ),
+            ]
+        )
+    )
+    fake_seat0_hint = _completed_process(stdout=_busctl_property_json("b", True))
+    fake_seat0_since = _completed_process(
+        stdout=_busctl_property_json("t", idle_since_usec)
+    )
+    fake_seat1_hint = _completed_process(stdout=_busctl_property_json("b", False))
+    with patch(
+        "iai_mcp.idle_detector.subprocess.run",
+        side_effect=[
+            fake_sessions, fake_seat0_hint, fake_seat0_since, fake_seat1_hint,
+        ],
+    ):
+        result = IdleDetector().logind_idle_time_sec()
+    assert result is None
+
+
+def test_logind_idle_time_sec_takes_min_across_idle_seats() -> None:
+    # Both seats idle, but for different durations -- the aggregate must be
+    # the shorter (more conservative) of the two, not the longer.
+    seat0_since = int(
+        (datetime.now(timezone.utc) - timedelta(seconds=7200)).timestamp() * 1_000_000
+    )
+    seat1_since = int(
+        (datetime.now(timezone.utc) - timedelta(seconds=100)).timestamp() * 1_000_000
+    )
+    fake_sessions = _completed_process(
+        stdout=_busctl_list_sessions_json(
+            [
+                (
+                    "c2", _OWN_UID, "testuser",
+                    "seat0", "/org/freedesktop/login1/session/c2",
+                ),
+                (
+                    "c4", _OWN_UID, "testuser",
+                    "seat1", "/org/freedesktop/login1/session/c4",
+                ),
+            ]
+        )
+    )
+    fake_seat0_hint = _completed_process(stdout=_busctl_property_json("b", True))
+    fake_seat0_since = _completed_process(
+        stdout=_busctl_property_json("t", seat0_since)
+    )
+    fake_seat1_hint = _completed_process(stdout=_busctl_property_json("b", True))
+    fake_seat1_since = _completed_process(
+        stdout=_busctl_property_json("t", seat1_since)
+    )
+    with patch(
+        "iai_mcp.idle_detector.subprocess.run",
+        side_effect=[
+            fake_sessions,
+            fake_seat0_hint, fake_seat0_since,
+            fake_seat1_hint, fake_seat1_since,
+        ],
+    ):
+        result = IdleDetector().logind_idle_time_sec()
+    assert result is not None
+    assert 95 <= result <= 105
 
 
 def test_os_idle_time_sec_dispatches_to_logind_on_linux() -> None:

--- a/tests/test_idle_detector.py
+++ b/tests/test_idle_detector.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import json
+import os
 import subprocess
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock, patch
-
-import pytest
+from unittest.mock import patch
 
 from iai_mcp.idle_detector import IdleDetector, IdleStatus
 
@@ -217,24 +217,63 @@ def test_status_when_signals_missing() -> None:
 # Linux: systemd-logind IdleHint / IdleSinceHint
 # ---------------------------------------------------------------------------
 
-
-def _busctl_session_path_stdout(path: str = "/org/freedesktop/login1/session/c2") -> str:
-    return f'o "{path}"\n'
+_OWN_UID = os.getuid() if hasattr(os, "getuid") else 1000
 
 
-def _busctl_bool_stdout(value: bool) -> str:
-    return f"b {'true' if value else 'false'}\n"
+def _busctl_list_sessions_json(
+    sessions: list[tuple[str, int, str, str, str]],
+) -> str:
+    # Real shape: {"type":"a(susso)","data":[[[id,uid,user,seat,path], ...]]}
+    return json.dumps({"type": "a(susso)", "data": [[list(s) for s in sessions]]})
 
 
-def _busctl_uint64_stdout(value: int) -> str:
-    return f"t {value}\n"
+def _busctl_property_json(type_code: str, value: object) -> str:
+    return json.dumps({"type": type_code, "data": value})
 
 
-def test_logind_session_path_parses_busctl_call_output() -> None:
-    fake = _completed_process(stdout=_busctl_session_path_stdout())
+def test_logind_session_path_picks_own_uid_seat_session() -> None:
+    fake = _completed_process(
+        stdout=_busctl_list_sessions_json(
+            [("c2", _OWN_UID, "testuser", "seat0", "/org/freedesktop/login1/session/c2")]
+        )
+    )
     with patch("iai_mcp.idle_detector.subprocess.run", return_value=fake):
         result = IdleDetector()._logind_session_path()
     assert result == "/org/freedesktop/login1/session/c2"
+
+
+def test_logind_session_path_skips_other_uids_and_headless_sessions() -> None:
+    # Another user's graphical session and our own headless (no-seat) SSH
+    # session must both be skipped in favor of our own seat-attached one.
+    fake = _completed_process(
+        stdout=_busctl_list_sessions_json(
+            [
+                (
+                    "c1", _OWN_UID + 1, "otheruser",
+                    "seat0", "/org/freedesktop/login1/session/c1",
+                ),
+                ("c3", _OWN_UID, "testuser", "", "/org/freedesktop/login1/session/c3"),
+                (
+                    "c2", _OWN_UID, "testuser",
+                    "seat0", "/org/freedesktop/login1/session/c2",
+                ),
+            ]
+        )
+    )
+    with patch("iai_mcp.idle_detector.subprocess.run", return_value=fake):
+        result = IdleDetector()._logind_session_path()
+    assert result == "/org/freedesktop/login1/session/c2"
+
+
+def test_logind_session_path_returns_none_when_no_matching_session() -> None:
+    fake = _completed_process(
+        stdout=_busctl_list_sessions_json(
+            [("c1", _OWN_UID + 1, "otheruser", "seat0", "/org/freedesktop/login1/session/c1")]
+        )
+    )
+    with patch("iai_mcp.idle_detector.subprocess.run", return_value=fake):
+        result = IdleDetector()._logind_session_path()
+    assert result is None
 
 
 def test_logind_session_path_returns_none_when_busctl_missing() -> None:
@@ -247,11 +286,15 @@ def test_logind_session_path_returns_none_when_busctl_missing() -> None:
 
 
 def test_logind_idle_time_sec_returns_none_when_not_idle() -> None:
-    fake_path = _completed_process(stdout=_busctl_session_path_stdout())
-    fake_hint = _completed_process(stdout=_busctl_bool_stdout(False))
+    fake_sessions = _completed_process(
+        stdout=_busctl_list_sessions_json(
+            [("c2", _OWN_UID, "testuser", "seat0", "/org/freedesktop/login1/session/c2")]
+        )
+    )
+    fake_hint = _completed_process(stdout=_busctl_property_json("b", False))
     with patch(
         "iai_mcp.idle_detector.subprocess.run",
-        side_effect=[fake_path, fake_hint],
+        side_effect=[fake_sessions, fake_hint],
     ):
         result = IdleDetector().logind_idle_time_sec()
     assert result is None
@@ -261,12 +304,18 @@ def test_logind_idle_time_sec_computes_elapsed_when_idle() -> None:
     idle_since_usec = int(
         (datetime.now(timezone.utc) - timedelta(seconds=1800)).timestamp() * 1_000_000
     )
-    fake_path = _completed_process(stdout=_busctl_session_path_stdout())
-    fake_hint = _completed_process(stdout=_busctl_bool_stdout(True))
-    fake_since = _completed_process(stdout=_busctl_uint64_stdout(idle_since_usec))
+    fake_sessions = _completed_process(
+        stdout=_busctl_list_sessions_json(
+            [("c2", _OWN_UID, "testuser", "seat0", "/org/freedesktop/login1/session/c2")]
+        )
+    )
+    fake_hint = _completed_process(stdout=_busctl_property_json("b", True))
+    fake_since = _completed_process(
+        stdout=_busctl_property_json("t", idle_since_usec)
+    )
     with patch(
         "iai_mcp.idle_detector.subprocess.run",
-        side_effect=[fake_path, fake_hint, fake_since],
+        side_effect=[fake_sessions, fake_hint, fake_since],
     ):
         result = IdleDetector().logind_idle_time_sec()
     assert result is not None
@@ -281,13 +330,17 @@ def test_logind_idle_time_sec_returns_none_when_session_not_found() -> None:
 
 
 def test_os_idle_time_sec_dispatches_to_logind_on_linux() -> None:
-    fake_path = _completed_process(stdout=_busctl_session_path_stdout())
-    fake_hint = _completed_process(stdout=_busctl_bool_stdout(False))
+    fake_sessions = _completed_process(
+        stdout=_busctl_list_sessions_json(
+            [("c2", _OWN_UID, "testuser", "seat0", "/org/freedesktop/login1/session/c2")]
+        )
+    )
+    fake_hint = _completed_process(stdout=_busctl_property_json("b", False))
     with patch(
         "iai_mcp.idle_detector.platform.system", return_value="Linux"
     ), patch(
         "iai_mcp.idle_detector.subprocess.run",
-        side_effect=[fake_path, fake_hint],
+        side_effect=[fake_sessions, fake_hint],
     ):
         idle_sec, source = IdleDetector().os_idle_time_sec()
     assert idle_sec is None
@@ -324,27 +377,37 @@ def test_sleep_eligible_logind_idle_path() -> None:
     idle_since_usec = int(
         (datetime.now(timezone.utc) - timedelta(seconds=1900)).timestamp() * 1_000_000
     )
-    fake_path = _completed_process(stdout=_busctl_session_path_stdout())
-    fake_hint = _completed_process(stdout=_busctl_bool_stdout(True))
-    fake_since = _completed_process(stdout=_busctl_uint64_stdout(idle_since_usec))
+    fake_sessions = _completed_process(
+        stdout=_busctl_list_sessions_json(
+            [("c2", _OWN_UID, "testuser", "seat0", "/org/freedesktop/login1/session/c2")]
+        )
+    )
+    fake_hint = _completed_process(stdout=_busctl_property_json("b", True))
+    fake_since = _completed_process(
+        stdout=_busctl_property_json("t", idle_since_usec)
+    )
     with patch(
         "iai_mcp.idle_detector.platform.system", return_value="Linux"
     ), patch(
         "iai_mcp.idle_detector.subprocess.run",
-        side_effect=[fake_path, fake_hint, fake_since],
+        side_effect=[fake_sessions, fake_hint, fake_since],
     ):
         result = IdleDetector().sleep_eligible(heartbeat_idle_30min=False)
     assert result is True
 
 
 def test_sleep_eligible_logind_not_idle_has_no_pmset_fallback() -> None:
-    fake_path = _completed_process(stdout=_busctl_session_path_stdout())
-    fake_hint = _completed_process(stdout=_busctl_bool_stdout(False))
+    fake_sessions = _completed_process(
+        stdout=_busctl_list_sessions_json(
+            [("c2", _OWN_UID, "testuser", "seat0", "/org/freedesktop/login1/session/c2")]
+        )
+    )
+    fake_hint = _completed_process(stdout=_busctl_property_json("b", False))
     with patch(
         "iai_mcp.idle_detector.platform.system", return_value="Linux"
     ), patch(
         "iai_mcp.idle_detector.subprocess.run",
-        side_effect=[fake_path, fake_hint],
+        side_effect=[fake_sessions, fake_hint],
     ) as run_mock:
         result = IdleDetector().sleep_eligible(heartbeat_idle_30min=False)
     assert result is False
@@ -353,13 +416,17 @@ def test_sleep_eligible_logind_not_idle_has_no_pmset_fallback() -> None:
 
 
 def test_status_reports_logind_signal_on_linux() -> None:
-    fake_path = _completed_process(stdout=_busctl_session_path_stdout())
-    fake_hint = _completed_process(stdout=_busctl_bool_stdout(False))
+    fake_sessions = _completed_process(
+        stdout=_busctl_list_sessions_json(
+            [("c2", _OWN_UID, "testuser", "seat0", "/org/freedesktop/login1/session/c2")]
+        )
+    )
+    fake_hint = _completed_process(stdout=_busctl_property_json("b", False))
     with patch(
         "iai_mcp.idle_detector.platform.system", return_value="Linux"
     ), patch(
         "iai_mcp.idle_detector.subprocess.run",
-        side_effect=[fake_path, fake_hint],
+        side_effect=[fake_sessions, fake_hint],
     ):
         status = IdleDetector().status()
     assert status.available_signals == ["logind"]

--- a/tests/test_idle_detector.py
+++ b/tests/test_idle_detector.py
@@ -124,6 +124,8 @@ def test_sleep_eligible_hid_idle_path() -> None:
         stdout=_ioreg_stdout(idle_ns=1900 * 1_000_000_000)
     )
     with patch(
+        "iai_mcp.idle_detector.platform.system", return_value="Darwin"
+    ), patch(
         "iai_mcp.idle_detector.subprocess.run",
         return_value=fake_ioreg,
     ) as run_mock:
@@ -142,6 +144,8 @@ def test_sleep_eligible_pmset_path() -> None:
         ])
     )
     with patch(
+        "iai_mcp.idle_detector.platform.system", return_value="Darwin"
+    ), patch(
         "iai_mcp.idle_detector.subprocess.run",
         side_effect=[fake_ioreg, fake_pmset],
     ):
@@ -155,8 +159,21 @@ def test_sleep_eligible_all_false() -> None:
     )
     fake_pmset = _completed_process(stdout="")
     with patch(
+        "iai_mcp.idle_detector.platform.system", return_value="Darwin"
+    ), patch(
         "iai_mcp.idle_detector.subprocess.run",
         side_effect=[fake_ioreg, fake_pmset],
+    ):
+        result = IdleDetector().sleep_eligible(heartbeat_idle_30min=False)
+    assert result is False
+
+
+def test_sleep_eligible_unknown_platform_has_no_secondary_signal() -> None:
+    with patch(
+        "iai_mcp.idle_detector.platform.system", return_value="FreeBSD"
+    ), patch(
+        "iai_mcp.idle_detector.subprocess.run",
+        side_effect=AssertionError("must not spawn on an unsupported platform"),
     ):
         result = IdleDetector().sleep_eligible(heartbeat_idle_30min=False)
     assert result is False
@@ -169,6 +186,8 @@ def test_status_for_doctor_row_all_signals_available() -> None:
     fake_pmset_log = _completed_process(stdout="")
     fake_pmset_g = _completed_process(stdout="Now drawing from 'AC Power'\n")
     with patch(
+        "iai_mcp.idle_detector.platform.system", return_value="Darwin"
+    ), patch(
         "iai_mcp.idle_detector.subprocess.run",
         side_effect=[fake_ioreg, fake_pmset_log, fake_pmset_g],
     ):
@@ -183,12 +202,179 @@ def test_status_for_doctor_row_all_signals_available() -> None:
 
 def test_status_when_signals_missing() -> None:
     with patch(
+        "iai_mcp.idle_detector.platform.system", return_value="Darwin"
+    ), patch(
         "iai_mcp.idle_detector.subprocess.run",
         side_effect=FileNotFoundError(2, "No such file"),
     ):
         status = IdleDetector().status()
     assert status.hid_idle_sec is None
     assert status.pmset_recent_sleep is False
+    assert status.available_signals == []
+
+
+# ---------------------------------------------------------------------------
+# Linux: systemd-logind IdleHint / IdleSinceHint
+# ---------------------------------------------------------------------------
+
+
+def _busctl_session_path_stdout(path: str = "/org/freedesktop/login1/session/c2") -> str:
+    return f'o "{path}"\n'
+
+
+def _busctl_bool_stdout(value: bool) -> str:
+    return f"b {'true' if value else 'false'}\n"
+
+
+def _busctl_uint64_stdout(value: int) -> str:
+    return f"t {value}\n"
+
+
+def test_logind_session_path_parses_busctl_call_output() -> None:
+    fake = _completed_process(stdout=_busctl_session_path_stdout())
+    with patch("iai_mcp.idle_detector.subprocess.run", return_value=fake):
+        result = IdleDetector()._logind_session_path()
+    assert result == "/org/freedesktop/login1/session/c2"
+
+
+def test_logind_session_path_returns_none_when_busctl_missing() -> None:
+    with patch(
+        "iai_mcp.idle_detector.subprocess.run",
+        side_effect=FileNotFoundError(2, "No such file"),
+    ):
+        result = IdleDetector()._logind_session_path()
+    assert result is None
+
+
+def test_logind_idle_time_sec_returns_none_when_not_idle() -> None:
+    fake_path = _completed_process(stdout=_busctl_session_path_stdout())
+    fake_hint = _completed_process(stdout=_busctl_bool_stdout(False))
+    with patch(
+        "iai_mcp.idle_detector.subprocess.run",
+        side_effect=[fake_path, fake_hint],
+    ):
+        result = IdleDetector().logind_idle_time_sec()
+    assert result is None
+
+
+def test_logind_idle_time_sec_computes_elapsed_when_idle() -> None:
+    idle_since_usec = int(
+        (datetime.now(timezone.utc) - timedelta(seconds=1800)).timestamp() * 1_000_000
+    )
+    fake_path = _completed_process(stdout=_busctl_session_path_stdout())
+    fake_hint = _completed_process(stdout=_busctl_bool_stdout(True))
+    fake_since = _completed_process(stdout=_busctl_uint64_stdout(idle_since_usec))
+    with patch(
+        "iai_mcp.idle_detector.subprocess.run",
+        side_effect=[fake_path, fake_hint, fake_since],
+    ):
+        result = IdleDetector().logind_idle_time_sec()
+    assert result is not None
+    assert 1795 <= result <= 1805
+
+
+def test_logind_idle_time_sec_returns_none_when_session_not_found() -> None:
+    fake = _completed_process(stdout="", returncode=1)
+    with patch("iai_mcp.idle_detector.subprocess.run", return_value=fake):
+        result = IdleDetector().logind_idle_time_sec()
+    assert result is None
+
+
+def test_os_idle_time_sec_dispatches_to_logind_on_linux() -> None:
+    fake_path = _completed_process(stdout=_busctl_session_path_stdout())
+    fake_hint = _completed_process(stdout=_busctl_bool_stdout(False))
+    with patch(
+        "iai_mcp.idle_detector.platform.system", return_value="Linux"
+    ), patch(
+        "iai_mcp.idle_detector.subprocess.run",
+        side_effect=[fake_path, fake_hint],
+    ):
+        idle_sec, source = IdleDetector().os_idle_time_sec()
+    assert idle_sec is None
+    assert source == "logind"
+
+
+def test_os_idle_time_sec_dispatches_to_hid_on_darwin() -> None:
+    fake_ioreg = _completed_process(
+        stdout=_ioreg_stdout(idle_ns=100 * 1_000_000_000)
+    )
+    with patch(
+        "iai_mcp.idle_detector.platform.system", return_value="Darwin"
+    ), patch(
+        "iai_mcp.idle_detector.subprocess.run", return_value=fake_ioreg
+    ):
+        idle_sec, source = IdleDetector().os_idle_time_sec()
+    assert idle_sec == 100
+    assert source == "HIDIdleTime"
+
+
+def test_os_idle_time_sec_none_on_unsupported_platform() -> None:
+    with patch(
+        "iai_mcp.idle_detector.platform.system", return_value="FreeBSD"
+    ), patch(
+        "iai_mcp.idle_detector.subprocess.run",
+        side_effect=AssertionError("must not spawn on an unsupported platform"),
+    ):
+        idle_sec, source = IdleDetector().os_idle_time_sec()
+    assert idle_sec is None
+    assert source is None
+
+
+def test_sleep_eligible_logind_idle_path() -> None:
+    idle_since_usec = int(
+        (datetime.now(timezone.utc) - timedelta(seconds=1900)).timestamp() * 1_000_000
+    )
+    fake_path = _completed_process(stdout=_busctl_session_path_stdout())
+    fake_hint = _completed_process(stdout=_busctl_bool_stdout(True))
+    fake_since = _completed_process(stdout=_busctl_uint64_stdout(idle_since_usec))
+    with patch(
+        "iai_mcp.idle_detector.platform.system", return_value="Linux"
+    ), patch(
+        "iai_mcp.idle_detector.subprocess.run",
+        side_effect=[fake_path, fake_hint, fake_since],
+    ):
+        result = IdleDetector().sleep_eligible(heartbeat_idle_30min=False)
+    assert result is True
+
+
+def test_sleep_eligible_logind_not_idle_has_no_pmset_fallback() -> None:
+    fake_path = _completed_process(stdout=_busctl_session_path_stdout())
+    fake_hint = _completed_process(stdout=_busctl_bool_stdout(False))
+    with patch(
+        "iai_mcp.idle_detector.platform.system", return_value="Linux"
+    ), patch(
+        "iai_mcp.idle_detector.subprocess.run",
+        side_effect=[fake_path, fake_hint],
+    ) as run_mock:
+        result = IdleDetector().sleep_eligible(heartbeat_idle_30min=False)
+    assert result is False
+    # Only the logind calls -- no attempt to shell out to pmset on Linux.
+    assert run_mock.call_count == 2
+
+
+def test_status_reports_logind_signal_on_linux() -> None:
+    fake_path = _completed_process(stdout=_busctl_session_path_stdout())
+    fake_hint = _completed_process(stdout=_busctl_bool_stdout(False))
+    with patch(
+        "iai_mcp.idle_detector.platform.system", return_value="Linux"
+    ), patch(
+        "iai_mcp.idle_detector.subprocess.run",
+        side_effect=[fake_path, fake_hint],
+    ):
+        status = IdleDetector().status()
+    assert status.available_signals == ["logind"]
+    assert status.pmset_recent_sleep is False
+
+
+def test_status_reports_no_signal_when_logind_unreachable() -> None:
+    with patch(
+        "iai_mcp.idle_detector.platform.system", return_value="Linux"
+    ), patch(
+        "iai_mcp.idle_detector.subprocess.run",
+        side_effect=FileNotFoundError(2, "No such file"),
+    ):
+        status = IdleDetector().status()
+    assert status.hid_idle_sec is None
     assert status.available_signals == []
 
 

--- a/tests/test_idle_detector.py
+++ b/tests/test_idle_detector.py
@@ -311,71 +311,48 @@ def test_logind_session_paths_returns_empty_when_busctl_missing() -> None:
     assert result == []
 
 
-def test_logind_idle_time_sec_returns_none_when_not_idle() -> None:
-    fake_sessions = _completed_process(
-        stdout=_busctl_list_sessions_json(
-            [("c2", _OWN_UID, "testuser", "seat0", "/org/freedesktop/login1/session/c2")]
-        )
-    )
+def test_logind_aggregate_idle_returns_none_when_not_idle() -> None:
     fake_hint = _completed_process(stdout=_busctl_property_json("b", False))
-    with patch(
-        "iai_mcp.idle_detector.subprocess.run",
-        side_effect=[fake_sessions, fake_hint],
-    ):
-        result = IdleDetector().logind_idle_time_sec()
+    with patch("iai_mcp.idle_detector.subprocess.run", return_value=fake_hint):
+        result = IdleDetector()._logind_aggregate_idle(
+            ["/org/freedesktop/login1/session/c2"]
+        )
     assert result is None
 
 
-def test_logind_idle_time_sec_computes_elapsed_when_idle() -> None:
+def test_logind_aggregate_idle_computes_elapsed_when_idle() -> None:
     idle_since_usec = int(
         (datetime.now(timezone.utc) - timedelta(seconds=1800)).timestamp() * 1_000_000
     )
-    fake_sessions = _completed_process(
-        stdout=_busctl_list_sessions_json(
-            [("c2", _OWN_UID, "testuser", "seat0", "/org/freedesktop/login1/session/c2")]
-        )
-    )
     fake_hint = _completed_process(stdout=_busctl_property_json("b", True))
-    fake_since = _completed_process(
-        stdout=_busctl_property_json("t", idle_since_usec)
-    )
+    fake_since = _completed_process(stdout=_busctl_property_json("t", idle_since_usec))
     with patch(
         "iai_mcp.idle_detector.subprocess.run",
-        side_effect=[fake_sessions, fake_hint, fake_since],
+        side_effect=[fake_hint, fake_since],
     ):
-        result = IdleDetector().logind_idle_time_sec()
+        result = IdleDetector()._logind_aggregate_idle(
+            ["/org/freedesktop/login1/session/c2"]
+        )
     assert result is not None
     assert 1795 <= result <= 1805
 
 
-def test_logind_idle_time_sec_returns_none_when_session_not_found() -> None:
-    fake = _completed_process(stdout="", returncode=1)
-    with patch("iai_mcp.idle_detector.subprocess.run", return_value=fake):
-        result = IdleDetector().logind_idle_time_sec()
+def test_logind_aggregate_idle_returns_none_for_empty_session_list() -> None:
+    with patch(
+        "iai_mcp.idle_detector.subprocess.run",
+        side_effect=AssertionError("must not spawn when there are no sessions"),
+    ):
+        result = IdleDetector()._logind_aggregate_idle([])
     assert result is None
 
 
-def test_logind_idle_time_sec_not_idle_if_any_seat_is_active() -> None:
+def test_logind_aggregate_idle_not_idle_if_any_seat_is_active() -> None:
     # Two seat-attached sessions: seat0 has been idle for a long time, but
     # seat1 is actively in use. Overall must report "not idle" -- a single
     # active seat means the user isn't idle, no matter how long the other
     # seat has sat untouched.
     idle_since_usec = int(
         (datetime.now(timezone.utc) - timedelta(seconds=7200)).timestamp() * 1_000_000
-    )
-    fake_sessions = _completed_process(
-        stdout=_busctl_list_sessions_json(
-            [
-                (
-                    "c2", _OWN_UID, "testuser",
-                    "seat0", "/org/freedesktop/login1/session/c2",
-                ),
-                (
-                    "c4", _OWN_UID, "testuser",
-                    "seat1", "/org/freedesktop/login1/session/c4",
-                ),
-            ]
-        )
     )
     fake_seat0_hint = _completed_process(stdout=_busctl_property_json("b", True))
     fake_seat0_since = _completed_process(
@@ -384,15 +361,18 @@ def test_logind_idle_time_sec_not_idle_if_any_seat_is_active() -> None:
     fake_seat1_hint = _completed_process(stdout=_busctl_property_json("b", False))
     with patch(
         "iai_mcp.idle_detector.subprocess.run",
-        side_effect=[
-            fake_sessions, fake_seat0_hint, fake_seat0_since, fake_seat1_hint,
-        ],
+        side_effect=[fake_seat0_hint, fake_seat0_since, fake_seat1_hint],
     ):
-        result = IdleDetector().logind_idle_time_sec()
+        result = IdleDetector()._logind_aggregate_idle(
+            [
+                "/org/freedesktop/login1/session/c2",
+                "/org/freedesktop/login1/session/c4",
+            ]
+        )
     assert result is None
 
 
-def test_logind_idle_time_sec_takes_min_across_idle_seats() -> None:
+def test_logind_aggregate_idle_takes_min_across_idle_seats() -> None:
     # Both seats idle, but for different durations -- the aggregate must be
     # the shorter (more conservative) of the two, not the longer.
     seat0_since = int(
@@ -400,20 +380,6 @@ def test_logind_idle_time_sec_takes_min_across_idle_seats() -> None:
     )
     seat1_since = int(
         (datetime.now(timezone.utc) - timedelta(seconds=100)).timestamp() * 1_000_000
-    )
-    fake_sessions = _completed_process(
-        stdout=_busctl_list_sessions_json(
-            [
-                (
-                    "c2", _OWN_UID, "testuser",
-                    "seat0", "/org/freedesktop/login1/session/c2",
-                ),
-                (
-                    "c4", _OWN_UID, "testuser",
-                    "seat1", "/org/freedesktop/login1/session/c4",
-                ),
-            ]
-        )
     )
     fake_seat0_hint = _completed_process(stdout=_busctl_property_json("b", True))
     fake_seat0_since = _completed_process(
@@ -426,12 +392,16 @@ def test_logind_idle_time_sec_takes_min_across_idle_seats() -> None:
     with patch(
         "iai_mcp.idle_detector.subprocess.run",
         side_effect=[
-            fake_sessions,
             fake_seat0_hint, fake_seat0_since,
             fake_seat1_hint, fake_seat1_since,
         ],
     ):
-        result = IdleDetector().logind_idle_time_sec()
+        result = IdleDetector()._logind_aggregate_idle(
+            [
+                "/org/freedesktop/login1/session/c2",
+                "/org/freedesktop/login1/session/c4",
+            ]
+        )
     assert result is not None
     assert 95 <= result <= 105
 


### PR DESCRIPTION
## Summary

Updates the idle sensor to read from the logind service on a Linux machine.  This aims to be agnostic between X11 and Wayland.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / tooling

## Affected areas

- [ ] Capture path
- [ ] Recall / retrieval
- [ ] Consolidation / sleep cycles
- [x] Daemon lifecycle / FSM
- [ ] Storage / encryption at rest
- [ ] MCP wrapper (TypeScript)
- [ ] Bench harness
- [ ] CLI / doctor
- [ ] Other: ___

## Testing

- [x] `pytest` passes locally
- [x] `ruff check src/ tests/` clean
- [x] New tests added for changed behaviour, or rationale below for why not

## Benchmarks

This does not touch the active path of any benchmark-eligible change.

## Notes for reviewers

This change updates the idle sensor for Linux platforms to use logind, mimicking how the enriched check on macOS checks for HID idleness.  

### logind Differences
The underlying theory of the way that logind works on Linux and how IOHIDSystem work on macOS is different.  When querying IOReg on macOS, there is no need to scan for a session that is using a console, since there is only one console to worry about.  logind is predicated on multi-session, so the code must scan for all sessions using a console (seatN) and then look for the lowest idle time to return for actual comparison.  In truthfulness, this is me being extremely pedantic for completeness, the likelihood of this actually happening is very low.  

The current implementation could be pulled back and simplified to look for the first seat found (usually seat0), and then just use the IdleHint from that console.  Given the code already has to fall through the MCP heartbeat check to start polling for idleness, that would optimise it slightly, shaving about ~300 nanoseconds from the idle check.  I already have it written the way it is though, so not sure if you want me to pull that back or not.

I looked into unifying the idle approach, since they are both Unix-based, and that is actually a worse result with the same split complexity, because looking up the active terminals is different across platforms.

