### PR TITLE
Add decoding regression coverage for all idle-detector readers

### DIFF
--- a/tests/test_idle_detector.py
+++ b/tests/test_idle_detector.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 
-from iai_mcp.idle_detector import IdleDetector, IdleStatus
+from iai_mcp.idle_detector import IdleDetector, IdleStatus, _pmset_responsive
 
 
 def _completed_process(
@@ -113,10 +113,10 @@ def test_pmset_recent_sleep_returns_false_when_pmset_missing() -> None:
 
 
 def test_pmset_recent_sleep_survives_invalid_utf8_in_log() -> None:
-    log = _pmset_log_stdout([
-        (_now_pmset_ts(offset_min=2), "System Sleep"),
-    ])
-    corrupted = b"\xd2 garbage line\n" + log.encode("utf-8")
+    corrupted = (
+        f"{_now_pmset_ts(offset_min=2)} ".encode()
+        + b"\xd2 System Sleep Notification clientId=foo\n"
+    )
     fake = _completed_process(stdout=corrupted)
     with patch("iai_mcp.idle_detector.subprocess.run", return_value=fake):
         result = IdleDetector().pmset_recent_sleep(window_min=5)
@@ -129,6 +129,16 @@ def test_hid_idle_time_sec_survives_invalid_utf8() -> None:
     with patch("iai_mcp.idle_detector.subprocess.run", return_value=fake):
         result = IdleDetector().hid_idle_time_sec()
     assert result == 42
+
+
+def test_pmset_responsive_survives_invalid_utf8() -> None:
+    fake = _completed_process(stdout=b"AC Power \xd2\n")
+    with patch(
+        "iai_mcp.idle_detector.subprocess.run",
+        return_value=fake,
+    ):
+        result = _pmset_responsive()
+    assert result is True
 
 
 def test_sleep_eligible_heartbeat_idle_path() -> None:
@@ -258,6 +268,16 @@ def test_logind_session_paths_picks_own_uid_seat_session() -> None:
             [("c2", _OWN_UID, "testuser", "seat0", "/org/freedesktop/login1/session/c2")]
         )
     )
+    with patch("iai_mcp.idle_detector.subprocess.run", return_value=fake):
+        result = IdleDetector()._logind_session_paths()
+    assert result == ["/org/freedesktop/login1/session/c2"]
+
+
+def test_logind_session_paths_survives_invalid_utf8() -> None:
+    raw = _busctl_list_sessions_json(
+        [("c2", _OWN_UID, "testuser", "seat0", "/org/freedesktop/login1/session/c2")]
+    ).encode("utf-8")
+    fake = _completed_process(stdout=raw.replace(b"testuser", b"test\xd2user"))
     with patch("iai_mcp.idle_detector.subprocess.run", return_value=fake):
         result = IdleDetector()._logind_session_paths()
     assert result == ["/org/freedesktop/login1/session/c2"]


### PR DESCRIPTION
## Summary

Repointed against current `main` as requested after the production fix shipped in v2.6.1. This PR now contains regression coverage only; it makes no production-code changes.

The shared lenient-decoding helper serves four system readers. The test coverage now exercises all four paths:

- `ioreg` HID idle output (existing invalid-UTF-8 test retained);
- `pmset -g log`, strengthened so the invalid byte occurs inside an otherwise valid sleep-event line;
- `pmset -g` responsiveness output;
- Linux `busctl` JSON output.

This is regression coverage for #86.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / tooling
- [x] Other: regression tests

## Affected areas

- [ ] Capture path
- [ ] Recall / retrieval
- [ ] Consolidation / sleep cycles
- [x] Daemon lifecycle / FSM
- [ ] Storage / encryption at rest
- [ ] MCP wrapper (TypeScript)
- [ ] Bench harness
- [x] Other: macOS and Linux idle detection

## Testing

- [ ] `pytest` passes locally
- [ ] `ruff check src/ tests/` clean
- [x] New tests added for changed behaviour, or rationale below for why not

Targeted validation:

- `pytest -q tests/test_idle_detector.py`: 37 passed
- `ruff check tests/test_idle_detector.py`: passed
- `git diff --check`: passed

Full local suite:

- 5511 passed, 216 skipped, 4 xfailed, 2 failed

Both failures are checkout-environment mismatches unrelated to this test-only diff:

- the local installed distribution is still 2.6.0 while current `main` declares 2.6.1;
- the checkout contains both Python 3.11 and Python 3.12 native extension binaries, while the test requires exactly one.

The pull-request CI will validate the branch in a clean environment. The repository-wide Ruff baseline is not currently clean; the touched file introduces no Ruff diagnostics.

## Benchmarks

Not applicable: this PR changes tests only.

## Notes for reviewers

The previous implementation change has been removed because v2.6.1 already ships the shared `_run_captured` fix. The branch is rebased onto current `main` and now preserves only the stronger regression coverage requested in review.