### PR TITLE
Fix FileNotFoundError race in turn-capture offset writes under concurrency

### DIFF
--- a/plugin/hooks/iai-mcp-turn-capture.sh
+++ b/plugin/hooks/iai-mcp-turn-capture.sh
@@ -115,7 +115,12 @@ if prev > total:
     # Transcript is shorter than the stored offset — it was rotated or
     # replaced.  Preserve the existing offset and skip capture to avoid
     # re-emitting old turns or clobbering a valid large offset.
-    tmp = state_dir / f"{session_id}.offset.tmp"
+    # PID-suffixed tmp name: this hook and the Stop hook capture-turn-
+    # deferred call both touch {session_id}.offset and can fire close
+    # together for one exchange. A shared tmp path lets whichever
+    # process replaces second find its source already consumed by the
+    # first (FileNotFoundError).
+    tmp = state_dir / f"{session_id}.offset.{os.getpid()}.tmp"
     tmp.write_text(str(prev))
     os.replace(tmp, offset)
     sys.exit(0)
@@ -276,7 +281,8 @@ if total > prev:
             emitted += 1
 
 new_offset = prev + consumed
-tmp = state_dir / f"{session_id}.offset.tmp"
+# PID-suffixed tmp name — see the rotated-transcript branch above for why.
+tmp = state_dir / f"{session_id}.offset.{os.getpid()}.tmp"
 with open(tmp, "w") as _f:
     _f.write(str(new_offset))
     _f.flush()
@@ -353,7 +359,8 @@ try:
     def _gate_write_watermark(sid, ts):
         d = home / ".iai-mcp" / ".capture-state"
         d.mkdir(parents=True, exist_ok=True)
-        tmp_wm = d / f"{sid}.watermark.tmp"
+        # PID-suffixed tmp name — see the offset-write above for why.
+        tmp_wm = d / f"{sid}.watermark.{os.getpid()}.tmp"
         tmp_wm.write_text(_gate_utc_iso(ts))
         os.replace(tmp_wm, d / f"{sid}.watermark")
 
@@ -394,7 +401,8 @@ try:
     def _gate_write_fingerprint(sid, total_sz):
         d = home / ".iai-mcp" / ".capture-state"
         d.mkdir(parents=True, exist_ok=True)
-        tmp_fp = d / f"{sid}.live-fingerprint.tmp"
+        # PID-suffixed tmp name — see the offset-write above for why.
+        tmp_fp = d / f"{sid}.live-fingerprint.{os.getpid()}.tmp"
         tmp_fp.write_text(str(total_sz))
         os.replace(tmp_fp, d / f"{sid}.live-fingerprint")
 

--- a/src/iai_mcp/_deploy/hooks/iai-mcp-turn-capture.sh
+++ b/src/iai_mcp/_deploy/hooks/iai-mcp-turn-capture.sh
@@ -115,7 +115,12 @@ if prev > total:
     # Transcript is shorter than the stored offset — it was rotated or
     # replaced.  Preserve the existing offset and skip capture to avoid
     # re-emitting old turns or clobbering a valid large offset.
-    tmp = state_dir / f"{session_id}.offset.tmp"
+    # PID-suffixed tmp name: this hook and the Stop hook capture-turn-
+    # deferred call both touch {session_id}.offset and can fire close
+    # together for one exchange. A shared tmp path lets whichever
+    # process replaces second find its source already consumed by the
+    # first (FileNotFoundError).
+    tmp = state_dir / f"{session_id}.offset.{os.getpid()}.tmp"
     tmp.write_text(str(prev))
     os.replace(tmp, offset)
     sys.exit(0)
@@ -276,7 +281,8 @@ if total > prev:
             emitted += 1
 
 new_offset = prev + consumed
-tmp = state_dir / f"{session_id}.offset.tmp"
+# PID-suffixed tmp name — see the rotated-transcript branch above for why.
+tmp = state_dir / f"{session_id}.offset.{os.getpid()}.tmp"
 with open(tmp, "w") as _f:
     _f.write(str(new_offset))
     _f.flush()
@@ -353,7 +359,8 @@ try:
     def _gate_write_watermark(sid, ts):
         d = home / ".iai-mcp" / ".capture-state"
         d.mkdir(parents=True, exist_ok=True)
-        tmp_wm = d / f"{sid}.watermark.tmp"
+        # PID-suffixed tmp name — see the offset-write above for why.
+        tmp_wm = d / f"{sid}.watermark.{os.getpid()}.tmp"
         tmp_wm.write_text(_gate_utc_iso(ts))
         os.replace(tmp_wm, d / f"{sid}.watermark")
 
@@ -394,7 +401,8 @@ try:
     def _gate_write_fingerprint(sid, total_sz):
         d = home / ".iai-mcp" / ".capture-state"
         d.mkdir(parents=True, exist_ok=True)
-        tmp_fp = d / f"{sid}.live-fingerprint.tmp"
+        # PID-suffixed tmp name — see the offset-write above for why.
+        tmp_fp = d / f"{sid}.live-fingerprint.{os.getpid()}.tmp"
         tmp_fp.write_text(str(total_sz))
         os.replace(tmp_fp, d / f"{sid}.live-fingerprint")
 

--- a/src/iai_mcp/cli/_capture.py
+++ b/src/iai_mcp/cli/_capture.py
@@ -101,7 +101,11 @@ def read_live_fingerprint(session_id: str) -> int | None:
 def write_live_fingerprint(session_id: str, total_size: int) -> None:
     d = Path.home() / ".iai-mcp" / ".capture-state"
     d.mkdir(parents=True, exist_ok=True)
-    tmp = d / f"{session_id}.live-fingerprint.tmp"
+    # PID-suffixed tmp name: concurrent hook invocations for the same
+    # session (e.g. UserPromptSubmit and Stop firing close together) must
+    # not share one tmp path, or the second os.replace() raises
+    # FileNotFoundError once the first has already consumed it.
+    tmp = d / f"{session_id}.live-fingerprint.{os.getpid()}.tmp"
     tmp.write_text(str(total_size), encoding="utf-8")
     os.replace(tmp, d / f"{session_id}.live-fingerprint")
 
@@ -161,7 +165,8 @@ def read_watermark(session_id: str) -> str | None:
 def write_watermark(session_id: str, ts: str) -> None:
     d = Path.home() / ".iai-mcp" / ".capture-state"
     d.mkdir(parents=True, exist_ok=True)
-    tmp = d / f"{session_id}.watermark.tmp"
+    # PID-suffixed tmp name — see write_live_fingerprint() above for why.
+    tmp = d / f"{session_id}.watermark.{os.getpid()}.tmp"
     tmp.write_text(_utc_iso(ts), encoding="utf-8")
     os.replace(tmp, d / f"{session_id}.watermark")
 
@@ -362,7 +367,13 @@ def cmd_capture_turn_deferred(args: argparse.Namespace) -> int:
             emitted += 1
 
         new_offset = prev_offset + consumed
-        tmp_path = offset_path.parent / (offset_path.name + ".tmp")
+        # PID-suffixed tmp name: UserPromptSubmit's turn-capture hook and
+        # Stop's session-capture hook (which calls this command) both
+        # maintain the same {session_id}.offset file and can fire close
+        # together for one exchange. A shared tmp path lets whichever
+        # process calls os.replace() second find its source already
+        # consumed by the first — see write_live_fingerprint() above.
+        tmp_path = offset_path.parent / f"{offset_path.name}.{os.getpid()}.tmp"
         # fsync before the rename: a crash between them must never publish an
         # empty offset file — a zero offset replays the whole transcript.
         fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)

--- a/tests/test_capture_turn_deferred.py
+++ b/tests/test_capture_turn_deferred.py
@@ -26,6 +26,19 @@ def _build_args(session_id: str, transcript_path: Path, max_turns: int = 200) ->
     )
 
 
+def _race_worker(home: str, session_id: str, transcript_path: str, q) -> None:
+    """Module-level (picklable under macOS's spawn start method) worker for
+    the concurrent-capture regression test below."""
+    import os as _os
+    _os.environ["HOME"] = home
+    from iai_mcp.cli import cmd_capture_turn_deferred
+    try:
+        rc = cmd_capture_turn_deferred(_build_args(session_id, Path(transcript_path)))
+        q.put(("ok", rc))
+    except Exception as exc:  # the pre-fix bug surfaces here
+        q.put(("error", f"{type(exc).__name__}: {exc}"))
+
+
 def test_first_call_writes_header_and_one_event(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     from iai_mcp.cli import cmd_capture_turn_deferred
@@ -169,3 +182,45 @@ def test_max_turns_per_call_cap(tmp_path, monkeypatch):
 
     offset = int((tmp_path / ".iai-mcp" / ".capture-state" / "S7.offset").read_text().strip())
     assert offset == 3
+
+
+def test_concurrent_calls_do_not_race_on_shared_tmp_path(tmp_path, monkeypatch):
+    """UserPromptSubmit's turn-capture and Stop's session-capture (which also
+    calls this command) can fire close together for one exchange, both
+    touching the same {session_id}.offset file. Before the fix, both writers
+    shared one {session_id}.offset.tmp path, so whichever called os.replace()
+    second raised FileNotFoundError once the first had already consumed it.
+    Regression test: run genuinely concurrent OS processes (not threads —
+    the fix keys uniqueness off os.getpid(), which threads would share) and
+    assert none of them ever hit that error."""
+    import multiprocessing as mp
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text(
+        _make_transcript_line("user", "concurrent race regression turn one")
+        + _make_transcript_line("assistant", "concurrent race regression turn two")
+    )
+    session_id = "RACE1"
+
+    ctx = mp.get_context("spawn" if platform.system() != "Linux" else "fork")
+    q = ctx.Queue()
+    procs = [
+        ctx.Process(target=_race_worker, args=(str(tmp_path), session_id, str(transcript), q))
+        for _ in range(10)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=30)
+
+    results = [q.get(timeout=5) for _ in procs]
+    errors = [r for r in results if r[0] == "error"]
+    assert not errors, f"concurrent capture-turn-deferred calls raised: {errors}"
+
+    offset_path = tmp_path / ".iai-mcp" / ".capture-state" / f"{session_id}.offset"
+    assert offset_path.exists()
+    assert int(offset_path.read_text().strip()) == 2, "offset must land on the real turn count"
+
+    leftover_tmp = list((tmp_path / ".iai-mcp" / ".capture-state").glob(f"{session_id}.offset*.tmp"))
+    assert not leftover_tmp, f"orphaned tmp files left behind: {leftover_tmp}"


### PR DESCRIPTION
Fixes #98.

UserPromptSubmit's turn-capture hook and Stop's session-capture hook (which calls `capture-turn-deferred`) both maintain the same `{session_id}.offset` file, and can fire close together for one exchange — confirmed live on Cursor, which fires the turn-capture hook twice per prompt. Both writers built their rename-source tmp path from the session id alone, no per-process uniqueness, so whichever process called `os.replace()` second found its source already consumed by the first, raising `FileNotFoundError`. The error is caught and logged, never fatal, but the write it belonged to is lost — on a session's first turn (no prior offset baseline) this can drop the write entirely until the Stop-hook safety net catches up.

## Fix

Suffix every tmp path with `os.getpid()`, so concurrent writers never share a rename source. Applies to the three call sites sharing this pattern (offset, watermark, live-fingerprint tmp writes) in both the turn-capture hook script and `cli/_capture.py`'s `capture-turn-deferred`.

## Verification

Not just inspection — a 20-process concurrency stress test (10 pairs of the turn-capture hook + `capture-turn-deferred`, launched simultaneously against the same session) against the unpatched code failed 9/20 calls with this exact `FileNotFoundError`. The same test against the patched code passed 20/20, with no leftover tmp files and the correct final offset.

Regression test added (`test_concurrent_calls_do_not_race_on_shared_tmp_path`) using real subprocesses via `multiprocessing`, not threads — the fix's uniqueness keys off `os.getpid()`, which threads would share, so a thread-based test would not actually exercise the fix.

## Test plan

- [x] `pytest tests/test_capture_turn_deferred.py` — 8 passed, including the new regression test
- [x] Manual concurrency stress test against both unpatched (9/20 fail) and patched (20/20 pass) code
- [x] `ruff check --select F,E9` on changed files — no new issues (pre-existing file has unrelated lint backlog per `extended-checks.yml`, which is explicitly non-blocking)