### PR TITLE
Fix Windows regressions since the v2.1.0 port

### DIFF
--- a/src/iai_mcp/capture.py
+++ b/src/iai_mcp/capture.py
@@ -1693,7 +1693,7 @@ _PERMANENT_FAILED_NAMED_RE = re.compile(r"^(.+)\.permanent-failed-([^.]+)\.jsonl
 
 def _count_lines(fpath: Path) -> int:
     try:
-        with fpath.open() as fh:
+        with fpath.open(encoding="utf-8", errors="replace") as fh:
             return sum(1 for ln in fh if ln.strip())
     except OSError:
         return 0
@@ -1758,7 +1758,7 @@ def drain_permanent_failed_files(
         file_dropped = 0
 
         try:
-            with fpath.open() as fh:
+            with fpath.open(encoding="utf-8", errors="replace") as fh:
                 lines = [ln.rstrip("\n") for ln in fh if ln.strip()]
 
             if not lines:

--- a/src/iai_mcp/doctor/_lifecycle_checks.py
+++ b/src/iai_mcp/doctor/_lifecycle_checks.py
@@ -177,7 +177,8 @@ def check_b_socket_fresh() -> CheckResult:
 
 def check_c_lock_healthy() -> CheckResult:
     import errno as _errno
-    import fcntl as _fcntl
+
+    from iai_mcp import _flock as _fcntl  # flock seam: fcntl on POSIX, msvcrt region lock on Windows
 
     lock_path = _resolve_hippo_db_path().parent / ".lock"
     if not lock_path.exists():

--- a/src/iai_mcp/socket_server.py
+++ b/src/iai_mcp/socket_server.py
@@ -255,9 +255,6 @@ class SocketServer:
             env_path = os.environ.get("IAI_DAEMON_SOCKET_PATH")
             socket_path = Path(env_path) if env_path else SOCKET_PATH
 
-        sig = inspect.signature(asyncio.start_unix_server)
-        supports_cleanup_socket = "cleanup_socket" in sig.parameters
-
         # One JSON-RPC request is one line; a relayed document upload
         # (base64, ≤25 MB raw) must fit the StreamReader line buffer.
         _line_limit = 64 * 1024 * 1024
@@ -274,6 +271,10 @@ class SocketServer:
             finally:
                 shutdown_ipc()
             return
+        # POSIX from here down. start_unix_server does not exist on Windows,
+        # so even its signature must only be inspected past the branch above.
+        sig = inspect.signature(asyncio.start_unix_server)
+        supports_cleanup_socket = "cleanup_socket" in sig.parameters
         inherited = _inherit_activated_socket()
         if inherited is not None:
             server = await asyncio.start_unix_server(


### PR DESCRIPTION
## What this fixes

The v2.1.0 community port had Windows working end to end — thank you for taking that in. Best we can tell, a handful of Unix-only constructs crept back in between v2.2.0 and v2.3.1, and on Windows the v2.3.1 daemon now fails in two stages: it crashes at boot (`import resource`, then `signal.SIGHUP` in the shutdown-handler tuple), and once past those it runs but is unreachable — `SocketServer.serve()` inspects `inspect.signature(asyncio.start_unix_server)` before its `IS_WINDOWS` branch, and since `start_unix_server` doesn't exist on Windows the listener task dies at birth while the daemon keeps ticking. `daemon status` then reports "not running" against a live daemon and `.daemon.port` goes stale.

## Changes (one concern per commit)

1. **Daemon boot + socket serving** — guard `import resource` (fd rlimits are a Unix concern), resolve `SIGHUP` with `getattr` so the tuple itself can't raise, and move the `start_unix_server` signature inspection below the Windows early-return.
2. **File locking** — `capture_queue.py`, `lifecycle.py`, and `lifecycle_event_log.py` import `fcntl` directly; swapped to the `_flock` seam the port introduced (drop-in for `flock`/`LOCK_*`). `lillibrain/io.py` gets a guarded import since its `F_FULLFSYNC` use is already `_DARWIN`-gated.
3. **CLI + doctor** — `cmd_daemon_start` called `os.getuid()` before its OS dispatch (crash instead of the intended "Unsupported OS" message); doctor check (c) now uses the `_flock` seam, and check (b) probes `.daemon.port` on Windows instead of the nonexistent `.daemon.sock`.

## Validation

Windows 11, Python 3.12, editable install, daemon under Task Scheduler: daemon boots and serves, `daemon status` responds, `doctor` passes 26/26 (the HID-idle warn is expected there), and MCP capture/recall verified end to end from Claude Code against a store migrated from v1.2.1. The POSIX paths are untouched or moved verbatim, so this shouldn't change behavior there — but you know the codebase better; happy to split or adjust however you'd prefer.

One thought: even a minimal Windows CI job (import + boot smoke test) would catch this whole class going forward — happy to take a stab at that in a follow-up if it'd be useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016c4fUyixyVeVHYGrnJi98B
