### PR TITLE
Windows: consume_wake_signal drops wakes on transient sharing violation + de-flake race test

### DIFF
--- a/src/iai_mcp/wake_handler.py
+++ b/src/iai_mcp/wake_handler.py
@@ -1,9 +1,24 @@
 from __future__ import annotations
 
+import platform
+import time
 from pathlib import Path
 
 
 __all__ = ["WakeHandler"]
+
+_IS_WINDOWS: bool = platform.system() == "Windows"
+
+# Windows os.unlink fails with PermissionError (WinError 5/ACCESS_DENIED or
+# 32/SHARING_VIOLATION) when another process momentarily holds the target
+# open -- e.g. the CLI/hook atomically replacing the signal, or `daemon
+# status`/the MCP server reading it, at the same instant the daemon consumes
+# it. Python's open() on Windows does not request FILE_SHARE_DELETE, so any
+# concurrent handle transiently blocks the unlink. The handle is held only
+# briefly, so a few short retries resolve it. POSIX unlink never sees this.
+# Mirrors iai_mcp.daemon_state._atomic_replace.
+_UNLINK_RETRY_ATTEMPTS: int = 10
+_UNLINK_RETRY_SLEEP_SEC: float = 0.05
 
 
 class WakeHandler:
@@ -12,13 +27,25 @@ class WakeHandler:
         self._wake_signal_path = wake_signal_path
 
     def consume_wake_signal(self) -> bool:
-        try:
-            self._wake_signal_path.unlink()
-        except FileNotFoundError:
-            return False
-        except OSError:
-            return False
-        return True
+        for attempt in range(_UNLINK_RETRY_ATTEMPTS):
+            try:
+                self._wake_signal_path.unlink()
+                return True
+            except FileNotFoundError:
+                return False
+            except PermissionError:
+                # Transient Windows sharing violation: the signal exists but a
+                # concurrent writer/reader holds it open. Returning False here
+                # would drop a real wake signal and strand the daemon in
+                # HIBERNATION with an unserved socket, so retry briefly. On
+                # POSIX a PermissionError is a genuine permission fault -- do
+                # not retry.
+                if not _IS_WINDOWS or attempt == _UNLINK_RETRY_ATTEMPTS - 1:
+                    return False
+                time.sleep(_UNLINK_RETRY_SLEEP_SEC)
+            except OSError:
+                return False
+        return False
 
     def signal_wake(self) -> bool:
         """Create the wake signal so the next daemon boot enters WAKE.

--- a/tests/test_wake_handler.py
+++ b/tests/test_wake_handler.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import platform
 import threading
+import time
 from pathlib import Path
 
 import pytest
 
 from iai_mcp.wake_handler import WakeHandler
+
+_IS_WINDOWS = platform.system() == "Windows"
 
 @pytest.fixture
 def wake_signal_path(tmp_path: Path) -> Path:
@@ -18,7 +22,21 @@ def _write_signal(
 ) -> None:
     tmp = path.with_suffix(path.suffix + tmp_suffix)
     tmp.write_text(payload, encoding="utf-8")
-    tmp.replace(path)
+    # Model a robust atomic writer: on Windows os.replace (MoveFileEx)
+    # transiently fails with PermissionError when the consumer momentarily
+    # holds the destination open. Production writers retry the same way (see
+    # iai_mcp.daemon_state._atomic_replace); the harness must too, otherwise
+    # the writer thread dies early and starves the consumer. POSIX rename is
+    # atomic and never sees this.
+    attempts = 10 if _IS_WINDOWS else 1
+    for i in range(attempts):
+        try:
+            tmp.replace(path)
+            return
+        except PermissionError:
+            if i == attempts - 1:
+                raise
+            time.sleep(0.05)
 
 def test_consume_wake_signal_when_present_deletes_and_returns_true(
     wake_signal_path: Path,
@@ -58,6 +76,18 @@ def test_has_pending_wake_read_only(wake_signal_path: Path) -> None:
     assert handler.has_pending_wake() is False
 
 def test_consume_atomic_no_race(wake_signal_path: Path) -> None:
+    """Concurrent writers replacing the signal while a consumer unlinks it must
+    never raise, and the consumer must observe at least one signal.
+
+    The consumer polls until it has consumed a few times or a deadline expires,
+    while the writers produce continuously until told to stop -- rather than each
+    running a fixed iteration count. A fixed count is flaky: the consumer's fast
+    unlink loop can finish before any writer's first replace lands (adverse
+    thread scheduling on a loaded runner), reading consumed=0. Continuous
+    production plus a poll-until-consumed consumer makes the >=1 liveness check
+    deterministic without weakening the atomicity intent (no error, no crash
+    under concurrent write+consume). Bounded by deadlines so it can never hang.
+    """
     handler = WakeHandler(wake_signal_path)
     consumed_truthy_count = 0
     errors: list[BaseException] = []
@@ -67,19 +97,20 @@ def test_consume_atomic_no_race(wake_signal_path: Path) -> None:
     def writer_loop(writer_id: int) -> None:
         suffix = f".tmp.w{writer_id}"
         try:
-            for _ in range(200):
-                if stop_writers.is_set():
-                    return
+            while not stop_writers.is_set():
                 _write_signal(wake_signal_path, tmp_suffix=suffix)
         except BaseException as exc:  # pragma: no cover -- defensive
             errors.append(exc)
 
     def consumer_loop() -> None:
         nonlocal consumed_truthy_count
+        deadline = time.monotonic() + 10.0
         try:
-            for _ in range(200):
+            while time.monotonic() < deadline:
                 if handler.consume_wake_signal():
                     consumed_truthy_count += 1
+                    if consumed_truthy_count >= 5:
+                        return
         except BaseException as exc:
             errors.append(exc)
 
@@ -90,10 +121,63 @@ def test_consume_atomic_no_race(wake_signal_path: Path) -> None:
     for w in writers:
         w.start()
     consumer.start()
-    consumer.join(timeout=10.0)
+    consumer.join(timeout=15.0)
     stop_writers.set()
     for w in writers:
         w.join(timeout=10.0)
 
     assert errors == []
     assert consumed_truthy_count >= 1
+
+
+def test_consume_retries_transient_permission_error_on_windows(
+    wake_signal_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient Windows sharing-violation (PermissionError) from unlink must
+    be retried, not swallowed as 'no signal'. Swallowing it drops a real wake
+    and strands the daemon in HIBERNATION with an unserved socket. Simulates the
+    Windows branch + a flaky unlink so it runs deterministically on any platform.
+    """
+    import iai_mcp.wake_handler as wh
+
+    monkeypatch.setattr(wh, "_IS_WINDOWS", True)
+    monkeypatch.setattr(wh, "_UNLINK_RETRY_SLEEP_SEC", 0.0)
+
+    calls = {"n": 0}
+
+    def flaky_unlink(self, *a, **k):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise PermissionError("simulated Windows sharing violation")
+        return None
+
+    monkeypatch.setattr(Path, "unlink", flaky_unlink)
+
+    handler = WakeHandler(wake_signal_path)
+    # Retries past the two transient failures and consumes on the third attempt.
+    assert handler.consume_wake_signal() is True
+    assert calls["n"] == 3
+
+
+def test_consume_does_not_retry_permission_error_on_posix(
+    wake_signal_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On POSIX a PermissionError from unlink is a genuine permission fault, not
+    a transient sharing violation, so it must NOT be retried -- return False on
+    the first failure. Guards against the Windows retry leaking onto POSIX.
+    """
+    import iai_mcp.wake_handler as wh
+
+    monkeypatch.setattr(wh, "_IS_WINDOWS", False)
+
+    calls = {"n": 0}
+
+    def perm_unlink(self, *a, **k):
+        calls["n"] += 1
+        raise PermissionError("genuine permission fault")
+
+    monkeypatch.setattr(Path, "unlink", perm_unlink)
+
+    handler = WakeHandler(wake_signal_path)
+    assert handler.consume_wake_signal() is False
+    assert calls["n"] == 1


### PR DESCRIPTION
## Problem

Two issues surfaced by `tests/test_wake_handler.py::test_consume_atomic_no_race` failing on macOS CI with `assert 0 >= 1`.

**1. A real Windows bug in `consume_wake_signal()`.** It does an unlink-to-consume inside a bare handler:

```python
try:
    self._wake_signal_path.unlink()
except FileNotFoundError:
    return False
except OSError:          # <-- swallows PermissionError too
    return False
return True
```

On Windows, `unlink()` raises `PermissionError` (sharing violation, WinError 5/32) when a concurrent writer or reader momentarily holds the signal file open — Python's `open()` there doesn't request `FILE_SHARE_DELETE`. The bare `except OSError` swallows that transient failure as *"no signal,"* **dropping a real wake** and leaving the daemon stranded in HIBERNATION with an unserved socket. On POSIX this never happens (you can unlink an open file).

**2. The test itself is flaky.** `consumed_truthy_count >= 1` had no synchronization: the consumer ran a fixed 200 unlink iterations and could finish before any writer's first `replace` landed (adverse thread scheduling on a loaded runner), reading `consumed=0`. That's the `assert 0 >= 1` seen on macOS — independent of the Windows bug, and unfixed by a Windows-only change.

## Fix

- **`consume_wake_signal`**: retry the unlink briefly on a Windows `PermissionError` (mirrors `daemon_state._atomic_replace`). On POSIX a `PermissionError` is a genuine permission fault, so it still returns `False` on the first failure — no behavior change off Windows.
- **De-flake `test_consume_atomic_no_race`**: writers produce continuously and the consumer polls until it consumes (bounded by a deadline) instead of a fixed count. Keeps the atomicity intent (`errors == []`, no crash under concurrent write+consume) while making the `>=1` liveness check deterministic on any scheduler. The writer harness also retries `os.replace` on a Windows `PermissionError`, mirroring production.
- **Two deterministic regression tests** for the retry (simulated via monkeypatch, so they run on every platform): a transient Windows `PermissionError` is retried and consumed; a POSIX `PermissionError` is not retried.

## Verification

`wake_handler` suite green; `test_consume_atomic_no_race` looped 10× locally on Windows with zero flakes. The two new deterministic tests fail against the pre-fix source (the retry path doesn't exist), confirming they gate the fix. macOS behavior is exercised by this PR's CI.
