### PR TITLE
fix(daemon): tick diagnostics hardening (3 small fixes)

### DIFF
--- a/src/iai_mcp/daemon/__init__.py
+++ b/src/iai_mcp/daemon/__init__.py
@@ -347,11 +347,7 @@ def transition(state: dict, new_fsm: str) -> None:
 
 
 def _store_is_empty(store: MemoryStore) -> bool:
-    try:
-        return store.db.open_table("records").count_rows() == 0
-    except (OSError, ValueError, KeyError, RuntimeError) as exc:
-        log.debug("store empty check failed, assuming empty: %s", exc)
-        return True
+    return store.db.open_table("records").count_rows() == 0
 
 
 def _is_inside_window(

--- a/src/iai_mcp/daemon/__init__.py
+++ b/src/iai_mcp/daemon/__init__.py
@@ -605,6 +605,8 @@ async def _tick_body(
         await asyncio.to_thread(save_state, state)
         return
 
+    state.pop("last_tick_skipped_reason", None)
+
     now = datetime.now(timezone.utc)
     try:
         tz = load_user_tz()

--- a/src/iai_mcp/daemon/__init__.py
+++ b/src/iai_mcp/daemon/__init__.py
@@ -350,6 +350,23 @@ def _store_is_empty(store: MemoryStore) -> bool:
     return store.db.open_table("records").count_rows() == 0
 
 
+def _ann_pool_health_payload(store: MemoryStore) -> dict:
+    # Module-level so it is directly unit-testable without assembling the
+    # daemon. `fence_reopens` is published as None ("not applicable") when
+    # there is no read-only pool (stdlib driver) -- 0 would be
+    # indistinguishable from "fence active, zero reopens so far".
+    _hp_pool = getattr(store.db, "_ro_pool", None)
+    return {
+        "reuse_collisions": int(getattr(store.db, "_reuse_collision_count", 0)),
+        "fence_reopens": (
+            int(getattr(_hp_pool, "fence_reopen_count", 0) or 0)
+            if _hp_pool is not None
+            else None
+        ),
+        "writer_fallbacks": int(getattr(_hp_pool, "writer_fallback_count", 0) or 0),
+    }
+
+
 def _is_inside_window(
     window: tuple[int, int] | list | None,
     now: datetime,
@@ -1610,18 +1627,7 @@ async def main() -> int:
                     # status surface every tick — a write-only counter
                     # observes nothing. Read via `iai-mcp daemon status`.
                     try:
-                        _hp_pool = getattr(store.db, "_ro_pool", None)
-                        state["ann_pool_health"] = {
-                            "reuse_collisions": int(
-                                getattr(store.db, "_reuse_collision_count", 0)
-                            ),
-                            "fence_reopens": int(
-                                getattr(_hp_pool, "fence_reopen_count", 0) or 0
-                            ),
-                            "writer_fallbacks": int(
-                                getattr(_hp_pool, "writer_fallback_count", 0) or 0
-                            ),
-                        }
+                        state["ann_pool_health"] = _ann_pool_health_payload(store)
                     except Exception:  # noqa: BLE001 -- health publish is best-effort
                         pass
 

--- a/tests/test_daemon_tick_flags.py
+++ b/tests/test_daemon_tick_flags.py
@@ -221,3 +221,37 @@ def test_store_is_empty_check_failure_propagates(tick_env, monkeypatch):
     err_events = query_events(store, kind="tick_error", limit=5)
     assert len(err_events) >= 1
     assert "simulated store check failure" in err_events[0]["data"].get("error", "")
+
+
+def test_ann_pool_health_fence_reopens_none_without_ro_pool(tick_env):
+    """No _ro_pool (stdlib driver) -> fence_reopens is None ("not
+    applicable"), never 0 -- 0 would be indistinguishable from "fence
+    active, zero reopens so far"."""
+    from iai_mcp import daemon as daemon_mod
+
+    store, state_path, tmp_path = tick_env
+
+    assert getattr(store.db, "_ro_pool", None) is None
+
+    payload = daemon_mod._ann_pool_health_payload(store)
+
+    assert payload["fence_reopens"] is None
+
+
+def test_ann_pool_health_fence_reopens_reports_pool_count(tick_env, monkeypatch):
+    """With a _ro_pool present, fence_reopens publishes its
+    fence_reopen_count verbatim."""
+    from iai_mcp import daemon as daemon_mod
+
+    store, state_path, tmp_path = tick_env
+
+    class _FakePool:
+        fence_reopen_count = 7
+        writer_fallback_count = 2
+
+    monkeypatch.setattr(store.db, "_ro_pool", _FakePool(), raising=False)
+
+    payload = daemon_mod._ann_pool_health_payload(store)
+
+    assert payload["fence_reopens"] == 7
+    assert payload["writer_fallbacks"] == 2

--- a/tests/test_daemon_tick_flags.py
+++ b/tests/test_daemon_tick_flags.py
@@ -156,3 +156,26 @@ def test_tick_updates_last_tick_at(tick_env, monkeypatch):
 
     assert "last_tick_at" in state
     datetime.fromisoformat(state["last_tick_at"])
+
+
+def test_last_tick_skipped_reason_cleared_after_normal_tick(tick_env, monkeypatch):
+    """A stale `last_tick_skipped_reason` from a prior skip must not survive
+    a subsequent tick that actually runs (regression: the flag used to be
+    fossilized forever once set)."""
+    from iai_mcp import daemon as daemon_mod
+
+    store, state_path, tmp_path = tick_env
+
+    monkeypatch.setattr(daemon_mod, "should_relearn", lambda last, now: False)
+
+    state = {
+        "fsm_state": "WAKE",
+        "scheduler_paused": True,
+    }
+    asyncio.run(daemon_mod._tick_body(store, state))
+    assert state.get("last_tick_skipped_reason") == "paused"
+
+    state["scheduler_paused"] = False
+    asyncio.run(daemon_mod._tick_body(store, state))
+
+    assert "last_tick_skipped_reason" not in state

--- a/tests/test_daemon_tick_flags.py
+++ b/tests/test_daemon_tick_flags.py
@@ -179,3 +179,45 @@ def test_last_tick_skipped_reason_cleared_after_normal_tick(tick_env, monkeypatc
     asyncio.run(daemon_mod._tick_body(store, state))
 
     assert "last_tick_skipped_reason" not in state
+
+
+def test_store_is_empty_check_failure_propagates(tick_env, monkeypatch):
+    """`_store_is_empty` must not swallow a failed check as "store empty" —
+    a broken check is not the same as an empty store. `_tick_body` should
+    let the exception bubble; `_scheduler_tick` turns it into a
+    `tick_error` event instead of silently skipping the tick."""
+    from iai_mcp import daemon as daemon_mod
+    from iai_mcp.events import query_events
+
+    store, state_path, tmp_path = tick_env
+
+    real_open_table = store.db.open_table
+
+    def _selective_boom(name):
+        if name == "records":
+            raise RuntimeError("simulated store check failure")
+        return real_open_table(name)
+
+    monkeypatch.setattr(store.db, "open_table", _selective_boom)
+
+    state = {"fsm_state": "WAKE"}
+
+    with pytest.raises(RuntimeError, match="simulated store check failure"):
+        asyncio.run(daemon_mod._tick_body(store, state))
+
+    monkeypatch.setattr(daemon_mod, "TICK_INTERVAL_SEC", 0)
+
+    async def runner():
+        task = asyncio.create_task(daemon_mod._scheduler_tick(store, state))
+        await asyncio.sleep(0.1)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(runner())
+
+    err_events = query_events(store, kind="tick_error", limit=5)
+    assert len(err_events) >= 1
+    assert "simulated store check failure" in err_events[0]["data"].get("error", "")


### PR DESCRIPTION
# fix(daemon): tick diagnostics hardening (3 small fixes)

Three small, independent correctness fixes to the daemon's tick/status surface, found while investigating a production incident (they made diagnosis harder; none of them was the incident's cause).

## 1. Clear stale `last_tick_skipped_reason` on a normal tick

The flag is set on the two skip shortcuts ("paused", "empty_store") but was never cleared, so a single skipped tick left the reason fossilized in the published state forever — during our incident it kept reporting `empty_store` from an old tick while the store had hundreds of records, sending diagnosis down the wrong path. Now a tick that actually runs pops the key. Regression test: skip followed by a normal tick → key gone.

## 2. Don't report a failed emptiness check as an empty store

`_store_is_empty` swallowed `(OSError, ValueError, KeyError, RuntimeError)` and returned `True` — a *failed check* was indistinguishable from an *empty store*, and the tick was skipped with the wrong reason. The exception now propagates; `_scheduler_tick`'s generic handler records it as `tick_error` and the scheduler loop keeps running. (Note: `sqlite3.OperationalError` does not inherit from `OSError`, so real disk I/O errors already propagated — the swallow only masked integrity-check failures.) Regression test: a raising store check propagates and surfaces as `tick_error`.

## 3. Publish `fence_reopens: None` when there is no read-only pool

`ann_pool_health.fence_reopens` was published as `getattr(_hp_pool, "fence_reopen_count", 0) or 0`. With the stdlib storage driver `_hp_pool is None`, so the metric read `0` forever — indistinguishable from "fence active, zero reopens", which is misleading (the fence only exists in the lilli driver). It now publishes `None` ("not applicable"). The payload assembly was extracted into `_ann_pool_health_payload()` so it is unit-testable; the only consumer (`concurrency.py`) treats the dict as opaque and is None-safe. Regression tests cover both the None and the real-pool cases.

## Test results

Targeted: `tests/test_daemon_tick_flags.py` — 37 passed. Full suite on this branch: 5149 passed, 228 skipped, 4 xfailed, 2 failed — both failures (`test_rss_bounded`, `test_subagent_spawns_zero_new_processes`) are environment-sensitive and already fail on a fresh `upstream/main` baseline on the same machine (3 failed, 5144 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
