### PR TITLE
fix(capture): extend noise filter and apply it in the capture-transcript recovery path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Noise filter no longer misses local-command output and compaction
+  summaries.** The ambient-capture noise filter gained patterns for
+  `<local-command-stdout>` / `<local-command-caveat>` blocks and for the
+  "This session is being continued from a previous conversation" text Claude
+  Code injects after a context-compaction, so neither ends up stored as a
+  real conversational turn.
+- **The `capture-transcript` recovery path now applies the same noise
+  filter.** `capture_transcript()` parsed transcript lines with its own
+  inline logic and never called the shared noise filter, so a manual/recovery
+  import could re-introduce compaction summaries and other noise that the
+  live per-turn and per-session capture paths already reject. It now skips
+  those lines the same way, and tallies them under a new `filtered` count so
+  the totals still reconcile with lines seen. Added regression tests for the
+  filter patterns and for `capture_transcript`'s filtering behavior.
+
 ## [2.3.1] — 2026-07-14
 
 ### Fixed

--- a/src/iai_mcp/_deploy/hooks/iai-mcp-turn-capture.sh
+++ b/src/iai_mcp/_deploy/hooks/iai-mcp-turn-capture.sh
@@ -123,6 +123,9 @@ _NOISE_STARTSWITH = (
     "<command-name>",
     "Base directory for this skill:",
     "<task-notification>",
+    "<local-command-stdout>",
+    "<local-command-caveat>",
+    "This session is being continued from a previous conversation",
 )
 _NOISE_EQUALS = ("[Request interrupted by user]",)
 

--- a/src/iai_mcp/capture.py
+++ b/src/iai_mcp/capture.py
@@ -700,10 +700,10 @@ def capture_transcript(
 ) -> dict[str, Any]:
     path = Path(transcript_path).expanduser()
     if not path.exists():
-        return {"inserted": 0, "reinforced": 0, "skipped": 0, "errors": 1,
+        return {"inserted": 0, "reinforced": 0, "skipped": 0, "errors": 1, "filtered": 0,
                 "reason": f"transcript not found: {path}"}
 
-    counts = {"inserted": 0, "reinforced": 0, "skipped": 0, "errors": 0}
+    counts = {"inserted": 0, "reinforced": 0, "skipped": 0, "errors": 0, "filtered": 0}
     seen = 0
     with path.open() as fh:
         for line in fh:
@@ -730,6 +730,9 @@ def capture_transcript(
             else:
                 text = str(content).strip()
             if not text:
+                continue
+            if _is_noise(text):
+                counts["filtered"] += 1
                 continue
             result = capture_turn(
                 store,

--- a/src/iai_mcp/capture.py
+++ b/src/iai_mcp/capture.py
@@ -755,6 +755,9 @@ _NOISE_PATTERNS: tuple[tuple[str, str], ...] = (
     ("startswith", "<command-name>"),
     ("startswith", "Base directory for this skill:"),
     ("startswith", "<task-notification>"),
+    ("startswith", "<local-command-stdout>"),
+    ("startswith", "<local-command-caveat>"),
+    ("startswith", "This session is being continued from a previous conversation"),
     ("equals",     "[Request interrupted by user]"),
 )
 

--- a/tests/test_is_noise.py
+++ b/tests/test_is_noise.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import iai_mcp.capture as capture_mod
+from iai_mcp.capture import _NOISE_PATTERNS, _is_noise, capture_transcript
+
+_STARTSWITH_PATTERNS = [
+    pattern for match_type, pattern in _NOISE_PATTERNS if match_type == "startswith"
+]
+_EQUALS_PATTERNS = [
+    pattern for match_type, pattern in _NOISE_PATTERNS if match_type == "equals"
+]
+
+
+@pytest.mark.parametrize("pattern", _STARTSWITH_PATTERNS)
+def test_startswith_pattern_is_noise(pattern: str):
+    assert _is_noise(pattern) is True
+    assert _is_noise(pattern + " trailing content") is True
+
+
+def test_compaction_summary_is_noise():
+    text = (
+        "This session is being continued from a previous conversation that ran "
+        "out of context. The conversation is summarized below:"
+    )
+    assert _is_noise(text) is True
+
+
+@pytest.mark.parametrize("pattern", _EQUALS_PATTERNS)
+def test_equals_pattern_is_noise(pattern: str):
+    assert _is_noise(pattern) is True
+
+
+def test_equals_pattern_with_extra_suffix_is_not_noise():
+    # "equals" patterns must match the whole string, not just a prefix.
+    pattern = _EQUALS_PATTERNS[0]
+    assert _is_noise(pattern + " and then some") is False
+
+
+def test_normal_text_is_not_noise():
+    assert _is_noise("what was the session identifier for the last worktree build") is False
+
+
+def test_pattern_in_middle_of_text_is_not_noise():
+    text = (
+        "I saw [Request interrupted by user] appear in the logs, and later "
+        "This session is being continued from a previous conversation was quoted too"
+    )
+    assert _is_noise(text) is False
+
+
+def _transcript_line(role: str, text: str) -> str:
+    return json.dumps({"type": role, "message": {"role": role, "content": text}})
+
+
+def test_capture_transcript_drops_compaction_summary_and_keeps_genuine_line(
+    tmp_path, monkeypatch
+):
+    noisy_text = (
+        "This session is being continued from a previous conversation that ran "
+        "out of context. The conversation is summarized below:"
+    )
+    genuine_text = "what was the session identifier for the last worktree build"
+
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(
+        _transcript_line("user", noisy_text) + "\n"
+        + _transcript_line("user", genuine_text) + "\n"
+    )
+
+    captured_texts: list[str] = []
+
+    def fake_capture_turn(store, *, cue, text, **kwargs):
+        captured_texts.append(text)
+        return {"status": "inserted"}
+
+    monkeypatch.setattr(capture_mod, "capture_turn", fake_capture_turn)
+
+    counts = capture_transcript(store=object(), transcript_path=transcript)
+
+    assert noisy_text not in captured_texts, (
+        "compaction summary line must be filtered by capture_transcript"
+    )
+    assert genuine_text in captured_texts, (
+        "genuine user line must still be captured"
+    )
+    assert counts["inserted"] == 1
+    assert counts["filtered"] == 1, (
+        "noise-filtered lines must be tallied so `seen` reconciles with counts"
+    )


### PR DESCRIPTION
## Summary

Claude Code injects synthetic "user" turns into the transcript — context-compaction summaries ("This session is being continued from a previous conversation…") and local-command output blocks (`<local-command-stdout>`, `<local-command-caveat>`) — and ambient capture stored them as real conversational turns. This PR adds those three patterns to the existing noise filter, and fixes a parity gap: the `capture-transcript` recovery path parsed lines with its own inline logic and never called `_is_noise`, so a manual/recovery import re-ingested noise that the live per-turn and per-session capture paths already reject.

Field evidence (fresh store, first day of real use): two full compaction-summary blobs and one `<local-command-stdout>` block stored as user turns — each duplicates an entire conversation into a single record and dominates lexical search hits.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / tooling

## Affected areas

- [x] Capture path
- [ ] Recall / retrieval
- [ ] Consolidation / sleep cycles
- [ ] Daemon lifecycle / FSM
- [ ] Storage / encryption at rest
- [ ] MCP wrapper (TypeScript)
- [ ] Bench harness
- [ ] CLI / doctor
- [ ] Other: ___

## Testing

- [x] `pytest` passes locally — full suite: 5160 passed, 226 skipped, 4 xfailed. Two failures are environmental and unrelated: `test_socket_subagent_reuse.py::test_subagent_spawns_zero_new_processes` fails identically on baseline `f6f2ffa` without this change (verified by swapping `capture.py` back), and `test_migrate_to_lilli.py::test_rss_bounded` passes standalone on both versions and only trips under full-suite memory pressure (WSL2 host). Neither test references the touched code.
- [ ] `ruff check src/ tests/` clean — no new findings introduced: `tests/test_is_noise.py` is clean; the E402/F841 findings in `capture.py` pre-date this change (left untouched to keep the diff minimal).
- [x] New tests added for changed behaviour — `tests/test_is_noise.py`: parametrized coverage of every `_NOISE_PATTERNS` entry (the filter had no direct tests before) plus a regression test that `capture_transcript` drops a compaction-summary line, keeps a genuine line, and tallies the drop under the new `filtered` count.

## Benchmarks

- Bench command run: none — I found no capture-path harness under `bench/`. The live-path change is three extra entries in the prefix tuple scanned once per turn (sub-microsecond); the `capture_transcript` change gates the manual recovery command only. Happy to run a specific harness if there is one you use for capture.
- Before: n/a
- After: n/a

## Notes for reviewers

- The compaction-summary prefix is coupled to Claude Code's transcript wording, exactly like the existing `<command-message>`/`<task-notification>` patterns — same mechanism, same trade-off.
- Counter name `filtered` (rather than folding into `skipped`) keeps `capture-transcript`'s printed counts reconciling with lines seen: `skipped` already means "capture_turn decided not to insert", and `errors` covers invalid JSON.
- The deploy-hook shell mirror (`iai-mcp-turn-capture.sh`) got the same three patterns, and a CHANGELOG entry was added under `[Unreleased]` / `### Fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
