### PR TITLE
fix(hippo): cache driver detection to stop dropping POSIX locks

### DIFF
--- a/src/iai_mcp/hippo/_db.py
+++ b/src/iai_mcp/hippo/_db.py
@@ -257,6 +257,20 @@ def _validate_table_name(name: str) -> str:
     return name
 
 
+# Cache of on-disk-detected driver, keyed by the (string) db path. Populated
+# only once a real header has been read (see _resolve_effective_driver), so a
+# hit here means the file's format is already known and does not need to be
+# re-sniffed. Not lock-protected: under the GIL two racing writers compute the
+# same detected value, so the worst case is a harmless redundant open, not a
+# corrupt cache entry.
+_driver_detect_cache: dict[str, str] = {}
+
+
+def _driver_detect_cache_clear() -> None:
+    """Drop all cached driver detections (test/debugging helper)."""
+    _driver_detect_cache.clear()
+
+
 def _resolve_effective_driver(db_path: str) -> str:
     """Resolve the storage driver for a backing file, on-disk format first.
 
@@ -281,7 +295,23 @@ def _resolve_effective_driver(db_path: str) -> str:
     the store reads it with the driver that wrote it, regardless of the ambient
     variable. The env is honoured only when there is no file to sniff yet (a
     fresh store), so a first open still creates the intended format.
+
+    Once a header has been read successfully, the detected driver is cached
+    for the path and further calls skip the raw ``open()``/``close()``
+    entirely. This matters beyond a micro-optimisation: per POSIX fcntl(2)
+    semantics, closing *any* file descriptor on a path drops *all* POSIX
+    locks the process holds on that file (sqlite.org/howtocorrupt.html
+    §2.2) — repeatedly open()-ing the backing file just to sniff its header
+    was silently stripping the live sqlite connection's lock, leaving the
+    database vulnerable to an external reader deleting the WAL out from
+    under it. Absent files, read errors, and short/empty headers are never
+    cached, so those cases keep re-probing (and honouring the env) exactly
+    as before.
     """
+    cached = _driver_detect_cache.get(db_path)
+    if cached is not None:
+        return cached
+
     from iai_mcp.lillibrain.constants import DB_MAGIC  # noqa: PLC0415
 
     _SQLITE_MAGIC = b"SQLite format 3\x00"
@@ -294,8 +324,10 @@ def _resolve_effective_driver(db_path: str) -> str:
     except OSError:
         header = b""
 
-    if not header:
-        # No file yet (fresh store) or unreadable — honour the env intent.
+    if len(header) < len(DB_MAGIC):
+        # No file yet (fresh store), unreadable, or a short/partial header —
+        # not enough to detect from, so don't cache; honour the env intent
+        # and let the next call re-probe.
         return env_driver
 
     if header[:len(DB_MAGIC)] == DB_MAGIC:
@@ -304,7 +336,8 @@ def _resolve_effective_driver(db_path: str) -> str:
         detected = "stdlib"
     else:
         # Unknown/corrupt header: defer to the env so the writer that produced
-        # it (or the intended driver) reports its own error, unchanged.
+        # it (or the intended driver) reports its own error, unchanged. Not
+        # cached — a later write could still land a recognisable header.
         return env_driver
 
     if detected != env_driver:
@@ -315,6 +348,7 @@ def _resolve_effective_driver(db_path: str) -> str:
             detected,
             env_driver,
         )
+    _driver_detect_cache[db_path] = detected
     return detected
 
 

--- a/tests/test_storage_driver_autodetect.py
+++ b/tests/test_storage_driver_autodetect.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import pytest
 
+from iai_mcp.hippo import _db
 from iai_mcp.hippo._db import _resolve_effective_driver
 from iai_mcp.lillibrain.constants import DB_MAGIC
 
@@ -25,6 +26,14 @@ from iai_mcp.lillibrain.constants import DB_MAGIC
 def _write_magic(path: Path, magic: bytes) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(magic + b"\x00" * 64)
+
+
+@pytest.fixture(autouse=True)
+def _clear_driver_detect_cache() -> None:
+    """Keep the module-level detection cache from leaking across tests."""
+    _db._driver_detect_cache_clear()
+    yield
+    _db._driver_detect_cache_clear()
 
 
 def test_resolve_driver_prefers_ondisk_lilli_over_unset_env(
@@ -155,3 +164,50 @@ def test_lilli_store_reopens_when_env_unset(
         assert got.literal_surface == surface
     finally:
         reader.close()
+
+
+def test_resolve_driver_does_not_cache_absent_file_then_detects_from_header(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The "absent file" branch must not be cached.
+
+    First call honours the env because the file doesn't exist yet. Once the
+    file is created with a real header, the next call must detect from the
+    header instead of returning the stale env-honouring result — proving the
+    absent-file path was never written to the cache.
+    """
+    db = tmp_path / "hippo" / "brain.sqlite3"  # not created yet
+    monkeypatch.setenv("LILLI_STORAGE_DRIVER", "stdlib")
+    assert _resolve_effective_driver(str(db)) == "stdlib"
+
+    _write_magic(db, DB_MAGIC)
+    assert _resolve_effective_driver(str(db)) == "lilli"
+
+
+def test_resolve_driver_caches_after_header_detection_and_skips_reopen(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Once detected from a real header, subsequent calls must not reopen the
+    file at all — that raw open()/close() cycle is what silently drops the
+    live sqlite connection's POSIX locks (the WAL-deletion footgun)."""
+    db = tmp_path / "hippo" / "brain.sqlite3"
+    _write_magic(db, DB_MAGIC)
+    monkeypatch.delenv("LILLI_STORAGE_DRIVER", raising=False)
+
+    # First call reads the header and populates the cache.
+    assert _resolve_effective_driver(str(db)) == "lilli"
+
+    open_calls: list[str] = []
+    real_open = open
+
+    def _counting_open(file, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        if str(file) == str(db):
+            open_calls.append(str(file))
+        return real_open(file, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", _counting_open)
+
+    for _ in range(3):
+        assert _resolve_effective_driver(str(db)) == "lilli"
+
+    assert open_calls == []


### PR DESCRIPTION
# fix(hippo): cache driver detection to stop dropping POSIX locks

## Problem

`_resolve_effective_driver()` in `src/iai_mcp/hippo/_db.py` sniffs the 16-byte header with a raw `open(db_path, "rb")`/close on **every** `open_store_conn()` call. Under POSIX advisory locking, closing *any* file descriptor for a file drops *all* locks the process holds on that file — see sqlite.org/howtocorrupt.html §2.2 ("Posix advisory locks canceled by a separate thread doing close()").

Inside the daemon process this silently drops the live connection's SHARED lock on the main db file. SQLite believes it still holds the lock and never re-acquires it (verified via `/proc/locks`: after the sniff the main-db lock is gone and stays gone through subsequent INSERTs/SELECTs on the same connection). From that moment any ephemeral external reader — e.g. a plain `sqlite3` CLI invocation that opens and closes the db — legitimately deletes the WAL/SHM on close, because it sees no other reader. The daemon's connection is then left pointing at deleted `-wal`/`-shm` files and every subsequent operation fails with `disk I/O error` until the daemon restarts.

The vulnerability window is **permanent**: it opens on the first sniff after the connection is established (~60s after daemon start via the background loops) and only closes on restart. Both production incidents we traced ended in tracebacks through `iter_record_columns` → `_open_keyset_snapshot` → `open_store_conn`, matching this exact path.

## Reproduction (deterministic, 5/5)

```python
import sqlite3, os, subprocess

db = "/tmp/repro.sqlite3"
conn = sqlite3.connect(db, isolation_level=None)
conn.execute("PRAGMA journal_mode=WAL")
conn.execute("CREATE TABLE r(id INTEGER PRIMARY KEY, v TEXT)")
conn.execute("INSERT INTO r(v) VALUES('x')")

# the footgun: any raw open/close of the db in this process
with open(db, "rb") as fh:
    fh.read(16)

# /proc/locks now shows the main-db SHARED lock is gone (only the -shm
# DMS lock remains, which does NOT prevent WAL deletion). Queries on the
# connection do NOT re-acquire it.
subprocess.run(["sqlite3", db, "SELECT count(*) FROM r;"])
print(os.path.exists(db + "-wal"))  # False — WAL deleted by the CLI reader
```

Control run without the raw open keeps the WAL intact even under stress. The same experiment against `_resolve_effective_driver()` directly shows one lock-drop per call.

## Fix

Cache the detected driver per path in a module-level dict, so the header is read **at most once** per path per process:

- Only a successful full-length header read populates the cache.
- The absent-file / short-header / `OSError` branches are never cached — the "honour env for absent file" behaviour still re-checks on every call (`test_resolve_driver_honours_env_for_absent_file` still passes, plus a new test proving a file created between calls is detected).
- Unknown/corrupt headers are also not cached (a corrupt header may be replaced later).
- Env × header precedence is unchanged on every branch.

New regression test monkeypatches `builtins.open` to assert the file is not reopened once the cache is populated — it fails deterministically on the previous code.

All raw-sniff call sites go through this function (`hippo/_raw_open.py`, `hnsw_rebuild_worker.py`, `HippoDB.__init__`), so they are all covered by the cache; none of them relies on per-call re-sniffing (short-lived spawned processes or once-per-instance init).

## Test results

Targeted: `tests/test_storage_driver_autodetect.py` — 10 passed, 1 skipped (pre-existing skip). Full suite on this branch: 5145 passed, 228 skipped, 4 xfailed, 4 failed — compared against a fresh `upstream/main` baseline on the same machine (3 failed, 5144 passed, 228 skipped, 4 xfailed), the only overlapping failures are the two environment-sensitive baseline ones (`test_rss_bounded`, `test_subagent_spawns_zero_new_processes`); the two extra reds are `test_cli_daemon.py` asyncio flakes ("Event loop is closed") that pass in isolation on this branch, and the baseline itself flaked on a *different* test in that same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
