### PR TITLE
fix(install): honor detected Python instead of bare python3 for venv

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -126,10 +126,10 @@ fi
 # ---------------------------------------------------------------------------
 step "building (a few minutes: the Rust engine compiles from source)"
 if [ "${DRY_RUN}" = "1" ]; then
-    printf '   \033[0;36m→\033[0m would run: bash %s/scripts/install.sh\n' "${SRC_DIR}"
+    printf '   \033[0;36m→\033[0m would run: IAI_PYTHON=%s bash %s/scripts/install.sh\n' "${PYTHON}" "${SRC_DIR}"
 else
     [ -f "${SRC_DIR}/scripts/install.sh" ] || die "scripts/install.sh missing from the clone"
-    bash "${SRC_DIR}/scripts/install.sh"
+    IAI_PYTHON="${PYTHON}" bash "${SRC_DIR}/scripts/install.sh"
 fi
 
 IAI_BIN="${SRC_DIR}/.venv/bin/iai-mcp"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -40,11 +40,29 @@ else
     # 1. venv
     # -----------------------------------------------------------------------
     step "python venv"
-    if [ ! -d .venv ]; then
-        python3 -m venv .venv
-        ok ".venv created"
+    # The package supports 3.11 and 3.12 only. IAI_PYTHON overrides detection
+    # (bootstrap.sh sets it from its own preflight); otherwise probe the usual
+    # names rather than trusting whatever `python3` happens to resolve to.
+    version_ok() { "$1" -c 'import sys; sys.exit(0 if sys.version_info[:2] in ((3,11),(3,12)) else 1)' 2>/dev/null; }
+    PYTHON="${IAI_PYTHON:-}"
+    if [ -n "${PYTHON}" ]; then
+        version_ok "${PYTHON}" || die "IAI_PYTHON=${PYTHON} is $("${PYTHON}" --version 2>&1 || echo unusable); need Python 3.11 or 3.12"
     else
-        ok ".venv already exists"
+        for candidate in python3.12 python3.11 python3; do
+            if command -v "${candidate}" >/dev/null 2>&1 && version_ok "${candidate}"; then
+                PYTHON="$(command -v "${candidate}")"
+                break
+            fi
+        done
+        [ -n "${PYTHON}" ] || die "need Python 3.11 or 3.12 (default python3 is: $(python3 --version 2>&1 || echo none)). Install one, or point IAI_PYTHON at a suitable interpreter."
+    fi
+    if [ ! -d .venv ]; then
+        "${PYTHON}" -m venv .venv
+        ok ".venv created with $("${PYTHON}" --version)"
+    elif ! version_ok .venv/bin/python; then
+        die "existing .venv uses $(.venv/bin/python --version 2>&1 || echo 'a broken interpreter'); need Python 3.11 or 3.12. Remove ${REPO_ROOT}/.venv and re-run."
+    else
+        ok ".venv already exists ($(.venv/bin/python --version))"
     fi
 
     # -----------------------------------------------------------------------


### PR DESCRIPTION
Fixes #110.

## Problem

`bootstrap.sh` preflight detects a supported interpreter (3.11/3.12), but `install.sh` builds the venv with whatever bare `python3` resolves to. With Homebrew's `python3` now at 3.14, the install fails at `pip install -e .` with `requires a different Python: 3.14.7 not in '<3.13,>=3.11'` — after the multi-minute Rust prerequisite step. And since `install.sh` reuses an existing `.venv` unchecked, re-runs keep failing until the user deletes `.venv` by hand.

## Changes

- `install.sh` now selects the interpreter itself: `IAI_PYTHON` env override first (validated), otherwise the same version-gated `python3.12` → `python3.11` → `python3` probe bootstrap uses, with a clear `die` if none qualifies.
- An existing `.venv` on an unsupported interpreter is rejected up front with instructions to remove it, instead of failing later inside pip.
- `bootstrap.sh` passes its detected interpreter down via `IAI_PYTHON=` (dry-run output updated to match).

`install.sh` stays independently runnable for collaborators (probe fallback), and the fix is a no-op on systems where `python3` is already 3.11/3.12.

## Testing

- `bash -n` on both scripts.
- `bootstrap.sh --dry-run` shows `would run: IAI_PYTHON=/opt/homebrew/bin/python3.11 bash .../install.sh`.
- Negative test: `IAI_PYTHON=$(command -v python3)` (3.14.7) → dies immediately with `IAI_PYTHON=/opt/homebrew/bin/python3 is Python 3.14.7; need Python 3.11 or 3.12`.
- Real-world repro of the underlying bug: full bootstrap on macOS arm64 with Homebrew python3 = 3.14.7 failed exactly as in #110; with the venv on 3.11.16 the same install completes and `iai-mcp doctor` passes all checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
