### PR TITLE
Reach the numba ImportError fallback in detect_communities

### DIFF
--- a/src/iai_mcp/community.py
+++ b/src/iai_mcp/community.py
@@ -101,9 +101,7 @@ def detect_communities(
     prior: CommunityAssignment | None = None,
     prior_mode: Literal["seeded", "cold"] = "seeded",
 ) -> CommunityAssignment:
-    from iai_mcp.mosaic import run_mosaic
     from iai_mcp.mosaic_lineage import LineageReport
-    from iai_mcp.mosaic_policy import CPM_MODULARITY_FLOOR
 
     n = graph.node_count()
     if n == 0:
@@ -116,6 +114,14 @@ def detect_communities(
         return flat
 
     try:
+        # Imported inside the guard, not at function entry: iai_mcp.mosaic
+        # imports numba at module scope and mosaic_policy reaches numba
+        # through it. A missing or ABI-mismatched numba raises at import
+        # time, which must degrade to the flat assignment below rather than
+        # propagate out of detect_communities and fail the whole recall.
+        from iai_mcp.mosaic import run_mosaic
+        from iai_mcp.mosaic_policy import CPM_MODULARITY_FLOOR
+
         inner_assignment, lineage_report = run_mosaic(
             graph, prior=prior, prior_mode=prior_mode, seed=42
         )

--- a/tests/test_community_numba_import_fallback.py
+++ b/tests/test_community_numba_import_fallback.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import builtins
+import random
+import sys
+from uuid import uuid4
+
+import pytest
+
+from iai_mcp.community import detect_communities
+from iai_mcp.graph import MemoryGraph
+
+
+def _random_emb(seed: int) -> list[float]:
+    rng = random.Random(seed)
+    return [rng.random() for _ in range(384)]
+
+
+def _two_clique_graph() -> MemoryGraph:
+    """A graph large enough to take the mosaic path rather than a flat return."""
+    g = MemoryGraph()
+    clique_a = [uuid4() for _ in range(150)]
+    clique_b = [uuid4() for _ in range(150)]
+    for i, n in enumerate(clique_a):
+        g.add_node(n, community_id=None, embedding=_random_emb(i))
+    for i, n in enumerate(clique_b):
+        g.add_node(n, community_id=None, embedding=_random_emb(10_000 + i))
+    for i in range(150):
+        for j in range(i + 1, 150):
+            g.add_edge(clique_a[i], clique_a[j])
+            g.add_edge(clique_b[i], clique_b[j])
+    return g
+
+
+@pytest.fixture
+def broken_numba(monkeypatch):
+    """Make `import numba` fail the way a numpy ABI mismatch does.
+
+    numba raises ImportError from its own package __init__ when the installed
+    numpy is newer than it supports, so the failure lands at import time
+    rather than on first kernel call.
+    """
+    for name in [m for m in sys.modules if m == "numba" or m.startswith("numba.")]:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+    for name in [m for m in sys.modules if m.startswith("iai_mcp.mosaic")]:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "numba" or name.startswith("numba."):
+            raise ImportError("Numba needs NumPy 2.4 or less. Got NumPy 2.5.")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+def test_detect_communities_falls_back_when_numba_import_fails(broken_numba):
+    """A broken numba must degrade to the flat backend instead of raising.
+
+    The ImportError arm of the try/except was already there but unreachable:
+    `from iai_mcp.mosaic import run_mosaic` sat above the guard, so the error
+    escaped detect_communities and surfaced on every MCP tool call.
+    """
+    g = _two_clique_graph()
+
+    assignment = detect_communities(g, prior=None, prior_mode="seeded")
+
+    assert assignment.backend == "flat"
+    assert assignment.node_to_community
+
+
+def test_detect_communities_uses_mosaic_when_numba_is_healthy():
+    """Guard against the fallback quietly masking a real mosaic regression."""
+    pytest.importorskip("numba")
+    g = _two_clique_graph()
+
+    assignment = detect_communities(g, prior=None, prior_mode="seeded")
+
+    assert assignment.backend.startswith("leiden")


### PR DESCRIPTION
## Summary

`detect_communities` already degrades to the flat assignment on `ImportError`, but the handler could never fire for the case it was written for.

```python
def detect_communities(...):
    from iai_mcp.mosaic import run_mosaic          # ← module scope: imports numba
    ...
    try:
        inner_assignment, lineage_report = run_mosaic(...)
    except (ImportError, RuntimeError, ValueError, TypeError):
        flat = _flat_assignment(graph, prior)      # ← unreachable for import failures
        return flat
```

`iai_mcp.mosaic` does `from numba import njit` at module scope, and numba raises `ImportError` from its own `__init__` when the installed numpy is newer than it supports. The error therefore lands on the import line, above the guard, and propagates out of `detect_communities`.

Observed effect: **every** MCP tool call returned `error: Numba needs NumPy 2.4 or less. Got NumPy 2.5.` The server completed the MCP handshake and looked healthy, so the failure read as a broken server rather than a dependency problem. The daemon also re-raised it on each hippea cascade iteration, which grew `launchd-stderr.log` to 111 MB.

Real traceback from that box:

```
File "src/iai_mcp/retrieve.py", line 656, in _detect_communities_isolated
  assignment = detect_communities(graph, prior=None, prior_mode="seeded")
File "src/iai_mcp/community.py", line 104, in detect_communities
  from iai_mcp.mosaic import run_mosaic
File "src/iai_mcp/mosaic.py", line 10, in <module>
  from numba import njit
ImportError: Numba needs NumPy 2.4 or less. Got NumPy 2.5.
```

This moves the numba-tainted imports inside the guard. `mosaic_policy` reaches numba transitively (`mosaic_policy.py:7` imports from `iai_mcp.mosaic`), so it moves too. `mosaic_lineage` is numba-free and stays at function scope, where the `n == 0` and `n < SMALL_N_FLAT` early returns need `LineageReport`.

The environment that triggered this had a corrupted install — two numpy dist-info dirs, so `pip list` reported a compatible 2.2.6 while 2.5.1 was actually loaded. The pin in `pyproject.toml` is correct; the point of this PR is that the existing graceful-degradation path should hold when a venv drifts, rather than taking down every tool call.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / tooling

## Affected areas

- [ ] Capture path
- [x] Recall / retrieval
- [x] Consolidation / sleep cycles
- [ ] Daemon lifecycle / FSM
- [ ] Storage / encryption at rest
- [ ] MCP wrapper (TypeScript)
- [ ] Bench harness
- [ ] CLI / doctor
- [ ] Other: ___

## Testing

- [x] `pytest` passes locally
- [ ] `ruff check src/ tests/` clean
- [x] New tests added for changed behaviour

`tests/test_community_numba_import_fallback.py` simulates the ABI mismatch by making `import numba` raise, then asserts `detect_communities` returns the flat backend instead of propagating. A companion test asserts the leiden path is still taken when numba is healthy, so the fallback cannot silently mask a real mosaic regression.

Red/green against unpatched `community.py`:

```
# origin/main
FAILED test_detect_communities_falls_back_when_numba_import_fails
  ImportError: Numba needs NumPy 2.4 or less. Got NumPy 2.5.
1 failed, 1 passed

# this branch
2 passed
```

No regressions in the surrounding suites:

```
pytest tests/test_community.py tests/test_mosaic_integration.py tests/test_mosaic_lineage.py
53 passed
```

`ruff` is not installed in my environment and I did not want to modify the venv this machine runs the daemon from, so that box is unchecked. The diff is an import move plus a comment.

## Benchmarks

Not applicable. On a healthy numba the code path is unchanged — the same imports resolve, just a few lines later, and `run_mosaic` is called identically. The behaviour change is confined to the failure path, which previously raised and now returns the flat assignment that was always intended.

## Notes for reviewers

- Function-level imports are kept (not hoisted to module scope) because `iai_mcp.mosaic` imports `_flat_assignment` back from `iai_mcp.community`; hoisting would make the cycle real.
- `CPM_MODULARITY_FLOOR` is only read after the `try`, on the success path, so moving it inside the guard leaves its binding available where it is used.
- Worth a look: `retrieve.py:_detect_communities_isolated` catches the child-process failure and then calls `detect_communities` in-process, which hit the same import and raised again. With this change that second attempt degrades instead. I left that call structure alone since it is correct once the fallback works.