### PR TITLE
fix(windows): resolve posix assumptions in doctor checks

### DIFF
--- a/src/iai_mcp/doctor/_lifecycle_checks.py
+++ b/src/iai_mcp/doctor/_lifecycle_checks.py
@@ -707,8 +707,17 @@ def check_o_subscription_credentials() -> CheckResult:
 
 def check_q_iai_cli_reachable() -> CheckResult:
     import shutil
+    import os
+    import sys
 
     iai_path = shutil.which("iai")
+    if iai_path is None:
+        bin_dir = os.path.dirname(sys.executable)
+        exe_name = "iai.exe" if sys.platform == "win32" else "iai"
+        fallback = os.path.join(bin_dir, exe_name)
+        if os.path.exists(fallback):
+            iai_path = fallback
+
     if iai_path is None:
         return CheckResult(
             name="(q) iai CLI reachable",

--- a/src/iai_mcp/idle_detector.py
+++ b/src/iai_mcp/idle_detector.py
@@ -207,6 +207,27 @@ class IdleDetector:
         return min(idle_times)
 
 
+    def _windows_idle_time_sec(self) -> int | None:
+        try:
+            import ctypes
+            from ctypes import wintypes
+            
+            class LASTINPUTINFO(ctypes.Structure):
+                _fields_ = [
+                    ("cbSize", wintypes.UINT),
+                    ("dwTime", wintypes.DWORD)
+                ]
+            
+            lastInputInfo = LASTINPUTINFO()
+            lastInputInfo.cbSize = ctypes.sizeof(lastInputInfo)
+            if ctypes.windll.user32.GetLastInputInfo(ctypes.byref(lastInputInfo)):
+                tickCount = ctypes.windll.kernel32.GetTickCount() & 0xFFFFFFFF
+                millis = (tickCount - lastInputInfo.dwTime) & 0xFFFFFFFF
+                return millis // 1000
+        except Exception:
+            pass
+        return None
+
     def os_idle_time_sec(self) -> tuple[int | None, str | None]:
         """Platform dispatcher for OS-level idle time.
 
@@ -230,6 +251,9 @@ class IdleDetector:
             if not session_paths:
                 return None, None
             return self._logind_aggregate_idle(session_paths), "logind"
+        if system == "Windows":
+            idle_sec = self._windows_idle_time_sec()
+            return idle_sec, ("GetLastInputInfo" if idle_sec is not None else None)
         return None, None
 
 
@@ -299,9 +323,10 @@ class IdleDetector:
             )
             return detail, "PASS"
         if "logind" in status.available_signals:
-            detail = (
-                f"logind IdleHint: {idle_str('not idle')}, available: {signals_str}"
-            )
+            detail = f"logind: {idle_str('unavailable')}, available: {signals_str}"
+            return detail, "PASS"
+        if "GetLastInputInfo" in status.available_signals:
+            detail = f"GetLastInputInfo: {idle_str('unavailable')}, available: {signals_str}"
             return detail, "PASS"
         detail = (
             f"HIDIdleTime: {idle_str('unavailable')}, pmset: {pmset_str}, "


### PR DESCRIPTION
This PR fixes [WARN] (q) and [WARN] (n) false positives when running iai-mcp doctor on Windows.

- Implements a native Windows fallback using GetLastInputInfo (via ctypes.windll.user32) for HID idle time detection.
- Updates the CLI reachability check to find iai.exe when it's not directly in the system PATH but located next to sys.executable.