### PR TITLE
fix: accept transitioning daemon state in doctor

### DIFF
--- a/src/iai_mcp/doctor/_lifecycle_checks.py
+++ b/src/iai_mcp/doctor/_lifecycle_checks.py
@@ -261,7 +261,15 @@ def check_e_state_file_valid() -> CheckResult:
             "no state file (daemon never booted — not a bug)",
         )
 
-    valid = {"WAKE", "DROWSY", "SLEEP", "SLEEPING", "DREAMING", "HIBERNATION"}
+    valid = {
+        "WAKE",
+        "DROWSY",
+        "TRANSITIONING",
+        "SLEEP",
+        "SLEEPING",
+        "DREAMING",
+        "HIBERNATION",
+    }
     if fsm_state in valid:
         return CheckResult(
             "(e) daemon state file valid",

--- a/tests/test_doctor_checklist.py
+++ b/tests/test_doctor_checklist.py
@@ -216,6 +216,17 @@ def test_check_e_passes_when_state_file_absent(short_socket_paths):
     assert "no state file" in result.detail
 
 
+def test_check_e_passes_for_transitioning_state(short_socket_paths):
+    _, _, state_path = short_socket_paths
+    state_path.write_text(json.dumps({"fsm_state": "TRANSITIONING"}))
+
+    from iai_mcp.doctor import check_e_state_file_valid
+
+    result = check_e_state_file_valid()
+    assert result.passed is True
+    assert result.detail == "fsm_state=TRANSITIONING"
+
+
 def test_check_b_passes_against_silent_listening_socket(short_socket_paths):
     import socket as _socket
     import threading


### PR DESCRIPTION
Closes #80

## Summary

Treat `TRANSITIONING` as a valid legacy daemon state so `iai-mcp doctor` does not report a false failure while the canonical FSM is DROWSY.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / tooling

## Affected areas

- [ ] Capture path
- [ ] Recall / retrieval
- [ ] Consolidation / sleep cycles
- [x] Daemon lifecycle / FSM
- [ ] Storage / encryption at rest
- [ ] MCP wrapper (TypeScript)
- [ ] Bench harness
- [x] CLI / doctor
- [ ] Other: ___

## Testing

- [ ] `pytest` passes locally
- [ ] `ruff check src/ tests/` clean
- [x] New tests added for changed behaviour, or rationale below for why not

Focused doctor regressions and changed-file Ruff checks pass; the new test fails without the source change and passes with it. The full-project Ruff run reports 518 pre-existing findings outside this diff.

## Benchmarks

Not applicable; this change does not touch retrieval, capture, or consolidation.

- Bench command run: N/A
- Before: N/A
- After: N/A

## Notes for reviewers

`fsm_reconcile` already emits `TRANSITIONING` as the legacy representation of canonical DROWSY.
