### PR TITLE
Fix BrainView sleep control and lifecycle status

### DIFF
--- a/src/iai_mcp/brainview.py
+++ b/src/iai_mcp/brainview.py
@@ -541,10 +541,8 @@ class BrainView:
 
             lc_path = lifecycle_state_path(self.root)
             if lc_path.is_file():
-                return (
-                    json.loads(lc_path.read_text(encoding="utf-8")).get("state")
-                    or "awake"
-                )
+                state = json.loads(lc_path.read_text(encoding="utf-8"))
+                return state.get("current_state") or "awake"
         except Exception:  # noqa: BLE001 -- display is cosmetic
             pass
         return "awake"
@@ -827,18 +825,7 @@ class BrainView:
             if cov is not None:
                 counts["coverage"] = round(cov, 4)
 
-        lifecycle = "awake"
-        try:
-            from iai_mcp.lifecycle_state import lifecycle_state_path
-
-            lc_path = lifecycle_state_path(self.store.root)
-            if lc_path.is_file():
-                lifecycle = (
-                    json.loads(lc_path.read_text(encoding="utf-8")).get("state")
-                    or "awake"
-                )
-        except Exception:  # noqa: BLE001 -- lifecycle display is cosmetic
-            lifecycle = "awake"
+        lifecycle = self._lifecycle_label()
 
         daemon_up = False
         try:
@@ -1348,6 +1335,8 @@ class BrainView:
             s.connect(_addr)
             send_sync_auth_token(s)
             req = {"type": ctype, "ts": datetime.now(timezone.utc).isoformat()}
+            if ctype == "user_initiated_sleep":
+                req["reason"] = "BrainView dashboard control"
             s.sendall((json.dumps(req) + "\n").encode("utf-8"))
             buf = b""
             while not buf.endswith(b"\n") and len(buf) < 65536:

--- a/src/iai_mcp/brainview.py
+++ b/src/iai_mcp/brainview.py
@@ -1348,7 +1348,15 @@ class BrainView:
             resp = json.loads(buf or b"{}")
             # Require an explicit ok:true — an empty/EOF reply (daemon crashed
             # mid-request) must NOT read as success.
-            if resp.get("ok") is True:
+            # Sleep is a desired-state command.  A dashboard poll can lag the
+            # daemon by one tick, so a second click may race with the first
+            # request and arrive after SLEEP has already been entered.  Treat
+            # that reply as idempotent success instead of showing the generic
+            # failure toast for a state the user explicitly requested.
+            already_at_target = (
+                action == "sleep" and resp.get("reason") == "already_sleeping"
+            )
+            if resp.get("ok") is True or already_at_target:
                 return {"status": "ok", "action": action, "result": resp}
             return {"status": "error",
                     "reason": str(resp.get("reason") or resp.get("error")

--- a/tests/test_brainview.py
+++ b/tests/test_brainview.py
@@ -1027,14 +1027,15 @@ def test_janitor_never_closes_store_mid_write(tmp_path, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    ("action", "expected_type"),
+    ("action", "expected_type", "reply"),
     [
-        ("sleep", "user_initiated_sleep"),
-        ("wake", "force_wake"),
-        ("consolidate", "force_rem"),
+        ("sleep", "user_initiated_sleep", {"ok": True, "state": "TRANSITIONING"}),
+        ("sleep", "user_initiated_sleep", {"ok": False, "reason": "already_sleeping"}),
+        ("wake", "force_wake", {"ok": True, "reason": "wake_queued"}),
+        ("consolidate", "force_rem", {"ok": True, "reason": "rem_queued"}),
     ],
 )
-def test_daemon_action_uses_control_protocol(action, expected_type, tmp_path):
+def test_daemon_action_uses_control_protocol(action, expected_type, reply, tmp_path):
     """sleep/wake/consolidate are CONTROL messages (type-protocol). A fake
     daemon socket must receive `type`, not a JSON-RPC `method`."""
     import shutil
@@ -1060,7 +1061,7 @@ def test_daemon_action_uses_control_protocol(action, expected_type, tmp_path):
                     break
                 buf += c
             seen["req"] = json.loads(buf)
-            conn.sendall(b'{"ok": true, "reason": "rem_queued"}\n')
+            conn.sendall((json.dumps(reply) + "\n").encode("utf-8"))
             conn.close()
         except OSError:
             pass

--- a/tests/test_brainview.py
+++ b/tests/test_brainview.py
@@ -1026,7 +1026,15 @@ def test_janitor_never_closes_store_mid_write(tmp_path, monkeypatch):
     assert not observed_none["hit"], "janitor closed the store mid-write"
 
 
-def test_daemon_action_uses_control_protocol(tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    ("action", "expected_type"),
+    [
+        ("sleep", "user_initiated_sleep"),
+        ("wake", "force_wake"),
+        ("consolidate", "force_rem"),
+    ],
+)
+def test_daemon_action_uses_control_protocol(action, expected_type, tmp_path):
     """sleep/wake/consolidate are CONTROL messages (type-protocol). A fake
     daemon socket must receive `type`, not a JSON-RPC `method`."""
     import shutil
@@ -1060,10 +1068,12 @@ def test_daemon_action_uses_control_protocol(tmp_path, monkeypatch):
     t = threading.Thread(target=serve, daemon=True); t.start()
     try:
         view = BrainView(store_root=root)
-        res = view.daemon_action("consolidate")
+        res = view.daemon_action(action)
         t.join(3)
-        assert seen["req"]["type"] == "force_rem", seen["req"]
+        assert seen["req"]["type"] == expected_type, seen["req"]
         assert "method" not in seen["req"], "control msg must not be JSON-RPC"
+        if action == "sleep":
+            assert seen["req"]["reason"] == "BrainView dashboard control"
         assert res["status"] == "ok", res
     finally:
         srv.close()
@@ -1075,6 +1085,16 @@ def test_consolidate_button_in_page(served):
     _status, body = _get(port, "/")
     page = body.decode("utf-8")
     assert "btn-consolidate" in page and "sort memories now" in page
+
+
+def test_lifecycle_label_reads_current_state(tmp_path):
+    from iai_mcp.brainview import BrainView
+
+    (tmp_path / "lifecycle_state.json").write_text(
+        json.dumps({"current_state": "SLEEP"}), encoding="utf-8",
+    )
+    view = BrainView(store_root=tmp_path)
+    assert view._lifecycle_label() == "SLEEP"
 
 
 @pytest.mark.parametrize("driver", ["stdlib", "lilli"])


### PR DESCRIPTION
## Summary

Fix the BrainView sleep control and lifecycle indicator. The dashboard now sends the daemon-required `reason` field with `user_initiated_sleep` and reads the canonical `current_state` field from `lifecycle_state.json`.

Without these changes, clicking `let it rest` returned the generic `that didn't go through` message because the daemon rejected the request as `invalid_message`. A sleep started through another path still appeared as `awake` because BrainView looked for a field named `state`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / tooling

## Affected areas

- [ ] Capture path
- [ ] Recall / retrieval
- [x] Consolidation / sleep cycles
- [x] Daemon lifecycle / FSM
- [ ] Storage / encryption at rest
- [ ] MCP wrapper (TypeScript)
- [ ] Bench harness
- [ ] CLI / doctor
- [x] Other: BrainView dashboard

## Testing

- [x] `pytest` passes locally
- [ ] `ruff check src/ tests/` clean
- [x] New tests added for changed behaviour, or rationale below for why not

`pytest tests/test_brainview.py -q`: 62 passed.

The control-protocol test now covers sleep, wake, and consolidation. A separate regression test verifies that BrainView reads `current_state`.

## Benchmarks

Not applicable. This changes the dashboard control message and status display only; the consolidation pipeline itself is unchanged.

## Notes for reviewers

The repository's existing non-blocking Ruff backlog is unchanged. This PR does not include unrelated lint cleanup.
