### PR TITLE
Resolve the iai-mcp CLI from PATH in the session-recall hook

### DIFF
--- a/plugin/hooks/iai-mcp-session-recall.sh
+++ b/plugin/hooks/iai-mcp-session-recall.sh
@@ -73,8 +73,11 @@ fi
 #   1. IAI_MCP_SESSION_RECALL_CLI environment variable (developer override
 #      for non-standard install locations; export in your shell init).
 #   2. ~/.iai-mcp/.cli-path cache file (auto-populated below once the
-#      candidates array finds a working binary).
-#   3. Generic install locations in the candidates array.
+#      lookup finds a working binary).
+#   3. `command -v iai-mcp` — PATH lookup; picks up pyenv shims, pipx
+#      wrappers, and any other PATH-managed install transparently.
+#   4. Generic install locations in the candidates array, checked when PATH
+#      has no entry.
 # Only generic install paths are baked into the source; developer-specific
 # paths belong in the env var or the cache, never here.
 cli_cache="$HOME/.iai-mcp/.cli-path"
@@ -87,7 +90,18 @@ if [ -z "$iai_cli" ] && [ -f "$cli_cache" ]; then
   [ -x "$cached" ] && iai_cli="$cached"
 fi
 if [ -z "$iai_cli" ]; then
+  resolved=$(command -v iai-mcp 2>/dev/null || true)
+  if [ -n "$resolved" ] && [ -x "$resolved" ]; then
+    iai_cli="$resolved"
+    printf '%s' "$iai_cli" > "$cli_cache" 2>/dev/null || true
+  fi
+fi
+if [ -z "$iai_cli" ]; then
   for candidate in \
+    "$HOME/.pyenv/shims/iai-mcp" \
+    "$HOME/.local/bin/iai-mcp" \
+    "$HOME/.local/pipx/venvs/iai-mcp/bin/iai-mcp" \
+    "/opt/homebrew/bin/iai-mcp" \
     "$HOME/IAI-MCP/.venv/bin/iai-mcp" \
     "/usr/local/bin/iai-mcp"
   do

--- a/src/iai_mcp/_deploy/hooks/iai-mcp-session-recall.sh
+++ b/src/iai_mcp/_deploy/hooks/iai-mcp-session-recall.sh
@@ -73,8 +73,11 @@ fi
 #   1. IAI_MCP_SESSION_RECALL_CLI environment variable (developer override
 #      for non-standard install locations; export in your shell init).
 #   2. ~/.iai-mcp/.cli-path cache file (auto-populated below once the
-#      candidates array finds a working binary).
-#   3. Generic install locations in the candidates array.
+#      lookup finds a working binary).
+#   3. `command -v iai-mcp` — PATH lookup; picks up pyenv shims, pipx
+#      wrappers, and any other PATH-managed install transparently.
+#   4. Generic install locations in the candidates array, checked when PATH
+#      has no entry.
 # Only generic install paths are baked into the source; developer-specific
 # paths belong in the env var or the cache, never here.
 cli_cache="$HOME/.iai-mcp/.cli-path"
@@ -87,7 +90,18 @@ if [ -z "$iai_cli" ] && [ -f "$cli_cache" ]; then
   [ -x "$cached" ] && iai_cli="$cached"
 fi
 if [ -z "$iai_cli" ]; then
+  resolved=$(command -v iai-mcp 2>/dev/null || true)
+  if [ -n "$resolved" ] && [ -x "$resolved" ]; then
+    iai_cli="$resolved"
+    printf '%s' "$iai_cli" > "$cli_cache" 2>/dev/null || true
+  fi
+fi
+if [ -z "$iai_cli" ]; then
   for candidate in \
+    "$HOME/.pyenv/shims/iai-mcp" \
+    "$HOME/.local/bin/iai-mcp" \
+    "$HOME/.local/pipx/venvs/iai-mcp/bin/iai-mcp" \
+    "/opt/homebrew/bin/iai-mcp" \
     "$HOME/IAI-MCP/.venv/bin/iai-mcp" \
     "/usr/local/bin/iai-mcp"
   do

--- a/tests/test_session_recall_hook_cli_lookup.py
+++ b/tests/test_session_recall_hook_cli_lookup.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="POSIX shell hook"
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOK_PATH = (
+    REPO_ROOT / "src" / "iai_mcp" / "_deploy" / "hooks" / "iai-mcp-session-recall.sh"
+)
+
+
+def _make_stub_cli(dir_: Path) -> Path:
+    dir_.mkdir(parents=True, exist_ok=True)
+    cli = dir_ / "iai-mcp"
+    cli.write_text("#!/usr/bin/env bash\necho RECALLED\n")
+    cli.chmod(cli.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return cli
+
+
+def _run_hook(home: Path, path_entries: list[str]):
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    # Drop any developer override so the test exercises the built-in lookup.
+    env.pop("IAI_MCP_SESSION_RECALL_CLI", None)
+    env["PATH"] = os.pathsep.join([*path_entries, "/usr/bin", "/bin"])
+    return subprocess.run(
+        ["bash", str(HOOK_PATH)],
+        input='{"session_id":"x","source":"startup","cwd":"/tmp","transcript_path":""}',
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15.0,
+    )
+
+
+def test_hook_resolves_cli_from_path(tmp_path):
+    """A pip/pipx install that is only reachable via PATH must be found.
+
+    The candidate list cannot enumerate every install layout, so PATH is
+    consulted before falling back to it. Without this the hook exits 0 with
+    no output and recall is silently disabled.
+    """
+    home = tmp_path / "home"
+    (home / ".iai-mcp").mkdir(parents=True)
+    stub_dir = tmp_path / "path-only"
+    _make_stub_cli(stub_dir)
+
+    proc = _run_hook(home, [str(stub_dir)])
+
+    assert proc.returncode == 0, proc.stderr
+    cache = home / ".iai-mcp" / ".cli-path"
+    assert cache.exists(), "PATH-resolved CLI was not cached"
+    assert cache.read_text().strip() == str(stub_dir / "iai-mcp")
+
+
+def test_hook_resolves_cli_from_user_local_bin(tmp_path):
+    """`pip install --user` lands in ~/.local/bin; it must be a candidate."""
+    home = tmp_path / "home"
+    (home / ".iai-mcp").mkdir(parents=True)
+    _make_stub_cli(home / ".local" / "bin")
+
+    # Not on PATH — force the candidate-list branch to do the work.
+    proc = _run_hook(home, [])
+
+    assert proc.returncode == 0, proc.stderr
+    cache = home / ".iai-mcp" / ".cli-path"
+    assert cache.exists(), "~/.local/bin CLI was not found"
+    assert cache.read_text().strip() == str(home / ".local" / "bin" / "iai-mcp")
+
+
+def test_hook_still_exits_zero_when_cli_is_absent(tmp_path):
+    """Fail-safe is preserved: no CLI anywhere is still a silent exit 0."""
+    home = tmp_path / "home"
+    (home / ".iai-mcp").mkdir(parents=True)
+
+    proc = _run_hook(home, [])
+
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == ""
+    assert not (home / ".iai-mcp" / ".cli-path").exists()


### PR DESCRIPTION
## Summary

`iai-mcp-session-recall.sh` looked for the CLI in only two hardcoded locations (`~/IAI-MCP/.venv/bin`, `/usr/local/bin`). A standard `pip install` puts it in `~/.local/bin`, and pipx/pyenv/Homebrew installs land elsewhere again, so the hook found nothing.

Because the hook is fail-safe by design (exit 0, empty stdout on every error path), the result is silent: session recall is simply never injected, and the only trace is a `skipped: iai-mcp CLI not found` line in `~/.iai-mcp/logs/recall-YYYY-MM-DD.log`.

`iai-mcp-session-capture.sh` already solves this — it consults `command -v iai-mcp` before its candidate list, and that list covers pyenv shims, pipx, Homebrew and `~/.local/bin`. This PR gives the recall hook the same resolution order, so the two halves of the hook pair agree.

Found on a macOS install where capture worked and recall silently did not.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / tooling

## Affected areas

- [ ] Capture path
- [x] Recall / retrieval
- [ ] Consolidation / sleep cycles
- [ ] Daemon lifecycle / FSM
- [ ] Storage / encryption at rest
- [ ] MCP wrapper (TypeScript)
- [ ] Bench harness
- [ ] CLI / doctor
- [x] Other: Claude Code hook scripts

## Testing

- [x] `pytest` passes locally
- [ ] `ruff check src/ tests/` clean
- [x] New tests added for changed behaviour

`tests/test_session_recall_hook_cli_lookup.py` covers three cases: resolution via PATH, resolution via `~/.local/bin` when PATH has no entry, and the unchanged fail-safe when no CLI exists anywhere.

Verified red/green against the unpatched hook:

```
# origin/main
FAILED test_hook_resolves_cli_from_path
FAILED test_hook_resolves_cli_from_user_local_bin
2 failed, 1 passed

# this branch
3 passed
```

`tests/test_plugin_manifest.py` passes, so the `plugin/hooks/` and `src/iai_mcp/_deploy/hooks/` copies remain byte-identical.

I could not run `ruff` — it is not installed in my environment, and I did not want to add it to the venv this box runs the daemon from. The change is shell-only plus one new test file written in the style of `tests/test_session_recall_hook_failsafe_exit_zero.py`.

## Benchmarks

Not applicable — no retrieval, capture, or consolidation logic changes. The patch only affects how the hook locates the CLI binary.

## Notes for reviewers

- No behaviour change when the CLI is already found: the env-var override and `.cli-path` cache still take priority, in that order.
- The fail-safe contract is preserved — the added lookup cannot introduce a non-zero exit.
- `iai-mcp-per-turn-recall.sh` and `iai-mcp-turn-capture.sh` do not invoke the CLI, so they need no equivalent change.