### PR TITLE
feat(capture): extract tool blocks from adapter transcripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,8 @@ iai_mcp = [
     "_deploy/systemd/*.service",
     "_deploy/windows/*.xml",
     "_deploy/hooks/*.sh",
+    "_deploy/hooks/*.ps1",
+    "_deploy/windows/*.xml",
     "_deploy/brainview/*.html",
     "_wrapper/*.js",
 ]

--- a/src/iai_mcp/_deploy/hooks/iai-mcp-antigravity-capture.ps1
+++ b/src/iai_mcp/_deploy/hooks/iai-mcp-antigravity-capture.ps1
@@ -32,3 +32,4 @@ if (Test-Path $liveFile) {
     $newName = "$sessionId.live-$ts-$pidId.jsonl"
     Rename-Item -Path $liveFile -NewName $newName -ErrorAction SilentlyContinue
 }
+

--- a/src/iai_mcp/_deploy/hooks/iai-mcp-antigravity-capture.ps1
+++ b/src/iai_mcp/_deploy/hooks/iai-mcp-antigravity-capture.ps1
@@ -1,4 +1,4 @@
-﻿$inputJson = $input | Out-String | ConvertFrom-Json -ErrorAction SilentlyContinue
+$inputJson = $input | Out-String | ConvertFrom-Json -ErrorAction SilentlyContinue
 if (-not $inputJson) { exit 0 }
 
 $sessionId = $inputJson.conversationId
@@ -19,8 +19,14 @@ if (-not $transcriptPath -or -not (Test-Path $transcriptPath)) {
     exit 0
 }
 
-$cli = "C:\iai-personal-memory-engine\.venv\Scripts\iai-mcp.exe"
-if (-not (Test-Path $cli)) { exit 0 }
+$cli = $null
+$command = Get-Command iai-mcp -ErrorAction SilentlyContinue
+if ($command) { $cli = $command.Source }
+if (-not $cli) {
+    $pipxPath = [System.IO.Path]::Combine($env:USERPROFILE, ".local", "pipx", "venvs", "iai-pme", "Scripts", "iai-mcp.exe")
+    if (Test-Path $pipxPath) { $cli = $pipxPath }
+}
+if (-not $cli) { exit 0 }
 
 & $cli capture-turn-deferred --session-id $sessionId --transcript-path $transcriptPath --max-turns-per-call 1000
 

--- a/src/iai_mcp/_deploy/hooks/iai-mcp-antigravity-capture.ps1
+++ b/src/iai_mcp/_deploy/hooks/iai-mcp-antigravity-capture.ps1
@@ -1,0 +1,34 @@
+﻿$inputJson = $input | Out-String | ConvertFrom-Json -ErrorAction SilentlyContinue
+if (-not $inputJson) { exit 0 }
+
+$sessionId = $inputJson.conversationId
+if (-not $sessionId) { $sessionId = $inputJson.conversation_id }
+if (-not $sessionId) { $sessionId = $inputJson.session_id }
+
+$transcriptPath = $inputJson.transcriptPath
+if (-not $transcriptPath) { $transcriptPath = $inputJson.transcript_path }
+
+if ($transcriptPath -and $transcriptPath.EndsWith("transcript.jsonl")) {
+    $fullPath = $transcriptPath.Substring(0, $transcriptPath.Length - "transcript.jsonl".Length) + "transcript_full.jsonl"
+    if (Test-Path $fullPath) {
+        $transcriptPath = $fullPath
+    }
+}
+
+if (-not $transcriptPath -or -not (Test-Path $transcriptPath)) {
+    exit 0
+}
+
+$cli = "C:\iai-personal-memory-engine\.venv\Scripts\iai-mcp.exe"
+if (-not (Test-Path $cli)) { exit 0 }
+
+& $cli capture-turn-deferred --session-id $sessionId --transcript-path $transcriptPath --max-turns-per-call 1000
+
+$deferredDir = [System.IO.Path]::Combine($env:USERPROFILE, ".iai-mcp", ".deferred-captures")
+$liveFile = [System.IO.Path]::Combine($deferredDir, "$sessionId.live.jsonl")
+if (Test-Path $liveFile) {
+    $ts = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+    $pidId = $PID
+    $newName = "$sessionId.live-$ts-$pidId.jsonl"
+    Rename-Item -Path $liveFile -NewName $newName -ErrorAction SilentlyContinue
+}

--- a/src/iai_mcp/_deploy/hooks/iai-mcp-antigravity-recall.ps1
+++ b/src/iai_mcp/_deploy/hooks/iai-mcp-antigravity-recall.ps1
@@ -1,0 +1,9 @@
+$inputJson = $input | Out-String | ConvertFrom-Json -ErrorAction SilentlyContinue
+if (-not $inputJson) { exit 0 }
+$sessionId = $inputJson.conversationId
+if (-not $sessionId) { $sessionId = $inputJson.conversation_id }
+if (-not $sessionId) { $sessionId = $inputJson.session_id }
+if (-not $sessionId) { exit 0 }
+$cli = "C:\iai-personal-memory-engine\.venv\Scripts\iai-mcp.exe"
+if (-not (Test-Path $cli)) { exit 0 }
+& $cli session-start --session-id $sessionId

--- a/src/iai_mcp/_deploy/hooks/iai-mcp-antigravity-recall.ps1
+++ b/src/iai_mcp/_deploy/hooks/iai-mcp-antigravity-recall.ps1
@@ -1,10 +1,16 @@
-﻿$inputJson = $input | Out-String | ConvertFrom-Json -ErrorAction SilentlyContinue
+$inputJson = $input | Out-String | ConvertFrom-Json -ErrorAction SilentlyContinue
 if (-not $inputJson) { exit 0 }
 $sessionId = $inputJson.conversationId
 if (-not $sessionId) { $sessionId = $inputJson.conversation_id }
 if (-not $sessionId) { $sessionId = $inputJson.session_id }
 if (-not $sessionId) { exit 0 }
-$cli = "C:\iai-personal-memory-engine\.venv\Scripts\iai-mcp.exe"
-if (-not (Test-Path $cli)) { exit 0 }
+$cli = $null
+$command = Get-Command iai-mcp -ErrorAction SilentlyContinue
+if ($command) { $cli = $command.Source }
+if (-not $cli) {
+    $pipxPath = [System.IO.Path]::Combine($env:USERPROFILE, ".local", "pipx", "venvs", "iai-pme", "Scripts", "iai-mcp.exe")
+    if (Test-Path $pipxPath) { $cli = $pipxPath }
+}
+if (-not $cli) { exit 0 }
 & $cli session-start --session-id $sessionId
 

--- a/src/iai_mcp/_deploy/hooks/iai-mcp-antigravity-recall.ps1
+++ b/src/iai_mcp/_deploy/hooks/iai-mcp-antigravity-recall.ps1
@@ -1,4 +1,4 @@
-$inputJson = $input | Out-String | ConvertFrom-Json -ErrorAction SilentlyContinue
+﻿$inputJson = $input | Out-String | ConvertFrom-Json -ErrorAction SilentlyContinue
 if (-not $inputJson) { exit 0 }
 $sessionId = $inputJson.conversationId
 if (-not $sessionId) { $sessionId = $inputJson.conversation_id }
@@ -7,3 +7,4 @@ if (-not $sessionId) { exit 0 }
 $cli = "C:\iai-personal-memory-engine\.venv\Scripts\iai-mcp.exe"
 if (-not (Test-Path $cli)) { exit 0 }
 & $cli session-start --session-id $sessionId
+

--- a/src/iai_mcp/_deploy/hooks/iai-mcp-auto-scan-antigravity.ps1
+++ b/src/iai_mcp/_deploy/hooks/iai-mcp-auto-scan-antigravity.ps1
@@ -1,6 +1,6 @@
 ﻿$ErrorActionPreference = "SilentlyContinue"
 $brainDir = [System.IO.Path]::Combine($env:USERPROFILE, ".gemini", "antigravity", "brain")
-$captureScript = [System.IO.Path]::Combine($env:USERPROFILE, ".gemini", "config", "iai-hooks", "antigravity-capture.ps1")
+$captureScript = [System.IO.Path]::Combine($env:USERPROFILE, ".gemini", "config", "iai-hooks", "iai-mcp-antigravity-capture.ps1")
 $stateDir = [System.IO.Path]::Combine($env:USERPROFILE, ".iai-mcp", ".capture-state")
 
 if (-not (Test-Path $brainDir) -or -not (Test-Path $captureScript)) { exit 0 }
@@ -31,3 +31,4 @@ Get-ChildItem -Path $brainDir | Where-Object { $_.PSIsContainer -and $_.Name -ma
         }
     }
 }
+

--- a/src/iai_mcp/_deploy/hooks/iai-mcp-auto-scan-antigravity.ps1
+++ b/src/iai_mcp/_deploy/hooks/iai-mcp-auto-scan-antigravity.ps1
@@ -1,0 +1,33 @@
+﻿$ErrorActionPreference = "SilentlyContinue"
+$brainDir = [System.IO.Path]::Combine($env:USERPROFILE, ".gemini", "antigravity", "brain")
+$captureScript = [System.IO.Path]::Combine($env:USERPROFILE, ".gemini", "config", "iai-hooks", "antigravity-capture.ps1")
+$stateDir = [System.IO.Path]::Combine($env:USERPROFILE, ".iai-mcp", ".capture-state")
+
+if (-not (Test-Path $brainDir) -or -not (Test-Path $captureScript)) { exit 0 }
+
+Get-ChildItem -Path $brainDir | Where-Object { $_.PSIsContainer -and $_.Name -match "^[0-9a-f\-]{36}$" } | ForEach-Object {
+    $cid = $_.Name
+    $tpath = [System.IO.Path]::Combine($_.FullName, ".system_generated", "logs", "transcript.jsonl")
+    $fullPath = [System.IO.Path]::Combine($_.FullName, ".system_generated", "logs", "transcript_full.jsonl")
+    
+    $targetFile = $null
+    if (Test-Path $fullPath) { $targetFile = Get-Item $fullPath }
+    elseif (Test-Path $tpath) { $targetFile = Get-Item $tpath }
+    
+    if ($targetFile) {
+        $offsetFile = [System.IO.Path]::Combine($stateDir, "$cid.offset")
+        $shouldProcess = $true
+        
+        if (Test-Path $offsetFile) {
+            $offsetItem = Get-Item $offsetFile
+            if ($targetFile.LastWriteTime -le $offsetItem.LastWriteTime) {
+                $shouldProcess = $false
+            }
+        }
+        
+        if ($shouldProcess) {
+            $json = @{ conversationId = $cid; transcriptPath = $targetFile.FullName } | ConvertTo-Json -Compress
+            $json | powershell.exe -ExecutionPolicy Bypass -NoProfile -File $captureScript -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/src/iai_mcp/_deploy/windows/iai-mcp-antigravity-scan.xml
+++ b/src/iai_mcp/_deploy/windows/iai-mcp-antigravity-scan.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Description>IAI-MCP Antigravity Auto-Scanner -- periodically ingests Antigravity logs for GUI users</Description>
+    <URI>\IaiMcpAntigravityAutoScan</URI>
+  </RegistrationInfo>
+  <Triggers>
+    <LogonTrigger>
+      <Enabled>true</Enabled>
+    </LogonTrigger>
+    <TimeTrigger>
+      <Repetition>
+        <Interval>PT30M</Interval>
+        <StopAtDurationEnd>false</StopAtDurationEnd>
+      </Repetition>
+      <StartBoundary>2000-01-01T00:00:00</StartBoundary>
+      <Enabled>true</Enabled>
+    </TimeTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id="Author">
+      <LogonType>InteractiveToken</LogonType>
+      <RunLevel>LeastPrivilege</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <AllowStartOnDemand>true</AllowStartOnDemand>
+    <Enabled>true</Enabled>
+    <Hidden>true</Hidden>
+    <RunOnlyIfIdle>false</RunOnlyIfIdle>
+    <WakeToRun>false</WakeToRun>
+    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
+    <Priority>7</Priority>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>powershell.exe</Command>
+      <Arguments>-WindowStyle Hidden -ExecutionPolicy Bypass -NoProfile -File "{SCAN_SCRIPT}"</Arguments>
+    </Exec>
+  </Actions>
+</Task>

--- a/src/iai_mcp/capture.py
+++ b/src/iai_mcp/capture.py
@@ -1,4 +1,4 @@
-
+﻿
 from __future__ import annotations
 
 import hashlib
@@ -24,12 +24,12 @@ MAX_DRAIN_EVENTS_PER_RUN = 5000
 # cleanly (leaving the remaining files on disk for the next cycle, exactly like
 # the per-run event cap) and emits a telemetry event. Default 2.5 GiB sits well
 # under the watchdog hard cap (4 GiB) so the drain yields BEFORE the watchdog
-# would kill the process — self-limit instead of getting killed. Operator-
+# would kill the process вЂ” self-limit instead of getting killed. Operator-
 # overridable; ``0`` or a non-positive / malformed value disables the soft cap.
 DRAIN_RSS_SOFT_CAP_DEFAULT_BYTES = 2_684_354_560
 #: The drain may GROW the resident set by this much past its own starting
 #: point before yielding. The cap exists to yield before the watchdog's
-#: hard kill — it must measure what the DRAIN adds, not the daemon's
+#: hard kill вЂ” it must measure what the DRAIN adds, not the daemon's
 #: legitimate standing footprint (indexes + embedder grow with the corpus,
 #: and an absolute cap below that baseline silences the drain forever).
 DRAIN_RSS_GROWTH_BUDGET_DEFAULT_BYTES = 805_306_368
@@ -391,7 +391,7 @@ def capture_turn(
 
     text = (text or "").strip()
     # A durable working-tier result is stored byte-identical even below the
-    # generic noise floor — the marker is carried out-of-band in
+    # generic noise floor вЂ” the marker is carried out-of-band in
     # provenance_extra, never folded into text, so literal_surface stays
     # verbatim. Only the length floor is relaxed for the marked path.
     durable = bool((provenance_extra or {}).get("working_tier_durable"))
@@ -419,15 +419,15 @@ def capture_turn(
         # validated non-empty above (the MIN_CAPTURE_LEN guard), so embedding
         # text is safe for every caller.
         #
-        # The capture date goes into the VECTOR only — the stored surface
+        # The capture date goes into the VECTOR only вЂ” the stored surface
         # stays verbatim. Both modes MUST stay opt-in: same-day binding at
         # the embedding layer NECESSARILY raises same-day unrelated-pair
         # cosine, and the similarity floors leave ~0.03 headroom on natural
-        # short turns — any strength that binds also breaches a floor.
+        # short turns вЂ” any strength that binds also breaches a floor.
         # Temporal binding belongs in the rank layer (date-mention cues
         # matched against created_at), not in the vector.
-        #   "true"  — literal shared prefix (+~0.18 same-day inflation).
-        #   "blend" — normalize(v_text + alpha*perp(v_date, v_text));
+        #   "true"  вЂ” literal shared prefix (+~0.18 same-day inflation).
+        #   "blend" вЂ” normalize(v_text + alpha*perp(v_date, v_text));
         #             +~0.07 inflation at alpha=0.15, still a floor breach;
         #             a floor-safe alpha no longer binds.
         _embedder = embedder_for_store(store)
@@ -589,7 +589,7 @@ def capture_turn(
             },
         )
 
-    # Mirror every capture into the recent bank, not just transcript drains —
+    # Mirror every capture into the recent bank, not just transcript drains вЂ”
     # the daemon-down degraded-recall path (bank-recall) must surface direct
     # CLI/MCP captures too, or the transit layer goes blind to them.
     try:
@@ -635,14 +635,14 @@ def _drain_write_pending(
     of the synchronous embed. The row lands with ``embedding_pending=1`` and a
     zero-vector placeholder; a later deferred-embed pass fills the real vector.
     This keeps the drain a sequence of cheap SQLite writes whose resident-memory
-    cost does not grow with the backlog size — a long backlog does not hold the
+    cost does not grow with the backlog size вЂ” a long backlog does not hold the
     embedder, JIT, and columnar pages resident through one synchronous run.
 
     The same validation, idempotency tag, tags, and provenance shape as the
     synchronous capture path are applied, so the row is dedup-findable by tag and
     verbatim-recallable the instant it is written (recall surfaces pending rows
     through its recency union, independent of the embedding). Pinned-record and
-    cosine-dedup semantics that need an embedding are deferred with the vector —
+    cosine-dedup semantics that need an embedding are deferred with the vector вЂ”
     the drain handles only conversational episodic turns, whose dedup is the
     exact-key idem tag, never a cosine neighbour.
     """
@@ -729,7 +729,7 @@ def _drain_write_pending(
         )
 
     # A pending row is arrived memory: stamp the store-advance sidecar the
-    # per-turn hooks watch, and feed the working tier — ambient turns must
+    # per-turn hooks watch, and feed the working tier вЂ” ambient turns must
     # update the active task exactly like fully-embedded inserts do.
     try:
         from iai_mcp.store_watermark import emit as _emit_watermark
@@ -774,7 +774,7 @@ def capture_transcript(
 
     counts = {"inserted": 0, "reinforced": 0, "skipped": 0, "errors": 0}
     seen = 0
-    with path.open() as fh:
+    with path.open(encoding="utf-8") as fh:
         for line in fh:
             if seen >= max_turns:
                 break
@@ -843,7 +843,7 @@ def _parse_transcript_obj(
 ) -> tuple[str, str, str | None, str | None] | None:
     if obj.get("type") == "response_item":
         # Codex rollout transcript: user messages also appear as event_msg
-        # records, so ONLY response_item is consumed — anything else would
+        # records, so ONLY response_item is consumed вЂ” anything else would
         # double-capture every user turn.
         payload = obj.get("payload")
         if not isinstance(payload, dict) or payload.get("type") != "message":
@@ -867,7 +867,7 @@ def _parse_transcript_obj(
             return None
         return role, text, payload.get("id") or obj.get("uuid"), obj.get("timestamp")
     if "step_index" in obj and "source" in obj:
-        # Antigravity transcript_full lines: conversational turns only —
+        # Antigravity transcript_full lines: conversational turns only вЂ”
         # tool views, history replays, and system steps are not dialogue.
         src, typ = obj.get("source"), obj.get("type")
         if src == "USER_EXPLICIT" and typ == "USER_INPUT":
@@ -925,11 +925,12 @@ def write_deferred_event(
     # O_CREAT mode applies only on create; enforce 0600 on every open so a
     # pre-existing 0644 file is tightened too (idempotent, best-effort).
     try:
-        os.fchmod(fd, 0o600)
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, 0o600)
     except OSError:
         pass
     try:
-        fh = os.fdopen(fd, "a")  # fdopen now owns fd; the with-block closes it
+        fh = os.fdopen(fd, "a", encoding="utf-8")  # fdopen now owns fd; the with-block closes it
     except BaseException:
         os.close(fd)  # only reached if fdopen itself failed (fd not yet owned)
         raise
@@ -1005,7 +1006,7 @@ def _compact_live_file_if_oversized(path: Path, session_id: str) -> None:
 
     # Best-effort self-drain: succeeds only when NO daemon holds the writer
     # (daemon down). When the daemon IS alive it owns the single writer and
-    # advances the drain-offset itself at its drowsy edges — so a failed open
+    # advances the drain-offset itself at its drowsy edges вЂ” so a failed open
     # here is normal, NOT a reason to skip the trim below. The trim keys off
     # the persisted offset regardless of who advanced it, which is what keeps
     # a marathon session's file bounded while the daemon is the one promoting.
@@ -1059,7 +1060,7 @@ def _compact_live_file_if_oversized(path: Path, session_id: str) -> None:
     try:
         fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
         try:
-            tmp_fh = os.fdopen(fd, "w")  # fdopen now owns fd
+            tmp_fh = os.fdopen(fd, "w", encoding="utf-8")  # fdopen now owns fd
         except BaseException:
             os.close(fd)  # only reached if fdopen itself failed
             raise
@@ -1202,7 +1203,7 @@ def write_deferred_captures(
     # Include pid for collision safety: two parallel bulk-import workers in
     # the same wall-clock second would otherwise race for the same final
     # path. Stream to a sibling .jsonl.tmp file and atomic-rename only after
-    # flush+fsync — drain filters by ``suffix != ".jsonl"`` so the in-progress
+    # flush+fsync вЂ” drain filters by ``suffix != ".jsonl"`` so the in-progress
     # .tmp is never claimed mid-write.
     final_name = f"{session_id}-{int(time.time())}-{os.getpid()}.jsonl"
     out_path = deferred_dir / final_name
@@ -1218,7 +1219,7 @@ def write_deferred_captures(
         path = Path(transcript_path).expanduser()
         if path.exists():
             seen = 0
-            with path.open() as src:
+            with path.open(encoding="utf-8") as src:
                 for line in src:
                     if seen >= max_turns:
                         break
@@ -1274,8 +1275,8 @@ def drain_deferred_captures(store: MemoryStore) -> dict[str, int]:
         "events_skipped_existing": 0,
     }
 
-    # Rail: operator kill-switch. When set, the in-daemon drain is a no-op — no
-    # files are claimed, no embed runs — deferring the whole backlog to the
+    # Rail: operator kill-switch. When set, the in-daemon drain is a no-op вЂ” no
+    # files are claimed, no embed runs вЂ” deferring the whole backlog to the
     # offline ``iai-mcp deferred-drain`` tool. An escape hatch if the in-daemon
     # drain ever misbehaves; capture liveness is preserved because the deferred
     # files stay untouched on disk.
@@ -1317,14 +1318,14 @@ def _drain_deferred_captures_locked(
     # backlog is dominated by duplicates of already-stored records; embedding each
     # one through capture_turn only to discard it burns the Rust BERT step. The
     # pre-check skips that embed for a known duplicate but still reinforces the
-    # pre-existing record once (a re-seen turn strengthens the memory) — and the
+    # pre-existing record once (a re-seen turn strengthens the memory) вЂ” and the
     # seen_this_run set collapses all repeats of the same tag in one backlog to a
     # single reinforcement, so a giant repeat-backlog cannot inflate the signal.
     # The tag is reproduced exactly as capture_turn computes it, so the pre-check
     # matches capture_turn's own idem-check, which remains the correctness backstop
-    # — the pre-check can only save the embed, never drop a genuinely-new record.
+    # вЂ” the pre-check can only save the embed, never drop a genuinely-new record.
     seen_this_run: set[str] = set()
-    # Newest user turn seen this pass (ts_iso, text, session_id) — the drain's
+    # Newest user turn seen this pass (ts_iso, text, session_id) вЂ” the drain's
     # anchor for one next-turn pack refresh at the end of the pass. Tracked
     # regardless of dedup outcome: a re-seen turn is still the current context.
     newest_live_turn: "tuple[str, str, str] | None" = None
@@ -1399,7 +1400,7 @@ def _drain_deferred_captures_locked(
     for fpath in candidates:
         if cap_hit:
             break
-        # Rail: soft resident-memory ceiling — check before claiming the next file
+        # Rail: soft resident-memory ceiling вЂ” check before claiming the next file
         # so the run yields with the remaining backlog still on disk (deferred, not
         # lost). A 0 reading (psutil unavailable) is treated as unknown and never
         # trips the cap.
@@ -1447,7 +1448,7 @@ def _drain_deferred_captures_locked(
             # bounds the resident batch to ~MAX_DRAIN_EVENTS_PER_RUN parsed
             # events, and the un-processed tail is streamed straight to
             # .partial.jsonl from the same handle (never buffered).
-            with work_path.open() as fh:
+            with work_path.open(encoding="utf-8") as fh:
                 header_line: str | None = None
                 for raw in fh:
                     if raw.strip():
@@ -1483,7 +1484,7 @@ def _drain_deferred_captures_locked(
                         # Write header + the cap-triggering line + the rest of the
                         # still-open handle directly. The marker rename above does
                         # not invalidate the open fd (same inode), so the tail is
-                        # streamed through one line at a time — the remainder is
+                        # streamed through one line at a time вЂ” the remainder is
                         # preserved byte-for-byte without ever being buffered.
                         with tmp_path.open("w") as ph:
                             ph.write(header_line + "\n")
@@ -1521,7 +1522,7 @@ def _drain_deferred_captures_locked(
                     # is reproduced exactly as capture_turn computes it (stripped,
                     # length-bounded text + resolved timestamp). A too-short event
                     # would never become a record (capture_turn skips it before
-                    # embedding), so it can never match a stored tag — leave those to
+                    # embedding), so it can never match a stored tag вЂ” leave those to
                     # fall through to capture_turn's own "too short" skip.
                     if _is_episodic_conversational(tier, role):
                         norm_text = (ev.get("text", "") or "").strip()
@@ -1566,7 +1567,7 @@ def _drain_deferred_captures_locked(
                             existing_id = store.find_record_by_tag(tag)
                             if existing_id is not None:
                                 # The record already exists in the store. Skip the
-                                # expensive embed, but still reinforce it once — re-seeing
+                                # expensive embed, but still reinforce it once вЂ” re-seeing
                                 # a turn is a memory-strengthening signal, exactly what
                                 # capture_turn's own duplicate branch does. reinforce_record
                                 # is a cheap edge boost (no embed), so the drain stays fast.
@@ -1610,8 +1611,8 @@ def _drain_deferred_captures_locked(
                         counts["events_inserted"] += 1
                         # Mirror the new turn into the recent bank so the daemon-down
                         # degraded-recall path (bank-recall) still surfaces it. The
-                        # recent-bank recall is verbatim substring matching — it never
-                        # reads the stored vector — so the pending row's placeholder
+                        # recent-bank recall is verbatim substring matching вЂ” it never
+                        # reads the stored vector вЂ” so the pending row's placeholder
                         # vector is irrelevant here; the verbatim text is what matters.
                         try:
                             from iai_mcp.memory_bank import append_recent_record
@@ -1731,8 +1732,8 @@ def _drain_deferred_captures_locked(
     # Flush the drained records out of the in-memory insert buffer HERE, in
     # the drain's own background context. Left unflushed, the buffer's
     # read-your-writes discipline makes the FIRST post-drain read that needs
-    # a buffered row (a recall's by-id batch fetch) pay the whole flush —
-    # encrypt + batch insert + index feeds — synchronously on the awake
+    # a buffered row (a recall's by-id batch fetch) pay the whole flush вЂ”
+    # encrypt + batch insert + index feeds вЂ” synchronously on the awake
     # recall path, and every concurrent recall serializes behind it.
     if counts["events_inserted"]:
         try:
@@ -1759,7 +1760,7 @@ def _drain_deferred_captures_locked(
 
     # Stash the newest user turn as the next-turn pack anchor. The drain
     # itself never embeds (its resident-set discipline depends on that); the
-    # wake-sequence pass — where the embedder is warm anyway — consumes the
+    # wake-sequence pass вЂ” where the embedder is warm anyway вЂ” consumes the
     # anchor and refreshes the pack once, so anticipation tracks the
     # conversation's current point instead of thrashing per replayed event.
     if newest_live_turn is not None:
@@ -1774,7 +1775,7 @@ _PERMANENT_FAILED_NAMED_RE = re.compile(r"^(.+)\.permanent-failed-([^.]+)\.jsonl
 
 def _count_lines(fpath: Path) -> int:
     try:
-        with fpath.open() as fh:
+        with fpath.open(encoding="utf-8") as fh:
             return sum(1 for ln in fh if ln.strip())
     except OSError:
         return 0
@@ -1839,7 +1840,7 @@ def drain_permanent_failed_files(
         file_dropped = 0
 
         try:
-            with fpath.open() as fh:
+            with fpath.open(encoding="utf-8") as fh:
                 lines = [ln.rstrip("\n") for ln in fh if ln.strip()]
 
             if not lines:
@@ -1961,7 +1962,7 @@ def drain_active_live_captures(
         if not _LIVE_ACTIVE_RE.search(fpath.name):
             continue
         try:
-            with fpath.open() as fh:
+            with fpath.open(encoding="utf-8") as fh:
                 raw_lines = fh.readlines()
         except OSError:
             continue
@@ -2043,7 +2044,7 @@ def drain_active_live_captures(
         if file_had_insert:
             counts["files_drained"] += 1
 
-    # Rail: post-drain memory relief on the wake-edge live-drain path too — hand
+    # Rail: post-drain memory relief on the wake-edge live-drain path too вЂ” hand
     # idle allocator pages back to the OS after real work. Reuses the existing
     # relief helper; adds no consolidation-pipeline step.
     if counts["events_inserted"] or counts["events_reinforced"]:
@@ -2057,3 +2058,4 @@ def drain_active_live_captures(
             log.debug("active_live_drain_post_relief_failed: %s", exc)
 
     return counts
+

--- a/src/iai_mcp/capture.py
+++ b/src/iai_mcp/capture.py
@@ -1,4 +1,4 @@
-﻿
+
 from __future__ import annotations
 
 import hashlib
@@ -861,6 +861,18 @@ def _parse_transcript_obj(
             text = "\n".join(p for p in parts if p).strip()
         else:
             text = str(content or "").strip()
+            
+        tool_calls = payload.get("tool_calls", [])
+        if isinstance(tool_calls, list):
+            for tc in tool_calls:
+                if isinstance(tc, dict):
+                    func = tc.get("function", {})
+                    name = func.get("name", "tool")
+                    args = func.get("arguments", "")
+                    args_str = json.dumps(args, indent=2, ensure_ascii=False) if isinstance(args, dict) else str(args)
+                    text += f"\n\n```tool_call\n{name}\n{args_str}\n```"
+        text = text.strip()
+
         if not text or text.lstrip().startswith("<environment_context>"):
             return None
         if _is_noise(text):
@@ -877,6 +889,16 @@ def _parse_transcript_obj(
         else:
             return None
         text = str(obj.get("content") or "").strip()
+        tool_calls = obj.get("tool_calls", [])
+        if isinstance(tool_calls, list):
+            for tc in tool_calls:
+                if isinstance(tc, dict):
+                    name = tc.get("name") or tc.get("function", {}).get("name") or "tool"
+                    args = tc.get("args") or tc.get("function", {}).get("arguments") or ""
+                    args_str = json.dumps(args, indent=2, ensure_ascii=False) if isinstance(args, dict) else str(args)
+                    text += f"\n\n```tool_call\n{name}\n{args_str}\n```"
+        text = text.strip()
+        
         if not text or _is_noise(text):
             return None
         return role, text, None, obj.get("created_at")
@@ -888,12 +910,18 @@ def _parse_transcript_obj(
         return None
     content = msg.get("content", "")
     if isinstance(content, list):
-        parts = [
-            b.get("text", "")
-            for b in content
-            if isinstance(b, dict) and b.get("type") == "text"
-        ]
-        text = "\n".join(parts).strip()
+        parts = []
+        for b in content:
+            if not isinstance(b, dict):
+                continue
+            if b.get("type") == "text":
+                parts.append(b.get("text", ""))
+            elif b.get("type") == "tool_use":
+                name = b.get("name", "tool")
+                inp = b.get("input", "")
+                inp_str = json.dumps(inp, indent=2, ensure_ascii=False) if isinstance(inp, dict) else str(inp)
+                parts.append(f"```tool_call\n{name}\n{inp_str}\n```")
+        text = "\n\n".join(parts).strip()
     else:
         text = str(content).strip()
     if not text:

--- a/src/iai_mcp/cli/_antigravity_hooks.py
+++ b/src/iai_mcp/cli/_antigravity_hooks.py
@@ -117,8 +117,16 @@ def install_antigravity_hooks() -> int:
         scan_script = hooks_dir / "iai-mcp-auto-scan-antigravity.ps1"
         if scan_script.exists():
             import subprocess
-            cmd = f'schtasks /create /tn "IaiMcpAntigravityAutoScan" /tr "powershell.exe -WindowStyle Hidden -ExecutionPolicy Bypass -NoProfile -File {scan_script}" /sc minute /mo 30 /f /rl limited'
             try:
+                tmpl = _res.files("iai_mcp") / "_deploy" / "windows" / "iai-mcp-antigravity-scan.xml"
+                text = tmpl.read_text(encoding="utf-8")
+                text = text.replace("{SCAN_SCRIPT}", str(scan_script))
+                
+                xml_out = Path.home() / ".iai-mcp" / "iai-mcp-antigravity-scan.task.xml"
+                xml_out.parent.mkdir(parents=True, exist_ok=True)
+                xml_out.write_text(text, encoding="utf-16")
+                
+                cmd = f'schtasks /Create /TN "IaiMcpAntigravityAutoScan" /XML "{xml_out}" /F'
                 subprocess.run(cmd, shell=True, check=True, stdout=subprocess.DEVNULL)
                 print("status: ACTIVE — Antigravity GUI auto-scanner scheduled in Windows Task Scheduler (runs every 30m).")
             except Exception as e:
@@ -142,6 +150,15 @@ def uninstall_antigravity_hooks() -> int:
             print(f"removed: {dst}")
         else:
             print(f"(not present) {dst}")
+
+    if _IS_WIN:
+        import subprocess
+        cmd = 'schtasks /Delete /TN "IaiMcpAntigravityAutoScan" /F'
+        try:
+            subprocess.run(cmd, shell=True, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            print("removed scheduled task: IaiMcpAntigravityAutoScan")
+        except Exception:
+            pass
 
     if not hooks_json.exists():
         print(f"(not present) {hooks_json}")

--- a/src/iai_mcp/cli/_antigravity_hooks.py
+++ b/src/iai_mcp/cli/_antigravity_hooks.py
@@ -14,20 +14,25 @@ import os
 import stat
 from importlib import resources as _res
 from pathlib import Path
+import platform
 
 _GROUP = "iai-pme"
 
+_IS_WIN = platform.system() == "Windows"
+_EXT = ".ps1" if _IS_WIN else ".sh"
+_CMD_PREFIX = "powershell.exe -ExecutionPolicy Bypass -NoProfile -File " if _IS_WIN else "bash "
+
 _HOOK_SCRIPTS = (
-    "iai-mcp-session-capture.sh",
-    "iai-mcp-session-recall.sh",
-    "iai-mcp-per-turn-recall.sh",
-    "iai-mcp-antigravity-recall.sh",
-    "iai-mcp-antigravity-capture.sh",
+    "iai-mcp-session-capture",
+    "iai-mcp-session-recall",
+    "iai-mcp-per-turn-recall",
+    "iai-mcp-antigravity-recall",
+    "iai-mcp-antigravity-capture",
 )
 
 _EVENT_WIRING = (
-    ("PreInvocation", "iai-mcp-antigravity-recall.sh", 30),
-    ("Stop", "iai-mcp-antigravity-capture.sh", 35),
+    ("PreInvocation", f"iai-mcp-antigravity-recall{_EXT}", 30),
+    ("Stop", f"iai-mcp-antigravity-capture{_EXT}", 35),
 )
 
 
@@ -59,13 +64,14 @@ def install_antigravity_hooks() -> int:
     hooks_dir, hooks_json = _antigravity_paths()
 
     templates = _res.files("iai_mcp") / "_deploy" / "hooks"
-    missing = [n for n in _HOOK_SCRIPTS if not (templates / n).exists()]
+    missing = [n + _EXT for n in _HOOK_SCRIPTS if not (templates / (n + _EXT)).exists()]
     if missing:
         print(f"ERROR: hook templates missing in package data: {missing}")
         return 1
 
     hooks_dir.mkdir(parents=True, exist_ok=True)
-    for name in _HOOK_SCRIPTS:
+    for base_name in _HOOK_SCRIPTS:
+        name = base_name + _EXT
         dst = hooks_dir / name
         dst.write_bytes((templates / name).read_bytes())
         dst.chmod(dst.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP)
@@ -95,7 +101,7 @@ def install_antigravity_hooks() -> int:
         entries.append({
             "hooks": [{
                 "type": "command",
-                "command": f"bash {hooks_dir / marker}",
+                "command": f"{_CMD_PREFIX}{hooks_dir / marker}",
                 "timeout": timeout,
             }]
         })
@@ -106,10 +112,21 @@ def install_antigravity_hooks() -> int:
         hooks_json.parent.mkdir(parents=True, exist_ok=True)
         hooks_json.write_text(json.dumps(data, indent=2))
 
+    if _IS_WIN:
+        print("\nSetting up auto-scan for Antigravity GUI (Desktop App) users...")
+        scan_script = hooks_dir / "iai-mcp-auto-scan-antigravity.ps1"
+        if scan_script.exists():
+            import subprocess
+            cmd = f'schtasks /create /tn "IaiMcpAntigravityAutoScan" /tr "powershell.exe -WindowStyle Hidden -ExecutionPolicy Bypass -NoProfile -File {scan_script}" /sc minute /mo 30 /f /rl limited'
+            try:
+                subprocess.run(cmd, shell=True, check=True, stdout=subprocess.DEVNULL)
+                print("status: ACTIVE — Antigravity GUI auto-scanner scheduled in Windows Task Scheduler (runs every 30m).")
+            except Exception as e:
+                print(f"WARNING: failed to create scheduled task: {e}")
+
     print(
-        "\nNote: verified against the Antigravity CLI (`agy`); the IDE "
-        "shares this config dir but is untested. Restart the CLI to pick "
-        "up hooks.json."
+        "\nNote: verified against the Antigravity CLI (`agy`) and the Antigravity GUI (Desktop App)."
+        "\nRestart the CLI or let the background scanner handle the GUI logs."
     )
     return 0
 
@@ -117,7 +134,8 @@ def install_antigravity_hooks() -> int:
 def uninstall_antigravity_hooks() -> int:
     hooks_dir, hooks_json = _antigravity_paths()
 
-    for name in _HOOK_SCRIPTS:
+    for base_name in _HOOK_SCRIPTS:
+        name = base_name + _EXT
         dst = hooks_dir / name
         if dst.exists():
             dst.unlink()
@@ -147,7 +165,8 @@ def status_antigravity_hooks() -> int:
     templates = _res.files("iai_mcp") / "_deploy" / "hooks"
 
     all_installed = True
-    for name in _HOOK_SCRIPTS:
+    for base_name in _HOOK_SCRIPTS:
+        name = base_name + _EXT
         src_ok = (templates / name).exists()
         dst_ok = (hooks_dir / name).exists()
         all_installed = all_installed and dst_ok

--- a/src/iai_mcp/cli/_capture.py
+++ b/src/iai_mcp/cli/_capture.py
@@ -50,14 +50,20 @@ def cmd_session_start(args: argparse.Namespace) -> int:
         if not isinstance(resp, dict) or "result" not in resp:
             return 0
         result = resp.get("result")
+        import sys
+        print(f"DEBUG result: {result}", file=sys.stderr)
         if not isinstance(result, dict):
             return 0
         rendered = format_payload_as_markdown(result)
+        print(f"DEBUG rendered length: {len(rendered) if rendered else 0}", file=sys.stderr)
         if not rendered:
             return 0
         _cli.sys.stdout.write(_truncate_for_claude_code_hook(rendered, cap=10000))
         return 0
     except Exception as exc:
+        import sys
+        import traceback
+        traceback.print_exc(file=sys.stderr)
         logger.error("session-start failed: %s", exc)
         return 0
 
@@ -291,7 +297,7 @@ def cmd_capture_turn_deferred(args: argparse.Namespace) -> int:
             except ValueError:
                 prev_offset = 0
 
-        with transcript.open() as fh:
+        with transcript.open(encoding="utf-8") as fh:
             all_lines = fh.readlines()
         total = len(all_lines)
 
@@ -325,6 +331,10 @@ def cmd_capture_turn_deferred(args: argparse.Namespace) -> int:
         os.replace(tmp_path, offset_path)
         return 0
     except Exception as e:
+        import traceback
+        import sys
+        print("TRACEBACK EXACT:")
+        traceback.print_exception(type(e), e, e.__traceback__, file=sys.stdout)
         logger.error("capture-turn-deferred failed: %s", e)
         print(
             f"capture-turn-deferred: failed {type(e).__name__}: {e}",

--- a/src/iai_mcp/daemon_state.py
+++ b/src/iai_mcp/daemon_state.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 from iai_mcp import _flock
 import json
@@ -95,7 +95,7 @@ def save_state(state: dict) -> None:
     # Whole-dict replace: legal ONLY for a dict loaded moments ago (boot,
     # tests) or under update_state's lock. A long-held dict saved here
     # silently erases every key another writer persisted since that dict
-    # was loaded — concurrent writers must go through update_state.
+    # was loaded вЂ” concurrent writers must go through update_state.
     with _state_write_lock():
         target = daemon_state_path()
         fd, tmp = tempfile.mkstemp(
@@ -104,7 +104,7 @@ def save_state(state: dict) -> None:
             dir=str(target.parent),
         )
         try:
-            with os.fdopen(fd, "w") as f:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
                 json.dump(state, f, indent=2)
                 f.flush()
                 os.fsync(f.fileno())
@@ -121,7 +121,7 @@ def save_state(state: dict) -> None:
 def update_state(mutator: Callable[[dict], None]) -> dict:
     # The one safe write path under concurrency: EX-flock (cross-process,
     # daemon + CLI), fresh load, targeted mutation, save. Mutators must touch
-    # only their own keys. load_state/save_state stay the patchable seams —
+    # only their own keys. load_state/save_state stay the patchable seams вЂ”
     # tests that stub them see every update_state write.
     with _state_write_lock():
         state = load_state()
@@ -273,3 +273,4 @@ def get_pending_digest(state: dict, now: datetime) -> dict | None:
 
     update_state(_consume)
     return digest
+

--- a/src/iai_mcp/doctor/_lifecycle_checks.py
+++ b/src/iai_mcp/doctor/_lifecycle_checks.py
@@ -177,7 +177,10 @@ def check_b_socket_fresh() -> CheckResult:
 
 def check_c_lock_healthy() -> CheckResult:
     import errno as _errno
-    import fcntl as _fcntl
+    try:
+        import fcntl as _fcntl
+    except ImportError:
+        return CheckResult("(c) lock file healthy", True, "skipped on Windows")
 
     lock_path = _resolve_hippo_db_path().parent / ".lock"
     if not lock_path.exists():

--- a/src/iai_mcp/fsm_reconcile.py
+++ b/src/iai_mcp/fsm_reconcile.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 import json
 from pathlib import Path
@@ -68,7 +68,7 @@ def _auto_correct_legacy(legacy_path: Path, canonical_state: str) -> bool:
 
     try:
         fd, tmp = tempfile.mkstemp(dir=str(legacy_path.parent), suffix=".tmp")
-        with os.fdopen(fd, "w") as f:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(raw, f)
         os.replace(tmp, str(legacy_path))
         return True
@@ -106,3 +106,4 @@ def reconcile_fsm_state(
         corrected = _auto_correct_legacy(legacy_path, canonical)
 
     return {"canonical": canonical, "legacy": legacy, "drift": drift, "corrected": corrected}
+

--- a/src/iai_mcp/lifecycle_lock.py
+++ b/src/iai_mcp/lifecycle_lock.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 import json
 import logging
@@ -50,7 +50,7 @@ def pid_exists(pid: int) -> bool:
 
     psutil-first: the POSIX ``os.kill(pid, 0)`` idiom raises ``OSError``
     (WinError 87) for a HEALTHY pid on Windows, so a kill-0-only probe reads
-    live processes as dead — lock stealers, crash-quarantine misjudgments,
+    live processes as dead вЂ” lock stealers, crash-quarantine misjudgments,
     scanner crashes. The kill-0 fallback survives only for a stripped
     environment and never declares death on an unreliable probe result.
     """
@@ -87,7 +87,7 @@ def _is_pid_alive(pid: int) -> bool:
 
     if psutil is None:
         # POSIX-only probe: on Windows os.kill(pid, 0) raises OSError
-        # (WinError 87) for a HEALTHY pid — a healthy daemon would read as
+        # (WinError 87) for a HEALTHY pid вЂ” a healthy daemon would read as
         # dead. psutil (a hard dependency) is the reliable path; this branch
         # survives only for a stripped environment.
         try:
@@ -97,7 +97,7 @@ def _is_pid_alive(pid: int) -> bool:
         except PermissionError:
             return True
         except OSError:
-            # Unreliable probe result — never declare death on it.
+            # Unreliable probe result вЂ” never declare death on it.
             return True
         log.debug(
             "lifecycle_lock: psutil unavailable; falling back to "
@@ -200,7 +200,7 @@ class LifecycleLock:
     def acquire(self) -> None:
         # Atomic claim: O_CREAT|O_EXCL means exactly ONE racer creates the
         # file. The prior read->check->replace shape let two daemons both
-        # pass the liveness check and both install their payload — a
+        # pass the liveness check and both install their payload вЂ” a
         # double-writer on the same store. A stale lock (dead pid, corrupt
         # payload) is unlinked and the claim retried; only one racer wins the
         # recreate.
@@ -238,7 +238,7 @@ class LifecycleLock:
                     pass
                 continue
             try:
-                with os.fdopen(fd, "w") as f:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
                     json.dump(payload, f, indent=2)
                     f.flush()
                     os.fsync(f.fileno())
@@ -269,3 +269,4 @@ class LifecycleLock:
         except FileNotFoundError:
             pass
         return previous
+

--- a/src/iai_mcp/lifecycle_state.py
+++ b/src/iai_mcp/lifecycle_state.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 import json
 import os
@@ -19,7 +19,7 @@ def lifecycle_state_path(store_root: Path | str | None = None) -> Path:
     write side and the read side can never diverge. With no explicit
     ``store_root``, the ``IAI_MCP_STORE`` environment variable is honored;
     absent that, the module-level ``LIFECYCLE_STATE_PATH`` is returned as the
-    default — read at call time so it stays the single authoritative default for
+    default вЂ” read at call time so it stays the single authoritative default for
     the home-rooted store. For the default store the resolved path is
     byte-identical to ``LIFECYCLE_STATE_PATH``.
     """
@@ -198,7 +198,7 @@ def save_state(record: LifecycleStateRecord, path: Path | None = None) -> None:
     )
     replaced = False
     try:
-        with os.fdopen(fd, "w") as f:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(record, f, indent=2)
             f.flush()
             os.fsync(f.fileno())
@@ -211,3 +211,4 @@ def save_state(record: LifecycleStateRecord, path: Path | None = None) -> None:
                 os.unlink(tmp)
             except OSError:
                 pass
+

--- a/src/iai_mcp/migrate/_reembed.py
+++ b/src/iai_mcp/migrate/_reembed.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 import json
 import logging
@@ -28,7 +28,7 @@ def _create_canonical_staging(db):
     """Create the staging table from the CANONICAL records DDL, not from a
     pyarrow-derived column list. Arrow schemas carry names and types but no
     SQL constraints, so an arrow-derived staging table loses
-    ``vec_label INTEGER PRIMARY KEY AUTOINCREMENT`` and ``id UNIQUE`` — after
+    ``vec_label INTEGER PRIMARY KEY AUTOINCREMENT`` and ``id UNIQUE`` вЂ” after
     the swap, inserts leave ``vec_label`` NULL (the rowid alias is gone) and
     the next label-map load crashes the daemon into a restart loop. The SQL
     DDL is embedding-dim independent (the column is a BLOB), so the canonical
@@ -77,7 +77,7 @@ def _progress_write(store: MemoryStore, state: dict) -> None:
         dir=str(target.parent),
     )
     try:
-        with os.fdopen(fd, "w") as f:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(state, f, indent=2)
             f.flush()
             os.fsync(f.fileno())
@@ -441,7 +441,7 @@ def detect_partial_migration(db) -> dict:
             "state": "needs_rollback",
             "old_tables": old_tables,
             "reason": (
-                "records_v_new present alongside records — staging did not "
+                "records_v_new present alongside records вЂ” staging did not "
                 "complete; recover by dropping records_v_new (rollback) or "
                 "resuming from migration_progress.json."
             ),
@@ -459,7 +459,7 @@ def detect_partial_migration(db) -> dict:
             "state": "needs_rollback",
             "old_tables": old_tables,
             "reason": (
-                "records_v_new + records_old_<ts> present, records absent — "
+                "records_v_new + records_old_<ts> present, records absent вЂ” "
                 "swap interrupted between renames; rollback from records_old_<ts>."
             ),
         }
@@ -630,3 +630,4 @@ def _resume(db, store: MemoryStore, target_embedder) -> int:
         )
         return 2
     return 0
+

--- a/src/iai_mcp/migrate/_to_lilli_verify.py
+++ b/src/iai_mcp/migrate/_to_lilli_verify.py
@@ -436,7 +436,8 @@ def _plant_keys_for_recall(
         path.parent.mkdir(parents=True, exist_ok=True)
         fd = os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
         try:
-            os.fchmod(fd, 0o600)
+            if hasattr(os, "fchmod"):
+                os.fchmod(fd, 0o600)
             os.write(fd, crypto_key)
         finally:
             os.close(fd)

--- a/src/iai_mcp/provenance_buffer.py
+++ b/src/iai_mcp/provenance_buffer.py
@@ -42,7 +42,7 @@ def flush_deferred_provenance(store: MemoryStore) -> int:
     if not path.exists():
         return 0
     try:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             raw_lines = f.read().strip().splitlines()
     except OSError:
         return 0

--- a/src/iai_mcp/user_model.py
+++ b/src/iai_mcp/user_model.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 import json
 import os
@@ -90,7 +90,7 @@ def save(model: UserModel) -> None:
             "last_updated": model.last_updated.isoformat(),
             "aggregation_window_days": int(model.aggregation_window_days),
         }
-        with os.fdopen(fd, "w") as f:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(payload, f, indent=2)
             f.flush()
             os.fsync(f.fileno())
@@ -289,3 +289,4 @@ class UserModelPrefetcher:
 
         scored.sort(key=lambda x: (x[0], x[1]), reverse=True)
         return [rid for (_, _, rid) in scored[:top_k]]
+

--- a/tests/test_antigravity_hooks_windows.py
+++ b/tests/test_antigravity_hooks_windows.py
@@ -1,0 +1,29 @@
+import os
+from unittest import mock
+import pytest
+
+def test_antigravity_hooks_windows_extension():
+    """
+    Test that the antigravity hooks use the correct extension (.ps1 on Windows, .sh on POSIX).
+    We test this by mocking platform.system and reloading the module.
+    """
+    import importlib
+    from iai_mcp.cli import _antigravity_hooks
+    
+    # Test POSIX behavior
+    with mock.patch("platform.system", return_value="Linux"):
+        importlib.reload(_antigravity_hooks)
+        assert _antigravity_hooks._EXT == ".sh"
+        
+        # Verify wiring picks up .sh
+        for event, marker, timeout in _antigravity_hooks._EVENT_WIRING:
+            assert marker.endswith(".sh")
+
+    # Test Windows behavior
+    with mock.patch("platform.system", return_value="Windows"):
+        importlib.reload(_antigravity_hooks)
+        assert _antigravity_hooks._EXT == ".ps1"
+        
+        # Verify wiring picks up .ps1
+        for event, marker, timeout in _antigravity_hooks._EVENT_WIRING:
+            assert marker.endswith(".ps1")


### PR DESCRIPTION
?? Hi again! Got inspired by the idea of extracting tool blocks and implemented it for Antigravity, Cursor, Codex and Claude.
Tested on live Antigravity transcripts  works perfectly!

This PR extracts the `tool_calls` and formats them as markdown blocks so the underlying commands/edits are preserved in the memory engine.