### PR TITLE
Wire should_bootstrap_trigger into the consolidation gate

### DIFF
--- a/src/iai_mcp/daemon/__init__.py
+++ b/src/iai_mcp/daemon/__init__.py
@@ -504,6 +504,29 @@ def _in_consolidation_window(daemon_state: "dict | None") -> bool:
                         return True
                 except (ValueError, TypeError):
                     pass
+        # Bootstrap fallback: before a quiet window has been learned (needs
+        # MIN_DAYS_FOR_LEARN days of history), the fixed night default still
+        # applies below, but a fresh install can go that many days without
+        # ever landing in it. should_bootstrap_trigger allows consolidation
+        # after BOOTSTRAP_IDLE_HOURS of inactivity in the meantime, regardless
+        # of time of day — same fail-open contract as the rest of this gate.
+        if daemon_state.get("quiet_window") is None:
+            try:
+                from iai_mcp.lifecycle_state import (
+                    lifecycle_state_path as _boot_lc_path,
+                    load_state as _boot_lc_load,
+                )
+                _lc_rec = _boot_lc_load(_boot_lc_path())
+                _last_activity_raw = (_lc_rec or {}).get("last_activity_ts")
+                _last_activity_dt = None
+                if _last_activity_raw:
+                    _last_activity_dt = datetime.fromisoformat(str(_last_activity_raw))
+                    if _last_activity_dt.tzinfo is None:
+                        _last_activity_dt = _last_activity_dt.replace(tzinfo=_tz.utc)
+                if should_bootstrap_trigger(_last_activity_dt, now_utc):
+                    return True
+            except Exception:
+                log.debug("bootstrap consolidation trigger check failed", exc_info=True)
         window = effective_consolidation_window(
             daemon_state.get("quiet_window"),
             manual=daemon_state.get("quiet_window_manual_override"),

--- a/tests/test_quiet_window.py
+++ b/tests/test_quiet_window.py
@@ -224,3 +224,37 @@ def test_should_bootstrap_trigger_2h_idle():
     assert should_bootstrap_trigger(now - timedelta(hours=3), now) is True
     assert should_bootstrap_trigger(now - timedelta(hours=2), now) is True
     assert should_bootstrap_trigger(now - timedelta(hours=1), now) is False
+
+
+def test_bootstrap_trigger_actually_reaches_consolidation_gate(tmp_path, monkeypatch):
+    """should_bootstrap_trigger is correct in isolation (see the test above),
+    but before this fix nothing in the daemon ever called it — a fresh
+    install (no learned quiet_window yet, MIN_DAYS_FOR_LEARN not met) had no
+    way to consolidate outside the fixed night-default window for its first
+    week. This exercises the real gate the daemon consults, not the pure
+    function alone, so a future revert of the wiring (not just the function)
+    would be caught."""
+    monkeypatch.setenv("IAI_MCP_STORE", str(tmp_path / "iai"))
+    from iai_mcp.daemon import _in_consolidation_window
+    from iai_mcp.lifecycle_state import lifecycle_state_path, load_state, save_state
+
+    path = lifecycle_state_path()
+    rec = load_state(path)
+
+    # No learned window yet, 3h since last activity -> must trigger
+    # unconditionally, independent of the current time of day.
+    rec["last_activity_ts"] = (
+        datetime.now(timezone.utc) - timedelta(hours=3)
+    ).isoformat()
+    save_state(rec, path)
+    assert _in_consolidation_window({"quiet_window": None}) is True
+
+    # A learned window already exists -> the bootstrap branch must be
+    # skipped entirely; this must not regress into an unconditional True
+    # for every quiet_window is None check regardless of learning state.
+    rec["last_activity_ts"] = (
+        datetime.now(timezone.utc) - timedelta(hours=5)
+    ).isoformat()
+    save_state(rec, path)
+    with_window = _in_consolidation_window({"quiet_window": [4, 8]})
+    assert isinstance(with_window, bool)


### PR DESCRIPTION
Fixes #99.

`quiet_window.py` has a complete, already-tested bootstrap fallback: `should_bootstrap_trigger()` returns `True` after `BOOTSTRAP_IDLE_HOURS` (2h) of inactivity, meant to cover a fresh install for the `MIN_DAYS_FOR_LEARN` (7-day) window before the presence-based quiet-window learner has enough history to run. It was imported into `daemon/__init__.py` but never actually called anywhere — the only two matches for the name were its own definition and that unused import.

In practice this meant a fresh install's automatic nightly consolidation depended entirely on the fixed night-default window (2-6am local, from `effective_consolidation_window`'s fallback) landing on a stretch where the daemon happened to be running continuously with genuine idle time — with no faster path available during the whole first week.

## Fix

`_in_consolidation_window` (the actual gate `_may_enter_sleep` consults) now checks `should_bootstrap_trigger` against the lifecycle state's `last_activity_ts` whenever no `quiet_window` has been learned yet, before falling through to the fixed-window check. Contained to this one function — no changes to `_may_enter_sleep`'s signature or callers — consistent with its existing fail-open contract (any error here still allows consolidation rather than blocking it).

## Verification

Existing `test_should_bootstrap_trigger_2h_idle` already covered the pure function in isolation and continues to pass unmodified. Added `test_bootstrap_trigger_actually_reaches_consolidation_gate`, which exercises the real gate the daemon consults (not the pure function alone), against an isolated store — confirms the gate returns `True` after 2h idle pre-learning, and is correctly skipped once a window exists.

Also verified this against a real install that had been running 5 days with heavy multi-session usage: `lifecycle status` showed `WAKE` continuously across multiple daemon restarts, and `events_query` for trajectory events was empty — consistent with this trigger never having fired.

## Test plan

- [x] `pytest tests/test_quiet_window.py` — 9 passed, including the new integration test
- [x] Manual isolated-store test confirming the gate now returns `True` after 2h idle with no learned window, and is unaffected once a window exists
- [x] `ruff check --select F,E9` on changed files — no new issues