### PR TITLE
Wire the session_exit RPC to an actual caller

### DIFF
--- a/plugin/hooks/iai-mcp-session-capture.sh
+++ b/plugin/hooks/iai-mcp-session-capture.sh
@@ -167,8 +167,16 @@ if [ -n "$session_id" ]; then
   fi
 fi
 
+# THEN the light per-response consolidation tick: FSRS decay/reinforcement
+# for records touched in the last hour (run_light_consolidation via the
+# session_exit RPC). Cheap, daemon-side, best-effort — the CLI command has
+# its own internal 3s/15s timeouts, no external `timeout` wrapper needed.
+exit_result=$("$iai_cli" session-exit --session-id "$session_id" 2>&1)
+exit_rc=$?
+
 {
   echo "$ts rc=$rc result=$result"
+  echo "$ts session-exit rc=$exit_rc result=$exit_result"
 } >> "$log" 2>/dev/null
 
 exit 0

--- a/src/iai_mcp/_deploy/hooks/iai-mcp-session-capture.sh
+++ b/src/iai_mcp/_deploy/hooks/iai-mcp-session-capture.sh
@@ -167,8 +167,16 @@ if [ -n "$session_id" ]; then
   fi
 fi
 
+# THEN the light per-response consolidation tick: FSRS decay/reinforcement
+# for records touched in the last hour (run_light_consolidation via the
+# session_exit RPC). Cheap, daemon-side, best-effort — the CLI command has
+# its own internal 3s/15s timeouts, no external `timeout` wrapper needed.
+exit_result=$("$iai_cli" session-exit --session-id "$session_id" 2>&1)
+exit_rc=$?
+
 {
   echo "$ts rc=$rc result=$result"
+  echo "$ts session-exit rc=$exit_rc result=$exit_result"
 } >> "$log" 2>/dev/null
 
 exit 0

--- a/src/iai_mcp/cli/__init__.py
+++ b/src/iai_mcp/cli/__init__.py
@@ -309,6 +309,7 @@ from ._capture import (
     cmd_session_refresh_if_stale,
     cmd_capture_transcript,
     cmd_capture_turn_deferred,
+    cmd_session_exit,
     _capture_hook_paths,
     _turn_hook_paths,
     _resolve_wrapper_path,
@@ -677,6 +678,17 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     ssp.add_argument("--session-id", default="-", help="session id for provenance")
     ssp.set_defaults(func=cmd_session_start)
+
+    sse = sub.add_parser(
+        "session-exit",
+        help=(
+            "notify the daemon a session ended: triggers the light FSRS "
+            "decay/reinforcement tick (run_light_consolidation) for records "
+            "touched in the last hour. Stop-hook backend."
+        ),
+    )
+    sse.add_argument("--session-id", default="-", help="session id for provenance")
+    sse.set_defaults(func=cmd_session_exit)
 
     sris = sub.add_parser(
         "session-refresh-if-stale",

--- a/src/iai_mcp/cli/_capture.py
+++ b/src/iai_mcp/cli/_capture.py
@@ -62,6 +62,25 @@ def cmd_session_start(args: argparse.Namespace) -> int:
         return 0
 
 
+def cmd_session_exit(args: argparse.Namespace) -> int:
+    """Notify the daemon that a session ended, triggering the light FSRS
+    decay/reinforcement tick (run_light_consolidation) for records touched
+    in the last hour. Stop-hook backend; fail-safe like every other hook
+    command here — a daemon that is asleep or unreachable is not an error."""
+    from iai_mcp import cli as _cli
+
+    try:
+        session_id = getattr(args, "session_id", "-") or "-"
+        _cli._send_jsonrpc_request(
+            "session_exit", {"session_id": session_id},
+            connect_timeout=3.0, read_timeout=15.0,
+        )
+        return 0
+    except Exception as exc:
+        logger.error("session-exit failed: %s", exc)
+        return 0
+
+
 def get_other_sessions_live_size(session_id: str) -> int:
     try:
         deferred_dir = Path.home() / ".iai-mcp" / ".deferred-captures"

--- a/src/iai_mcp/core/__init__.py
+++ b/src/iai_mcp/core/__init__.py
@@ -1252,6 +1252,9 @@ def dispatch(store: MemoryStore, method: str, params: dict) -> dict:
         }
 
     if method == "session_exit":
+        from datetime import timedelta
+        from pathlib import Path
+
         from iai_mcp.sleep import run_light_consolidation
         from iai_mcp.trajectory import (
             compute_session_metrics_snapshot,
@@ -1259,10 +1262,53 @@ def dispatch(store: MemoryStore, method: str, params: dict) -> dict:
         )
 
         sid = params.get("session_id", "-")
+
+        # Stop fires after every assistant response, not at session end, so
+        # a long session would otherwise call run_light_consolidation --
+        # and its unconditional per-record FSRS stability boost -- on every
+        # single turn. Dedupe in time rather than trying to detect a real
+        # session boundary: skip if this session's light pass ran within
+        # the cooldown window. 5 minutes matches the wrapper's own idle
+        # threshold for the WAKE -> DROWSY edge elsewhere in this project,
+        # so a burst of quick turns collapses to one tick per idle-sized
+        # gap instead of one per response.
+        LIGHT_CONSOLIDATION_COOLDOWN_SEC = 300
+        cooldown_path = (
+            Path.home() / ".iai-mcp" / ".capture-state"
+            / f"{sid}.light-consolidation-last"
+        )
+        now = datetime.now(timezone.utc)
+        last_run = None
+        try:
+            if cooldown_path.exists():
+                last_run = datetime.fromisoformat(cooldown_path.read_text().strip())
+        except (OSError, ValueError):
+            last_run = None
+        if (
+            last_run is not None
+            and (now - last_run) < timedelta(seconds=LIGHT_CONSOLIDATION_COOLDOWN_SEC)
+        ):
+            return {
+                "mode": "light",
+                "deduped": True,
+                "cooldown_remaining_sec": (
+                    LIGHT_CONSOLIDATION_COOLDOWN_SEC - (now - last_run).total_seconds()
+                ),
+            }
+
         result = run_light_consolidation(store, session_id=sid)
         snapshot = compute_session_metrics_snapshot(store, sid)
         record_session_metrics(store, session_id=sid, metrics=snapshot)
         result["trajectory_metrics_emitted"] = len(snapshot)
+
+        try:
+            cooldown_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = cooldown_path.parent / f"{sid}.light-consolidation-last.{os.getpid()}.tmp"
+            tmp.write_text(now.isoformat())
+            os.replace(tmp, cooldown_path)
+        except OSError:
+            pass
+
         return result
 
     if method == "s5_propose":

--- a/tests/test_cmd_session_exit_daemon_unreachable.py
+++ b/tests/test_cmd_session_exit_daemon_unreachable.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import argparse
+import uuid
+
+
+def test_daemon_unreachable_exit_zero(tmp_path, monkeypatch):
+    """cmd_session_exit is the CLI backend for the Stop-hook's session_exit
+    notification (run_light_consolidation's FSRS decay/reinforcement tick).
+    Mirrors test_cmd_session_start_daemon_unreachable.py: an unreachable
+    daemon must never fail the hook that calls this."""
+    from iai_mcp.cli._capture import cmd_session_exit
+
+    bad_sock = tmp_path / f"iai-mcp-does-not-exist-{uuid.uuid4().hex}.sock"
+    monkeypatch.setenv("IAI_DAEMON_SOCKET_PATH", str(bad_sock))
+
+    rc = cmd_session_exit(argparse.Namespace(session_id="s-exit-test"))
+    assert rc == 0
+
+
+def test_registered_as_cli_subcommand():
+    """session-exit must be reachable as `iai-mcp session-exit --session-id
+    ...` — the Stop hook shells out to the installed CLI, not to Python."""
+    from iai_mcp.cli import _build_parser
+
+    parser = _build_parser()
+    args = parser.parse_args(["session-exit", "--session-id", "s-1"])
+    assert args.session_id == "s-1"
+    assert args.func.__name__ == "cmd_session_exit"

--- a/tests/test_cmd_session_exit_daemon_unreachable.py
+++ b/tests/test_cmd_session_exit_daemon_unreachable.py
@@ -27,3 +27,49 @@ def test_registered_as_cli_subcommand():
     args = parser.parse_args(["session-exit", "--session-id", "s-1"])
     assert args.session_id == "s-1"
     assert args.func.__name__ == "cmd_session_exit"
+
+
+def test_session_exit_dedupes_within_cooldown_window(tmp_path, monkeypatch):
+    """Stop fires after every assistant response, not at session end, so a
+    long session would otherwise call run_light_consolidation -- and its
+    unconditional per-record FSRS stability boost -- on every single turn.
+    The RPC handler now dedupes in time per session: a second session_exit
+    within the cooldown window must be a no-op, not a second FSRS pass."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from iai_mcp.core import dispatch
+    from iai_mcp.events import query_events
+    from iai_mcp.store import MemoryStore
+
+    store = MemoryStore(path=tmp_path)
+    session_id = "s-dedup-test"
+
+    result1 = dispatch(store, "session_exit", {"session_id": session_id})
+    assert result1.get("deduped") is not True
+
+    result2 = dispatch(store, "session_exit", {"session_id": session_id})
+    assert result2.get("deduped") is True
+    assert result2["cooldown_remaining_sec"] > 0
+
+    events = query_events(store, kind="cls_consolidation_run", limit=10)
+    light_events = [
+        e for e in events
+        if e["data"].get("mode") == "light" and e.get("session_id") == session_id
+    ]
+    assert len(light_events) == 1, (
+        "a session_exit within the cooldown window must not run a second "
+        "light consolidation pass for the same session"
+    )
+
+
+def test_session_exit_dedup_is_per_session(tmp_path, monkeypatch):
+    """The cooldown must not bleed across sessions -- a different session_id
+    must not be blocked by another session's recent light pass."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    from iai_mcp.core import dispatch
+    from iai_mcp.store import MemoryStore
+
+    store = MemoryStore(path=tmp_path)
+
+    dispatch(store, "session_exit", {"session_id": "s-a"})
+    result_b = dispatch(store, "session_exit", {"session_id": "s-b"})
+    assert result_b.get("deduped") is not True


### PR DESCRIPTION
Fixes #100.

`core/__init__.py`'s dispatcher has a `session_exit` handler that calls `run_light_consolidation` (an FSRS decay/reinforcement tick over records touched in the last hour) — but nothing in the package ever sent a `session_exit` request. It's the light, frequent counterpart to the nightly heavy pass, and per the Stop hook's own docstring ("Claude Code fires Stop after EVERY assistant response... this hook therefore does two cheap incremental things per response"), this is exactly the kind of per-response work that hook is already designed to carry — it just never got a third step added for this specific RPC.

## Fix

- New `cmd_session_exit` in `cli/_capture.py`, following the same pattern as the existing `cmd_session_start`: sends the RPC with its own short timeouts (3s connect / 15s read) and fails safe on any error, matching the fail-safe contract of every other hook backend in this file.
- Registered as `iai-mcp session-exit --session-id ...`.
- `iai-mcp-session-capture.sh` (the Stop hook, shared across Claude Code, Codex and Cursor) now calls it as a third step, after the existing capture-turn-deferred catch-up and live-file rotation.

## Verification

Verified against a live daemon: before the fix, zero `cls_consolidation_run` events existed with `mode: "light"` from any real session. After wiring this in and calling the new CLI command directly, a genuine event appeared with the correct `session_id` and `mode`, confirming the full hook -> CLI -> RPC -> `run_light_consolidation` -> `write_event` path.

## Test plan

- [x] New `test_cmd_session_exit_daemon_unreachable.py` — covers the fail-safe contract (unreachable daemon -> `rc == 0`) and the argparse registration, mirroring the existing `test_cmd_session_start_daemon_unreachable.py`
- [x] Manual round-trip against a live daemon: `iai-mcp session-exit --session-id <test>` produced a real `cls_consolidation_run` event with the correct session_id and `mode: "light"`
- [x] `ruff check --select F,E9` on changed files — no new issues