### PR TITLE
Make macOS memory assertions process-isolated

### DIFF
--- a/tests/_runtime_graph_rss_arm.py
+++ b/tests/_runtime_graph_rss_arm.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import json
+import os
+import platform
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from typing import Literal
+
+RuntimeGraphProof = Literal["detection", "centrality"]
+
+_RSS_ARM_WORKER = textwrap.dedent(
+    """
+    import json, resource, sys
+    from datetime import datetime, timezone
+    from pathlib import Path
+    from uuid import uuid4
+
+    import numpy as np
+
+    import iai_mcp.community as _cm
+    from iai_mcp import retrieve, runtime_graph_cache
+    from iai_mcp.store import MemoryStore
+    from iai_mcp.store._buffers import flush_edge_buffer, flush_record_buffer
+    from iai_mcp.types import MemoryRecord
+
+    proof = sys.argv[1]
+    seed_base = int(sys.argv[2])
+    in_parent = sys.argv[3] == "in_parent"
+    root = Path(sys.argv[4])
+    n_records = int(sys.argv[5])
+
+    store = MemoryStore(path=root / "store")
+    store.root = root / "root"
+    store.root.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(timezone.utc)
+    for index in range(n_records):
+        seed = seed_base + index
+        rng = np.random.default_rng(seed)
+        vector = rng.random(store.embed_dim).astype(np.float32)
+        vector = (vector / np.linalg.norm(vector)).tolist()
+        store.insert(MemoryRecord(
+            id=uuid4(), tier="episodic",
+            literal_surface=f"surface number {seed} carrying real text",
+            aaak_index="", embedding=vector, community_id=None, centrality=0.0,
+            detail_level=2, pinned=False, stability=0.0, difficulty=0.0,
+            last_reviewed=None, never_decay=False, never_merge=False,
+            provenance=[], created_at=now, updated_at=now,
+            tags=[f"tag{seed % 3}"], language="en",
+        ))
+    flush_record_buffer(store)
+    flush_edge_buffer(store)
+
+    if proof == "detection" and in_parent:
+        def _in_parent_detect(graph, **kwargs):
+            assignment = _cm.detect_communities(
+                graph, prior=None, prior_mode="seeded"
+            )
+            if kwargs.get("with_centrality"):
+                return assignment, graph.centrality()
+            return assignment
+
+        runtime_graph_cache.compute_assignment_in_child = _in_parent_detect
+    elif proof == "centrality" and in_parent:
+        def _local_detect(store, graph, *, with_centrality=False):
+            assignment = _cm.detect_communities(
+                graph, prior=None, prior_mode="seeded"
+            )
+            if with_centrality:
+                return assignment, None
+            return assignment
+
+        retrieve._detect_communities_isolated = _local_detect
+        runtime_graph_cache.compute_centrality_in_child = (
+            lambda graph, **kwargs: graph.centrality()
+        )
+
+    retrieve.build_runtime_graph(store)
+    peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    print(json.dumps({"peak_rss_raw": peak}))
+    """
+)
+
+
+def _ru_maxrss_mb(raw: int) -> float:
+    if platform.system() == "Darwin":
+        return raw / (1024 * 1024)
+    return raw / 1024
+
+
+def run_runtime_graph_rss_arm(
+    *,
+    proof: RuntimeGraphProof,
+    driver: str,
+    seed_base: int,
+    in_parent: bool,
+    root: Path,
+    n_records: int,
+) -> float:
+    env = os.environ.copy()
+    env["LILLI_STORAGE_DRIVER"] = driver
+    env["IAI_MCP_CRYPTO_PASSPHRASE"] = "test-passphrase-not-secret"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _RSS_ARM_WORKER,
+            proof,
+            str(seed_base),
+            "in_parent" if in_parent else "isolated",
+            str(root),
+            str(n_records),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=600,
+        check=False,
+    )
+    assert proc.returncode == 0, (
+        f"RSS arm subprocess failed (rc={proc.returncode}):\n{proc.stderr}"
+    )
+    payload = json.loads(proc.stdout.strip().splitlines()[-1])
+    return _ru_maxrss_mb(int(payload["peak_rss_raw"]))

--- a/tests/test_build_runtime_graph_child_isolation.py
+++ b/tests/test_build_runtime_graph_child_isolation.py
@@ -17,7 +17,6 @@ Three guarantees are pinned here:
 """
 from __future__ import annotations
 
-import gc
 import os
 import platform
 from datetime import datetime, timezone
@@ -33,6 +32,7 @@ _LILLI_DRIVER = os.environ.get("LILLI_STORAGE_DRIVER", "stdlib").lower() == "lil
 from iai_mcp import retrieve, runtime_graph_cache
 from iai_mcp.store import MemoryStore
 from iai_mcp.types import MemoryRecord
+from tests._runtime_graph_rss_arm import run_runtime_graph_rss_arm
 
 
 @pytest.fixture(autouse=True)
@@ -222,26 +222,9 @@ def test_child_timeout_falls_back_to_in_process(
     assert graph.node_count() == 10
 
 
-def _settled_rss_bytes() -> int:
-    """Force returnable pages back to the OS, then take one RSS reading.
-
-    Mirrors the shipped per-step relief (pyarrow pool release + gc.collect +
-    macOS zone pressure relief) so the reading is a reproducible
-    "all-returnable-pages-returned" footprint rather than a jittery sample.
-    """
-    from iai_mcp.lilli.cycle.sleep_pipeline._memory_relief import (
-        _current_rss_bytes,
-        _step_memory_relief,
-    )
-
-    _step_memory_relief("rss-proof")
-    gc.collect()
-    return _current_rss_bytes()
-
-
 @pytest.mark.skipif(
     platform.system() != "Darwin",
-    reason="settled-RSS isolation proof calibrated on this host's allocator",
+    reason="peak-RSS isolation proof calibrated on this host's allocator",
 )
 @pytest.mark.skipif(
     _LILLI_DRIVER,
@@ -259,67 +242,36 @@ def test_parent_rss_lower_with_child_isolation(store: MemoryStore):
     materially below the in-parent-detection baseline, proving the detection
     arenas no longer reside in the parent.
 
-    The two arms run on independent fresh stores seeded identically so the
-    only difference is where detection executes. The in-parent arm forces
-    detection to run locally by routing the child call straight through the
-    in-process kernel; the isolated arm uses the real spawn-context child.
-    Each arm subtracts a fresh settled baseline, so an arm only measures the
-    resident growth it itself retains.
+    Each arm runs in its own fresh process and reports its peak RSS. The
+    in-parent arm forces detection to run locally; the isolated arm uses the
+    real spawn-context child. Independent processes keep the comparison free
+    of allocator history and arm ordering from the full pytest process.
     """
-    import iai_mcp.community as _cm
-
     n_records = 3000
 
-    def _build_arm(seed_base: int, in_parent: bool) -> int:
-        s = MemoryStore(path=store.root / f"arm-{seed_base}-{in_parent}")
-        s.root = store.root / f"arm-root-{seed_base}-{in_parent}"
-        s.root.mkdir(parents=True, exist_ok=True)
-        _seed_store(s, n=n_records, seed_base=seed_base)
+    in_parent_peak = run_runtime_graph_rss_arm(
+        proof="detection",
+        driver="stdlib",
+        seed_base=10_000,
+        in_parent=True,
+        root=store.root / "in-parent",
+        n_records=n_records,
+    )
+    isolated_peak = run_runtime_graph_rss_arm(
+        proof="detection",
+        driver="stdlib",
+        seed_base=10_000,
+        in_parent=False,
+        root=store.root / "isolated",
+        n_records=n_records,
+    )
 
-        with pytest.MonkeyPatch.context() as mp:
-            if in_parent:
-                # Route the "child" call through the in-process kernel so the
-                # detection arenas are reserved in this (parent) process. Honor
-                # the `with_centrality` contract: when requested, also compute
-                # centrality locally and return it alongside the assignment so
-                # the in-parent path retains both intermediates.
-                def _in_parent_detect(graph, **kw):
-                    assignment = _cm.detect_communities(
-                        graph, prior=None, prior_mode="seeded"
-                    )
-                    if kw.get("with_centrality"):
-                        return assignment, graph.centrality()
-                    return assignment
-
-                mp.setattr(
-                    runtime_graph_cache,
-                    "compute_assignment_in_child",
-                    _in_parent_detect,
-                )
-            baseline = _settled_rss_bytes()
-            retrieve.build_runtime_graph(s)
-            settled = _settled_rss_bytes()
-        return settled - baseline
-
-    # In-parent arm first: detection runs locally, leaving arenas resident.
-    in_parent_delta = _build_arm(seed_base=10_000, in_parent=True)
-    gc.collect()
-    _settled_rss_bytes()
-
-    # Isolated arm: detection runs in the ephemeral child.
-    isolated_delta = _build_arm(seed_base=50_000, in_parent=False)
-
-    # The isolated build must leave a materially smaller resident delta in the
-    # parent. Allow generous slack — the proof is the order-of-magnitude gap,
-    # not a tight bound. Below the noise floor the comparison is meaningless:
-    # under full-suite memory pressure the allocator can serve the in-parent
-    # arenas from already-resident freed pages, collapsing BOTH deltas to
-    # sub-MB values whose ordering is page-reuse noise. Sub-floor deltas mean
-    # the parent retained no material arena in either arm — the exact
-    # property this test protects.
-    noise_floor = 4 * 1024 * 1024
-    assert isolated_delta < max(in_parent_delta, noise_floor), (
+    print(
+        f"\n[detection-rss] in_parent_peak={in_parent_peak:.1f}MB "
+        f"isolated_peak={isolated_peak:.1f}MB"
+    )
+    assert isolated_peak < in_parent_peak * 0.95, (
         f"child isolation did not lower the parent footprint: "
-        f"in_parent_delta={in_parent_delta / 1e6:.1f}MB "
-        f"isolated_delta={isolated_delta / 1e6:.1f}MB"
+        f"in_parent_peak={in_parent_peak:.1f}MB "
+        f"isolated_peak={isolated_peak:.1f}MB"
     )

--- a/tests/test_runtime_graph_centrality_child.py
+++ b/tests/test_runtime_graph_centrality_child.py
@@ -20,12 +20,7 @@ Three guarantees are pinned here:
 """
 from __future__ import annotations
 
-import json
-import os
 import platform
-import subprocess
-import sys
-import textwrap
 from datetime import datetime, timezone
 from pathlib import Path
 from uuid import UUID, uuid4
@@ -37,6 +32,7 @@ from iai_mcp import retrieve, runtime_graph_cache
 from iai_mcp.graph import MemoryGraph
 from iai_mcp.store import MemoryStore
 from iai_mcp.types import MemoryRecord
+from tests._runtime_graph_rss_arm import run_runtime_graph_rss_arm
 
 
 @pytest.fixture(autouse=True)
@@ -496,101 +492,9 @@ def test_centrality_only_worker_skips_community_detection():
         assert abs(child_map[node_uuid] - ref_val) <= 1e-6
 
 
-# Worker run by each arm of the parent-RSS isolation proof in its OWN fresh
-# process.  Seeds a store, builds the runtime graph either with the centrality
-# child isolated (the real path) or forced in-parent (detection + exact
-# betweenness resident), then prints the child's own peak RSS taken from
-# getrusage(RUSAGE_SELF).  Each arm in a clean process means the measurement is
-# the resident high-water of that build alone, free of the in-process
-# accumulation and arm-ordering that made an in-parent before/after delta flake.
-_RSS_ARM_WORKER = textwrap.dedent(
-    """
-    import json, resource, sys
-    from datetime import datetime, timezone
-    from uuid import uuid4
-
-    import numpy as np
-
-    from iai_mcp import retrieve, runtime_graph_cache
-    import iai_mcp.community as _cm
-    from iai_mcp.store import MemoryStore
-    from iai_mcp.store._buffers import flush_edge_buffer, flush_record_buffer
-    from iai_mcp.types import MemoryRecord
-
-    seed_base = int(sys.argv[1])
-    in_parent = sys.argv[2] == "in_parent"
-    root = sys.argv[3]
-    n_records = int(sys.argv[4])
-
-    s = MemoryStore(path=root + "/store")
-    import pathlib
-    s.root = pathlib.Path(root) / "root"
-    s.root.mkdir(parents=True, exist_ok=True)
-    now = datetime.now(timezone.utc)
-    for i in range(n_records):
-        rng = np.random.default_rng(seed_base + i)
-        vec = rng.random(s.embed_dim).astype(np.float32)
-        vec = (vec / np.linalg.norm(vec)).tolist()
-        s.insert(MemoryRecord(
-            id=uuid4(), tier="episodic",
-            literal_surface=f"surface number {seed_base + i} carrying real text",
-            aaak_index="", embedding=vec, community_id=None, centrality=0.0,
-            detail_level=2, pinned=False, stability=0.0, difficulty=0.0,
-            last_reviewed=None, never_decay=False, never_merge=False,
-            provenance=[], created_at=now, updated_at=now,
-            tags=[f"tag{(seed_base + i) % 3}"], language="en",
-        ))
-    flush_record_buffer(s)
-    flush_edge_buffer(s)
-
-    if in_parent:
-        def _local_detect(store, graph, *, with_centrality=False):
-            assignment = _cm.detect_communities(graph, prior=None, prior_mode="seeded")
-            if with_centrality:
-                return assignment, None
-            return assignment
-        retrieve._detect_communities_isolated = _local_detect
-        runtime_graph_cache.compute_centrality_in_child = (
-            lambda graph, **kw: graph.centrality()
-        )
-
-    retrieve.build_runtime_graph(s)
-    peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
-    print(json.dumps({"peak_rss_raw": peak}))
-    """
-)
-
-
-def _ru_maxrss_mb(raw: int) -> float:
-    if platform.system() == "Darwin":
-        return raw / (1024 * 1024)
-    return raw / 1024
-
-
-def _run_rss_arm(seed_base: int, in_parent: bool, root: Path, n_records: int) -> float:
-    env = os.environ.copy()
-    env["LILLI_STORAGE_DRIVER"] = "lilli"
-    env["IAI_MCP_CRYPTO_PASSPHRASE"] = "test-passphrase-not-secret"
-    proc = subprocess.run(
-        [
-            sys.executable, "-c", _RSS_ARM_WORKER,
-            str(seed_base),
-            "in_parent" if in_parent else "isolated",
-            str(root),
-            str(n_records),
-        ],
-        capture_output=True, text=True, env=env, timeout=600,
-    )
-    assert proc.returncode == 0, (
-        f"RSS arm subprocess failed (rc={proc.returncode}):\n{proc.stderr}"
-    )
-    payload = json.loads(proc.stdout.strip().splitlines()[-1])
-    return _ru_maxrss_mb(int(payload["peak_rss_raw"]))
-
-
 @pytest.mark.skipif(
     platform.system() != "Darwin",
-    reason="settled-RSS isolation proof calibrated on this host's allocator",
+    reason="peak-RSS isolation proof calibrated on this host's allocator",
 )
 def test_parent_rss_lower_with_centrality_child(store: MemoryStore):
     """Building the runtime graph with the centrality child keeps the parent RSS
@@ -607,18 +511,28 @@ def test_parent_rss_lower_with_centrality_child(store: MemoryStore):
     """
     n_records = 3000
 
-    in_parent_peak = _run_rss_arm(
-        seed_base=20_000, in_parent=True, root=store.root / "in_parent", n_records=n_records
+    in_parent_peak = run_runtime_graph_rss_arm(
+        proof="centrality",
+        driver="lilli",
+        seed_base=20_000,
+        in_parent=True,
+        root=store.root / "in_parent",
+        n_records=n_records,
     )
-    isolated_peak = _run_rss_arm(
-        seed_base=60_000, in_parent=False, root=store.root / "isolated", n_records=n_records
+    isolated_peak = run_runtime_graph_rss_arm(
+        proof="centrality",
+        driver="lilli",
+        seed_base=20_000,
+        in_parent=False,
+        root=store.root / "isolated",
+        n_records=n_records,
     )
 
     print(
         f"\n[centrality-rss] in_parent_peak={in_parent_peak:.1f}MB "
         f"isolated_peak={isolated_peak:.1f}MB"
     )
-    assert isolated_peak < in_parent_peak, (
+    assert isolated_peak < in_parent_peak * 0.95, (
         f"centrality child isolation did not lower the parent footprint: "
         f"in_parent_peak={in_parent_peak:.1f}MB "
         f"isolated_peak={isolated_peak:.1f}MB"

--- a/tests/test_watchdog_phys_footprint.py
+++ b/tests/test_watchdog_phys_footprint.py
@@ -17,6 +17,8 @@ import json
 import os
 import platform
 import signal
+import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -46,12 +48,30 @@ def test_phys_footprint_reads_positive_int_on_macos() -> None:
 
 
 @pytest.mark.skipif(not DARWIN, reason="phys_footprint is a macOS metric")
-def test_phys_footprint_not_above_rss_on_clean_process() -> None:
+def test_phys_footprint_clean_process_smoke() -> None:
+    """Both probes return coherent values in an interpreter without heap history."""
     # phys_footprint excludes reusable (MADV_FREE) pages that still count toward
-    # resident_size, so it can only be <= RSS (a small slack absorbs the race
-    # between the two reads on a live, churning heap).
-    rss = wd._own_rss_bytes()
-    phys = wd._phys_footprint_bytes()
+    # resident_size. A fresh interpreter avoids allocator history; 5% slack
+    # covers the race between the two live-process readings.
+    probe = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json; "
+                "from iai_mcp.daemon import _watchdog as wd; "
+                "print(json.dumps({'rss': wd._own_rss_bytes(), "
+                "'phys': wd._phys_footprint_bytes()}))"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+    payload = json.loads(probe.stdout.strip().splitlines()[-1])
+    rss = payload["rss"]
+    phys = payload["phys"]
     assert rss is not None and phys is not None
     assert phys <= rss * 1.05, (
         f"phys_footprint ({phys}) should not exceed resident_size ({rss}); "


### PR DESCRIPTION
## Summary

Run the macOS memory assertions in fresh interpreter processes instead of measuring deltas inside the long-lived pytest worker. This removes allocator-history and arm-ordering dependence while strengthening the child-isolation checks.

This is intended to make the macOS correctness gate reliable before the separate fix for #86.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor (no behaviour change)
- [ ] Documentation
- [x] Build / tooling

## Affected areas

- [ ] Capture path
- [ ] Recall / retrieval
- [ ] Consolidation / sleep cycles
- [ ] Daemon lifecycle / FSM
- [ ] Storage / encryption at rest
- [ ] MCP wrapper (TypeScript)
- [ ] Bench harness
- [ ] CLI / doctor
- [x] Other: macOS CI test infrastructure

## Testing

- [x] `pytest` passes locally
- [ ] `ruff check src/ tests/` clean
- [x] New tests added for changed behaviour, or rationale below for why not

Exact pull-request gate reproduced locally on macOS with Python 3.12.13 and Rust 1.87.0:

`pytest --timeout=600 -m "not perf and not slow and not live"`

Result: 5508 passed, 106 skipped, 111 deselected, 4 xfailed, 0 failed.

`pip wheel . --no-deps` also completed successfully.

The repository-wide ruff baseline is not currently clean. The new helper and watchdog test are clean, and the edited test files introduce no new diagnostics relative to `origin/main`.

## Benchmarks

Not applicable: this PR changes test measurement only and does not modify production retrieval, capture, or consolidation behaviour.

## Notes for reviewers

Each comparison arm now runs in its own fresh interpreter with identical seeded data.

Observed peak RSS:

- Detection: 295.9 MB in-parent vs 248.5 MB isolated (~16% lower)
- Centrality: 366.8 MB in-parent vs 267.7 MB isolated (~27% lower)

Both assertions require the isolated arm to remain at least 5% below the in-parent arm. No test is skipped, marked xfail, or weakened.
