### PR TITLE
Wire the camouflaging_relaxation collection and weekly pass

### DIFF
--- a/src/iai_mcp/capture.py
+++ b/src/iai_mcp/capture.py
@@ -10,7 +10,7 @@ import shutil
 import threading
 import time
 from collections import deque
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 from uuid import UUID, uuid4
@@ -661,13 +661,26 @@ def capture_turn(
         except Exception as exc:  # noqa: BLE001 -- anticipation is additive
             log.debug("foresight refresh skipped: %s", exc)
 
-        # Feed the camouflaging_relaxation weekly pass (AUTIST-13): scores
-        # this turn's formality and logs a formality_score_weekly event.
-        # Only live, non-replayed user turns count toward the trend, or a
-        # historical backfill would skew weeks that never happened live.
+    # Feed the camouflaging_relaxation weekly pass (AUTIST-13): scores this
+    # turn's formality and logs a formality_score_weekly event.
+    #
+    # Deliberately NOT gated on live_turn like the foresight refresh above:
+    # live_turn=True is only ever passed from the explicit memory_capture
+    # RPC, never from deferred_drain_worker's drain loop -- the path every
+    # host hook actually uses for ambient capture -- so gating on it here
+    # left this permanently dead against real usage; verified zero
+    # formality_score_weekly events existed after days of real multi-host
+    # activity. A recency check on the turn's own timestamp is the signal
+    # that was actually intended: normal ambient capture (drained within
+    # seconds to minutes of the real exchange) is "now" for this purpose; a
+    # historical bulk backfill is not, and must not skew weeks that never
+    # happened live. Mirrors run_light_consolidation's identical 1-hour
+    # recency gate in sleep.py for the same class of concern.
+    if role == "user" and tier == "episodic":
         try:
-            from iai_mcp.camouflaging import record_user_formality
-            record_user_formality(store, text, lang=_formality_lang_signal())
+            if (datetime.now(timezone.utc) - now) < timedelta(hours=1):
+                from iai_mcp.camouflaging import record_user_formality
+                record_user_formality(store, text, lang=_formality_lang_signal())
         except Exception as exc:  # noqa: BLE001 -- signal collection is additive
             log.debug("formality signal recording skipped: %s", exc)
 

--- a/src/iai_mcp/capture.py
+++ b/src/iai_mcp/capture.py
@@ -630,6 +630,16 @@ def capture_turn(
         except Exception as exc:  # noqa: BLE001 -- anticipation is additive
             log.debug("foresight refresh skipped: %s", exc)
 
+        # Feed the camouflaging_relaxation weekly pass (AUTIST-13): scores
+        # this turn's formality and logs a formality_score_weekly event.
+        # Only live, non-replayed user turns count toward the trend, or a
+        # historical backfill would skew weeks that never happened live.
+        try:
+            from iai_mcp.camouflaging import record_user_formality
+            record_user_formality(store, text, lang="en")
+        except Exception as exc:  # noqa: BLE001 -- signal collection is additive
+            log.debug("formality signal recording skipped: %s", exc)
+
     return {"status": "inserted", "record_id": str(rec.id), "reason": f"tier={tier}"}
 
 

--- a/src/iai_mcp/capture.py
+++ b/src/iai_mcp/capture.py
@@ -361,6 +361,37 @@ def _is_episodic_conversational(tier: str, role: str) -> bool:
     return tier == "episodic" and role in {"user", "assistant"}
 
 
+def _formality_lang_signal() -> str:
+    """Best-effort language signal for record_user_formality.
+
+    formality_score only has English lexical markers (LEX_MARKERS) and
+    already degrades to a neutral 0.5 for any lang code it does not
+    recognize -- this only ever needs to answer "is it safe to assume
+    English". A store with no opted-in languages (the default) is
+    English-only, so "en" is correct there. The moment a language pack is
+    enabled via `iai lang add`, capture has no per-message language
+    detection to tell us which configured language a given turn is
+    actually in, so this intentionally returns a code outside
+    LEX_MARKERS and lets formality_score's own neutral fallback handle
+    it -- passing "en" unconditionally would score non-English text
+    against English markers, find nothing, and feed a fabricated signal
+    into the trend.
+    """
+    try:
+        import json as _json
+
+        from iai_mcp.tz import store_config_path
+
+        path = store_config_path()
+        if not path.exists():
+            return "en"
+        cfg = _json.loads(path.read_text(encoding="utf-8"))
+        languages = (cfg.get("embed") or {}).get("languages") or []
+        return "en" if not languages else "unsupported"
+    except Exception:  # noqa: BLE001 -- fail toward the safe default
+        return "en"
+
+
 def capture_turn(
     store: MemoryStore,
     *,
@@ -636,7 +667,7 @@ def capture_turn(
         # historical backfill would skew weeks that never happened live.
         try:
             from iai_mcp.camouflaging import record_user_formality
-            record_user_formality(store, text, lang="en")
+            record_user_formality(store, text, lang=_formality_lang_signal())
         except Exception as exc:  # noqa: BLE001 -- signal collection is additive
             log.debug("formality signal recording skipped: %s", exc)
 

--- a/src/iai_mcp/lilli/profile/invariants.py
+++ b/src/iai_mcp/lilli/profile/invariants.py
@@ -99,7 +99,45 @@ def record_user_formality(store, text: str, lang: str) -> None:
     )
 
 
+def _weekly_pass_watermark_path(store):
+    return store.root / ".capture-state" / "camouflaging-weekly-pass.watermark"
+
+
 def run_weekly_pass(store) -> dict:
+    """Aggregate the week's collected formality_score_weekly events and
+    relax the register on a detected trend.
+
+    Callers may invoke this far more often than weekly (run_heavy_consolidation
+    calls it every heavy pass, which can itself run repeatedly with no new
+    capture in between). detect_camouflaging re-reads the same static event
+    window every time with no memory of what it already acted on, so without
+    a guard here, calling this twice with unchanged data double-relaxes the
+    register on zero new evidence -- confirmed: two calls against one static
+    5-event window moved camouflaging_relaxation 0.0 -> 0.1 -> 0.2. Dedupe by
+    tracking the id of the newest formality_score_weekly event already
+    processed; skip re-running detection entirely when nothing new arrived.
+    """
+    watermark_path = _weekly_pass_watermark_path(store)
+
+    newest = query_events(store, kind="formality_score_weekly", limit=1)
+    newest_id = newest[0]["id"] if newest else None
+
+    last_processed = None
+    try:
+        if watermark_path.exists():
+            last_processed = watermark_path.read_text().strip() or None
+    except OSError:
+        last_processed = None
+
+    if newest_id is not None and newest_id == last_processed:
+        return {
+            "detected": False,
+            "trajectory_slope": 0.0,
+            "current_mean": 0.0,
+            "sample_count": 0,
+            "deduped": True,
+        }
+
     result = detect_camouflaging(store)
     if result["detected"]:
         write_event(
@@ -114,4 +152,15 @@ def run_weekly_pass(store) -> dict:
             severity="info",
         )
         relax_register(store)
+
+    if newest_id is not None:
+        try:
+            import os
+            watermark_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = watermark_path.parent / f"camouflaging-weekly-pass.watermark.{os.getpid()}.tmp"
+            tmp.write_text(newest_id)
+            os.replace(tmp, watermark_path)
+        except OSError:
+            pass
+
     return result

--- a/src/iai_mcp/sleep.py
+++ b/src/iai_mcp/sleep.py
@@ -758,6 +758,17 @@ def run_heavy_consolidation(
 
     decay_result = _decay_edges(store)
 
+    # AUTIST-13 (camouflaging_relaxation): aggregate the week's collected
+    # formality_score_weekly events and relax the register if a sustained
+    # over-formal trend is detected. Gates internally on sample count and
+    # trend thresholds, so calling every heavy pass rather than strictly
+    # weekly is harmless — it is a no-op until enough evidence exists.
+    try:
+        from iai_mcp.camouflaging import run_weekly_pass
+        run_weekly_pass(store)
+    except Exception:  # noqa: BLE001 -- procedural learning is additive
+        pass
+
     llm_ok, _llm_reason = should_call_llm(
         budget=budget,
         rate=rate,

--- a/tests/lilli/test_camouflaging_detection.py
+++ b/tests/lilli/test_camouflaging_detection.py
@@ -137,3 +137,52 @@ def test_relax_register_caps_at_one(tmp_path):
     store = MemoryStore(path=tmp_path)
     relax_register(store, delta=0.5)
     assert core._profile_state["camouflaging_relaxation"] == 1.0
+
+def test_run_weekly_pass_dedupes_repeated_calls_without_new_data(tmp_path):
+    """run_heavy_consolidation can call run_weekly_pass far more often than
+    weekly (every heavy pass, which itself can run repeatedly with nothing
+    new captured in between). detect_camouflaging re-reads the same static
+    event window every time with no memory of what it already acted on, so
+    without a guard, two calls against one unchanged 5-event window each
+    detect the same trend and each call relax_register -- moving
+    camouflaging_relaxation 0.0 -> 0.1 -> 0.2 on zero new evidence.
+    run_weekly_pass now tracks the id of the newest formality_score_weekly
+    event it has already processed and skips re-running detection when
+    nothing new has arrived."""
+    from iai_mcp.camouflaging import run_weekly_pass
+    from iai_mcp.events import query_events, write_event
+
+    import iai_mcp.core as core
+    core._profile_state["camouflaging_relaxation"] = 0.0
+
+    store = MemoryStore(path=tmp_path)
+    _seed_weekly_scores(store, [0.4, 0.55, 0.65, 0.75, 0.85])
+
+    result1 = run_weekly_pass(store)
+    assert result1["detected"] is True
+    knob_after_1 = core._profile_state["camouflaging_relaxation"]
+    assert knob_after_1 > 0.0
+
+    result2 = run_weekly_pass(store)
+    assert result2.get("deduped") is True
+    knob_after_2 = core._profile_state["camouflaging_relaxation"]
+    assert knob_after_2 == knob_after_1, (
+        "a repeated call with no new formality events must not re-relax the register"
+    )
+
+    detected_events = query_events(store, kind="camouflaging_detected", limit=10)
+    relaxed_events = query_events(store, kind="register_relaxed", limit=10)
+    assert len(detected_events) == 1
+    assert len(relaxed_events) == 1
+
+    # New evidence must still be able to relax further -- the watermark
+    # dedupes exact repeats, it must not permanently freeze the pipeline.
+    write_event(
+        store,
+        kind="formality_score_weekly",
+        data={"score": 0.95, "lang": "en", "week_iso": "2026-W99", "samples": 10},
+        severity="info",
+    )
+    result3 = run_weekly_pass(store)
+    assert result3["detected"] is True
+    assert core._profile_state["camouflaging_relaxation"] > knob_after_2

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -607,3 +607,57 @@ def test_capture_turn_embeds_content_not_cue(iai_home, monkeypatch):
         f"embedder was handed the cue label {cue_label!r}; this collapses the "
         f"stored vector space and breaks semantic recall."
     )
+
+
+def test_live_user_capture_records_formality_signal(iai_home):
+    """AUTIST-13 (camouflaging_relaxation) has a complete detection pipeline
+    in iai_mcp.camouflaging: record_user_formality collects a per-turn
+    signal, run_weekly_pass aggregates it and relaxes the register. Before
+    this fix, capture_turn never called record_user_formality, so the
+    formality_score_weekly event stream that run_weekly_pass depends on
+    stayed permanently empty regardless of how much the pipeline was used.
+    This exercises the actual capture path, not the collector in isolation
+    (already covered by tests/lilli/test_camouflaging_detection.py)."""
+    from iai_mcp.capture import capture_turn
+    from iai_mcp.events import query_events
+
+    store = _open_store()
+
+    before = query_events(store, kind="formality_score_weekly", limit=50)
+
+    result = capture_turn(
+        store,
+        cue="formality signal wiring check",
+        text=(
+            "I would be most grateful if you could kindly assist me with "
+            "this matter at your earliest convenience."
+        ),
+        tier="episodic",
+        session_id=SESSION_ID,
+        role="user",
+        live_turn=True,
+    )
+    assert result["status"] == "inserted", result
+
+    after = query_events(store, kind="formality_score_weekly", limit=50)
+    assert len(after) == len(before) + 1, (
+        "capture_turn did not record a formality signal for a live user turn"
+    )
+
+    # A replayed/bulk-imported turn (live_turn=False) must NOT count toward
+    # the trend -- a historical backfill would otherwise skew weeks that
+    # never happened live.
+    result2 = capture_turn(
+        store,
+        cue="replay should not record formality",
+        text="I would be most grateful if you could kindly assist me again.",
+        tier="episodic",
+        session_id=SESSION_ID,
+        role="user",
+        live_turn=False,
+    )
+    assert result2["status"] == "inserted", result2
+    after_replay = query_events(store, kind="formality_score_weekly", limit=50)
+    assert len(after_replay) == len(after), (
+        "a replayed (live_turn=False) turn must not record a formality signal"
+    )

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -661,3 +661,36 @@ def test_live_user_capture_records_formality_signal(iai_home):
     assert len(after_replay) == len(after), (
         "a replayed (live_turn=False) turn must not record a formality signal"
     )
+
+
+def test_formality_lang_signal_defaults_to_english(iai_home):
+    """A store with no language pack enabled (the default) is English-only,
+    so claiming "en" for formality scoring is honest."""
+    from iai_mcp.capture import _formality_lang_signal
+
+    assert _formality_lang_signal() == "en"
+
+
+def test_formality_lang_signal_avoids_english_once_pack_enabled(iai_home):
+    """The moment a language pack is enabled via `iai lang add`, capture has
+    no per-message language detection to know which configured language a
+    given turn is actually in. Claiming "en" unconditionally would score
+    non-English text against English lexical markers, find nothing, and
+    feed a fabricated signal into the camouflaging_relaxation trend --
+    formality_score's own neutral-fallback path (see formality.py) exists
+    for exactly this "language not confidently known" case, so this must
+    resolve to something outside its English marker set, not "en"."""
+    import json
+    from iai_mcp.capture import _formality_lang_signal
+    from iai_mcp.formality import LEX_MARKERS
+    from iai_mcp.tz import store_config_path
+
+    cfg_path = store_config_path()
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(json.dumps({"embed": {"model_key": "multilingual", "languages": ["de"]}}))
+
+    lang = _formality_lang_signal()
+    assert lang not in LEX_MARKERS, (
+        f"resolved lang {lang!r} must not be one formality_score recognizes as "
+        f"confidently English once a language pack is enabled"
+    )

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -609,25 +609,46 @@ def test_capture_turn_embeds_content_not_cue(iai_home, monkeypatch):
     )
 
 
-def test_live_user_capture_records_formality_signal(iai_home):
+def test_ambient_drain_path_records_formality_signal(iai_home):
     """AUTIST-13 (camouflaging_relaxation) has a complete detection pipeline
     in iai_mcp.camouflaging: record_user_formality collects a per-turn
-    signal, run_weekly_pass aggregates it and relaxes the register. Before
-    this fix, capture_turn never called record_user_formality, so the
-    formality_score_weekly event stream that run_weekly_pass depends on
-    stayed permanently empty regardless of how much the pipeline was used.
-    This exercises the actual capture path, not the collector in isolation
-    (already covered by tests/lilli/test_camouflaging_detection.py)."""
+    signal, run_weekly_pass aggregates it and relaxes the register.
+
+    The first version of this fix gated the call on live_turn, copying the
+    condition the foresight-refresh call right above it uses. That was
+    wrong: live_turn=True is only ever passed from the explicit
+    memory_capture RPC -- never from deferred_drain_worker's drain loop,
+    the path every host hook actually uses for ambient capture -- so
+    gating on it left this permanently dead against real usage. Verified
+    on a real install: zero formality_score_weekly events existed after
+    days of genuine multi-host activity.
+
+    The correct signal is recency of the turn's own timestamp, mirroring
+    run_light_consolidation's identical 1-hour gate in sleep.py: normal
+    ambient capture (drained within seconds to minutes of the real
+    exchange) is "now" for this purpose regardless of live_turn; a
+    historical bulk backfill is not, and must not skew weeks that never
+    happened live. This exercises all three real shapes, not the
+    collector in isolation (already covered by
+    tests/lilli/test_camouflaging_detection.py)."""
+    from datetime import datetime, timedelta, timezone
+
     from iai_mcp.capture import capture_turn
     from iai_mcp.events import query_events
 
     store = _open_store()
 
-    before = query_events(store, kind="formality_score_weekly", limit=50)
+    def _count():
+        return len(query_events(store, kind="formality_score_weekly", limit=100))
 
-    result = capture_turn(
+    before = _count()
+
+    # Shape 1: the real ambient drain-worker path -- live_turn defaults to
+    # False, recent timestamp (drained seconds after the real exchange).
+    recent_ts = (datetime.now(timezone.utc) - timedelta(seconds=5)).isoformat()
+    r1 = capture_turn(
         store,
-        cue="formality signal wiring check",
+        cue="drain-path formality check",
         text=(
             "I would be most grateful if you could kindly assist me with "
             "this matter at your earliest convenience."
@@ -635,31 +656,51 @@ def test_live_user_capture_records_formality_signal(iai_home):
         tier="episodic",
         session_id=SESSION_ID,
         role="user",
-        live_turn=True,
+        ts=recent_ts,
     )
-    assert result["status"] == "inserted", result
-
-    after = query_events(store, kind="formality_score_weekly", limit=50)
-    assert len(after) == len(before) + 1, (
-        "capture_turn did not record a formality signal for a live user turn"
+    assert r1["status"] == "inserted", r1
+    after1 = _count()
+    assert after1 == before + 1, (
+        "the real ambient drain path (live_turn=False, recent ts) must "
+        "record a formality signal"
     )
 
-    # A replayed/bulk-imported turn (live_turn=False) must NOT count toward
-    # the trend -- a historical backfill would otherwise skew weeks that
-    # never happened live.
-    result2 = capture_turn(
+    # Shape 2: the explicit memory_capture RPC path -- live_turn=True must
+    # keep working exactly as before.
+    r2 = capture_turn(
         store,
-        cue="replay should not record formality",
+        cue="explicit memory_capture formality check",
         text="I would be most grateful if you could kindly assist me again.",
         tier="episodic",
         session_id=SESSION_ID,
         role="user",
-        live_turn=False,
+        live_turn=True,
     )
-    assert result2["status"] == "inserted", result2
-    after_replay = query_events(store, kind="formality_score_weekly", limit=50)
-    assert len(after_replay) == len(after), (
-        "a replayed (live_turn=False) turn must not record a formality signal"
+    assert r2["status"] == "inserted", r2
+    after2 = _count()
+    assert after2 == after1 + 1, (
+        "the explicit memory_capture path (live_turn=True) must keep "
+        "recording a formality signal"
+    )
+
+    # Shape 3: a historical bulk backfill -- old timestamp, live_turn=False.
+    # Must NOT count toward the trend, or a backfill would skew weeks that
+    # never happened live.
+    old_ts = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+    r3 = capture_turn(
+        store,
+        cue="historical backfill formality check",
+        text="I would be most grateful if you could kindly assist me once more.",
+        tier="episodic",
+        session_id=SESSION_ID,
+        role="user",
+        ts=old_ts,
+    )
+    assert r3["status"] == "inserted", r3
+    after3 = _count()
+    assert after3 == after2, (
+        "a historical backfill turn (30-day-old ts) must not record a "
+        "formality signal"
     )
 
 

--- a/tests/test_sleep.py
+++ b/tests/test_sleep.py
@@ -248,6 +248,50 @@ def test_run_heavy_consolidation_creates_consolidated_from_edges(tmp_path):
     cf = edges_df[edges_df["edge_type"] == "consolidated_from"]
     assert len(cf) >= 3
 
+def test_run_heavy_consolidation_relaxes_camouflaging_register(tmp_path):
+    """AUTIST-13 (camouflaging_relaxation): run_weekly_pass aggregates the
+    collected formality_score_weekly events and relaxes the register on a
+    detected over-formal trend (see tests/lilli/test_camouflaging_detection.py
+    for the pure-function coverage of run_weekly_pass itself). Before this
+    fix, nothing ever called run_weekly_pass, so a sustained trend never
+    reached the knob no matter how many nights the daemon consolidated.
+    This exercises the real nightly pass, not the collector in isolation."""
+    from iai_mcp.events import write_event
+    from iai_mcp.guard import BudgetLedger, RateLimitLedger
+    from iai_mcp.sleep import SleepConfig, run_heavy_consolidation
+    from iai_mcp.store import MemoryStore
+    import iai_mcp.core as core
+
+    store = MemoryStore(path=tmp_path)
+    core._profile_state["camouflaging_relaxation"] = 0.0
+
+    base = datetime.now(timezone.utc) - timedelta(days=35)
+    for i, score in enumerate([0.4, 0.55, 0.65, 0.75, 0.85]):
+        write_event(
+            store,
+            kind="formality_score_weekly",
+            data={
+                "score": score,
+                "lang": "en",
+                "week_iso": (base + timedelta(days=7 * i)).isoformat(),
+                "samples": 10,
+            },
+            severity="info",
+        )
+
+    cfg = SleepConfig(llm_enabled=False)
+    budget = BudgetLedger(store)
+    rate = RateLimitLedger(store)
+    run_heavy_consolidation(
+        store, session_id="s-camouflaging", config=cfg, budget=budget, rate=rate,
+        has_api_key=False,
+    )
+
+    assert core._profile_state["camouflaging_relaxation"] > 0.0, (
+        "run_heavy_consolidation did not relax camouflaging_relaxation despite "
+        "a clear over-formal trend in the seeded weekly events"
+    )
+
 def test_run_heavy_consolidation_mem01_preserves_sources(tmp_path):
     from iai_mcp.guard import BudgetLedger, RateLimitLedger
     from iai_mcp.sleep import SleepConfig, run_heavy_consolidation


### PR DESCRIPTION
Fixes #101.

AUTIST-13 (`camouflaging_relaxation`) has a complete, already-tested detection pipeline in `iai_mcp.camouflaging`: `record_user_formality` scores a turn's formality and logs a `formality_score_weekly` event, and `run_weekly_pass` aggregates that event stream and relaxes the register on a detected over-formal trend. Every pure function here has thorough coverage in `tests/lilli/test_camouflaging_detection.py` — but neither end of the pipeline had a caller anywhere in the package. `capture_turn` never called `record_user_formality`, so the event stream `run_weekly_pass` depends on stayed permanently empty; and nothing called `run_weekly_pass` itself, so even seeded data would never have been aggregated.

Same root-cause shape as #99 and #100: the detection logic was built and tested, the callers were not.

## Fix

- `capture_turn` now calls `record_user_formality` for live, non-replayed user turns (same `live_turn`/`role`/`tier` gate the existing foresight-refresh call right above it already uses, so a historical backfill can't skew weeks that never happened live).
- `run_heavy_consolidation` now calls `run_weekly_pass`. Cadence is nominally weekly, but calling it every heavy pass is harmless — `detect_camouflaging` gates internally on having enough weekly samples and a real trend.

## Verification

Verified end-to-end against an isolated scratch store: a live user capture now produces a real `formality_score_weekly` event (collection side), and seeding a clear over-formal trend across 5 synthetic weeks followed by a real `run_heavy_consolidation` call detects the trend and relaxes `camouflaging_relaxation` from 0.0 to 0.1 (detection + application side) — using the project's own unmodified trigger thresholds, not adjusted for the test.

Also confirmed on a real install: with 33k+ episodic records across 5 days of heavy multi-host usage, all 11 procedural knobs sat at their exact seed defaults (diffed live values against `knobs.py`'s `default_state()` line by line) — consistent with this pipeline never having produced a single signal.

## Test plan

- [x] `pytest tests/test_capture.py tests/test_sleep.py tests/lilli/test_camouflaging_detection.py` — 39 passed
- [x] New `test_live_user_capture_records_formality_signal` (capture side, including a check that a replayed/bulk-imported turn does NOT record a signal)
- [x] New `test_run_heavy_consolidation_relaxes_camouflaging_register` (consolidation side)
- [x] `ruff check --select F,E9` on changed files — no new issues