### PR TITLE
Fix #113 (README doc gaps) and #114 (misleading capture-hooks status)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,111 @@
+# Handoff → Code
+
+## Origen
+
+Conversación en Chat, sesión del 17 de agosto de 2026. Empezó revisando un
+repo de terceros (`valera-studio-group/valera-studio-project`, un harness de
+memoria paginada para Claude Code CLI) como posible alternativa mientras se
+resolvía un problema real: iai-mcp no arrancaba en Windows.
+
+## Contexto
+
+Ayer (sesión previa, no en este hilo) se diagnosticó que el daemon de
+iai-mcp crasheaba al bootear en Windows 11 con un traceback de
+`AttributeError: module 'signal' has no attribute 'SIGHUP'`. Tras aplicar un
+parche local, el daemon llegó más lejos pero se quedó atascado (CPU casi
+plana, sin nuevo traceback, sin socket abierto) durante varios minutos, sin
+llegar a confirmarse healthy. Esa sesión se detuvo ahí, sin escalar más a
+ciegas.
+
+En este hilo se comparó el fork (`oscampo/iai-personal-memory-engine`)
+contra el proyecto original (`CodeAbra/iai-personal-memory-engine`) y se
+encontraron y corrigieron dos bugs reales, ya subidos a `main` del fork.
+
+## Hallazgos verificados
+
+- [Seguro] El fork de Oscar no tenía ningún commit propio: estaba al día
+  con `upstream/main` pero además 5 commits *atrás* (Release 3.0.2 y
+  siguientes). El parche de `SIGHUP` de la sesión de ayer nunca llegó a
+  commitearse, vivía solo (si acaso) en el working tree local de la máquina
+  Windows.
+- [Seguro] El bug de `SIGHUP` existe también en `upstream/main`, sin
+  arreglar: no es un problema del fork ni del entorno de Oscar, es un bug
+  real y reportable en `CodeAbra/iai-personal-memory-engine`.
+- [Seguro] El bug real: en `src/iai_mcp/daemon/__init__.py`, la función
+  `_install_boot_signal_trace` construía la tupla
+  `(signal.SIGTERM, signal.SIGINT, signal.SIGHUP)` directamente en la
+  cláusula `for`, evaluada antes de que el `try/except` interno pudiera
+  protegerla. Eso crashea en Windows (sin `SIGHUP`) antes de que los
+  handlers de shutdown graceful, unas líneas más abajo, lleguen a
+  instalarse (esos sí ya usaban `getattr(signal, "SIGHUP", None)`).
+- [Seguro] Segundo bug, idéntico en dos copias que deben mantenerse
+  sincronizadas (`plugin/hooks/iai-mcp-turn-capture.sh` y
+  `src/iai_mcp/_deploy/hooks/iai-mcp-turn-capture.sh`): el hook de captura
+  por turno invocaba `/usr/bin/python3` con ruta fija (no existe en Git
+  Bash de Windows) e importaba `fcntl` sin guard (módulo POSIX-only). Esto
+  causaba `rc=127` en cada turno en Windows, es decir, la captura ambiental
+  ("nunca digo 'recuérdalo'") estaba rota de fondo en esa plataforma.
+- [Seguro] El transporte del daemon para Windows **sí existe** en el
+  código: `src/iai_mcp/_ipc.py` implementa TCP loopback
+  (`127.0.0.1:<puerto efímero>`) con autenticación por token vía `icacls`,
+  agregado en el commit `6bfc5d9` ("Add Windows support..."), ya en `main`
+  desde antes del Release 3.0.0. Esto contradice la lectura inicial de que
+  "el soporte Windows no existía"; lo que se vio ayer (atascado sin socket)
+  probablemente era el daemon quedándose en otro punto antes de llegar a
+  bindear esa capa, no una ausencia de la capa misma.
+- [Probable] El atascamiento visto ayer (CPU plana, sin traceback) podría
+  desaparecer solo con el fix de `SIGHUP` si el daemon simplemente no había
+  llegado tan lejos antes. No confirmado: no se ha vuelto a correr en la
+  máquina Windows real desde que se subieron los parches.
+
+## Commits aplicados (ya en `main` de `oscampo/iai-personal-memory-engine`)
+
+1. `7e576682` — guard de `SIGHUP` en `_install_boot_signal_trace`
+   (`src/iai_mcp/daemon/__init__.py`).
+2. `c94e996f` — resolución de intérprete Python + guard de `fcntl` en
+   `plugin/hooks/iai-mcp-turn-capture.sh`.
+3. `b31a489b` — mismo fix, copia sincronizada en
+   `src/iai_mcp/_deploy/hooks/iai-mcp-turn-capture.sh`.
+
+## Conclusión
+
+El camino correcto sigue siendo terminar el port a Windows sobre el fork
+propio, no adoptar una herramienta externa (Valera Studio Harness, un
+wrapper de Claude Code CLI sin componente MCP, evaluado y descartado en
+este mismo hilo por no cubrir el caso de uso donde el MCP de iai-mcp ya
+funciona). Los dos bugs identificados con traceback en mano ya están
+corregidos y subidos. Queda por confirmar si eso basta para un boot limpio.
+
+## Próximo paso concreto
+
+En la máquina Windows: `git pull` sobre el fork, reinstalar
+(`pip install .` desde el checkout, o reemplazar el paquete en el venv ya
+activo), y repetir `iai-mcp daemon install` / arranque, con el mismo
+protocolo de diagnóstico de ayer (`Get-CimInstance` para confirmar
+proceso, revisar `task-stderr.log` y el log del daemon). Si vuelve a
+atascarse en el mismo punto (sin traceback, sin socket, CPU plana), el
+siguiente paso es leer `_ipc.py` y el arranque del `SocketServer` con el
+traceback real en mano, en vez de suponer.
+
+## Destino Code
+
+- **Repo:** `oscampo/iai-personal-memory-engine` (fork de
+  `CodeAbra/iai-personal-memory-engine`), rama `main`.
+- **Módulos relevantes al problema de Windows:**
+  - `src/iai_mcp/daemon/__init__.py` — boot del daemon, FSM, señales
+    (ya parcheado en el punto de `SIGHUP`).
+  - `src/iai_mcp/_ipc.py` — capa de transporte multiplataforma (Unix
+    socket en POSIX, TCP loopback + token en Windows). Punto de partida
+    si el atascamiento persiste.
+  - `plugin/hooks/iai-mcp-turn-capture.sh` y
+    `src/iai_mcp/_deploy/hooks/iai-mcp-turn-capture.sh` — hooks de
+    captura ambiental (ya parcheados, mantener sincronizados a mano si se
+    tocan de nuevo).
+  - `src/iai_mcp/_flock.py` — el shim de locking POSIX/Windows ya
+    existente en el paquete, usado como referencia para el fix del hook
+    (el hook no pudo importarlo directamente porque corre bajo el Python
+    del sistema, no el venv).
+- **Resultado esperado de la siguiente sesión de Code:** correr el daemon
+  en Windows real, capturar el traceback o confirmar arranque limpio, y si
+  hace falta, localizar y corregir el siguiente punto de fallo en
+  `_ipc.py` o en el arranque de `SocketServer`.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,111 +1,98 @@
-# Handoff → Code
+# Handoff → Cowork
 
 ## Origen
 
-Conversación en Chat, sesión del 17 de agosto de 2026. Empezó revisando un
-repo de terceros (`valera-studio-group/valera-studio-project`, un harness de
-memoria paginada para Claude Code CLI) como posible alternativa mientras se
-resolvía un problema real: iai-mcp no arrancaba en Windows.
+Conversación en Chat, sesión del 17 de agosto de 2026 (continuación de la
+sesión que ya resolvió el boot de Windows, ver commits `7e576682`,
+`c94e996f`, `b31a489b`, `1107640`, `23727ff`, todos en `main`, todos
+verificados end-to-end en la máquina real). Ese problema quedó cerrado.
+Este handoff es sobre uno nuevo, distinto: activar captura ambiental real
+en Claude Desktop.
 
 ## Contexto
 
-Ayer (sesión previa, no en este hilo) se diagnosticó que el daemon de
-iai-mcp crasheaba al bootear en Windows 11 con un traceback de
-`AttributeError: module 'signal' has no attribute 'SIGHUP'`. Tras aplicar un
-parche local, el daemon llegó más lejos pero se quedó atascado (CPU casi
-plana, sin nuevo traceback, sin socket abierto) durante varios minutos, sin
-llegar a confirmarse healthy. Esa sesión se detuvo ahí, sin escalar más a
-ciegas.
+Se diseñó (todavía a nivel de conversación, sin implementar) un sistema
+para reemplazar el rol de "memoria de largo plazo portable" de iai-pme por
+un vault de Obsidian sincronizado por git + LightRAG, dejando iai-pme
+únicamente como motor de recall semántico en vivo dentro de una sesión.
+Ese rediseño no es el foco de este handoff, se retoma después.
 
-En este hilo se comparó el fork (`oscampo/iai-personal-memory-engine`)
-contra el proyecto original (`CodeAbra/iai-personal-memory-engine`) y se
-encontraron y corrigieron dos bugs reales, ya subidos a `main` del fork.
+Durante la verificación se descubrió que `capture-hooks status` reporta
+`Claude Desktop: ... WIRED` de forma engañosa: eso solo confirma que
+`iai-mcp` está registrado como servidor MCP (`claude_desktop_config.json`),
+no que exista captura ambiental automática. Se probó en vivo: dos horas de
+conversación real en el Chat tab, cero registros nuevos en el store
+después. El Chat tab no tiene ningún mecanismo de hooks, estructuralmente,
+a diferencia de Claude Code.
+
+Se encontró que **Cowork sí tiene un mecanismo de hooks real**, vía el
+subcomando `iai-mcp cowork install/status`, que engancha
+`recall_hooks`/`capture_hooks` en el `cowork_settings.json` de cada
+"Cowork home". Se corrió `iai-mcp cowork install` en la máquina de casa:
+quedó el plugin "staged" en `~/.iai-mcp/claude-plugin`, pero no se pudo
+conectar porque **nunca se había abierto una sesión de Cowork en esta
+máquina** (`no Cowork homes found`).
 
 ## Hallazgos verificados
 
-- [Seguro] El fork de Oscar no tenía ningún commit propio: estaba al día
-  con `upstream/main` pero además 5 commits *atrás* (Release 3.0.2 y
-  siguientes). El parche de `SIGHUP` de la sesión de ayer nunca llegó a
-  commitearse, vivía solo (si acaso) en el working tree local de la máquina
-  Windows.
-- [Seguro] El bug de `SIGHUP` existe también en `upstream/main`, sin
-  arreglar: no es un problema del fork ni del entorno de Oscar, es un bug
-  real y reportable en `CodeAbra/iai-personal-memory-engine`.
-- [Seguro] El bug real: en `src/iai_mcp/daemon/__init__.py`, la función
-  `_install_boot_signal_trace` construía la tupla
-  `(signal.SIGTERM, signal.SIGINT, signal.SIGHUP)` directamente en la
-  cláusula `for`, evaluada antes de que el `try/except` interno pudiera
-  protegerla. Eso crashea en Windows (sin `SIGHUP`) antes de que los
-  handlers de shutdown graceful, unas líneas más abajo, lleguen a
-  instalarse (esos sí ya usaban `getattr(signal, "SIGHUP", None)`).
-- [Seguro] Segundo bug, idéntico en dos copias que deben mantenerse
-  sincronizadas (`plugin/hooks/iai-mcp-turn-capture.sh` y
-  `src/iai_mcp/_deploy/hooks/iai-mcp-turn-capture.sh`): el hook de captura
-  por turno invocaba `/usr/bin/python3` con ruta fija (no existe en Git
-  Bash de Windows) e importaba `fcntl` sin guard (módulo POSIX-only). Esto
-  causaba `rc=127` en cada turno en Windows, es decir, la captura ambiental
-  ("nunca digo 'recuérdalo'") estaba rota de fondo en esa plataforma.
-- [Seguro] El transporte del daemon para Windows **sí existe** en el
-  código: `src/iai_mcp/_ipc.py` implementa TCP loopback
-  (`127.0.0.1:<puerto efímero>`) con autenticación por token vía `icacls`,
-  agregado en el commit `6bfc5d9` ("Add Windows support..."), ya en `main`
-  desde antes del Release 3.0.0. Esto contradice la lectura inicial de que
-  "el soporte Windows no existía"; lo que se vio ayer (atascado sin socket)
-  probablemente era el daemon quedándose en otro punto antes de llegar a
-  bindear esa capa, no una ausencia de la capa misma.
-- [Probable] El atascamiento visto ayer (CPU plana, sin traceback) podría
-  desaparecer solo con el fix de `SIGHUP` si el daemon simplemente no había
-  llegado tan lejos antes. No confirmado: no se ha vuelto a correr en la
-  máquina Windows real desde que se subieron los parches.
-
-## Commits aplicados (ya en `main` de `oscampo/iai-personal-memory-engine`)
-
-1. `7e576682` — guard de `SIGHUP` en `_install_boot_signal_trace`
-   (`src/iai_mcp/daemon/__init__.py`).
-2. `c94e996f` — resolución de intérprete Python + guard de `fcntl` en
-   `plugin/hooks/iai-mcp-turn-capture.sh`.
-3. `b31a489b` — mismo fix, copia sincronizada en
-   `src/iai_mcp/_deploy/hooks/iai-mcp-turn-capture.sh`.
+- [Seguro] `claude_desktop_config.json` solo contiene `mcpServers`
+  (`github`, `iai-mcp`), sin ninguna sección de hooks. Confirmado leyendo
+  el archivo completo.
+- [Seguro] `episodes_recent` tras una sesión larga de Chat tab: 0 registros
+  nuevos. Solo los de pruebas manuales anteriores seguían ahí.
+- [Seguro] `iai-mcp cowork status` inicial: `status: INACTIVE`, `Cowork
+  homes: none found (desktop app absent or Cowork unused)`.
+- [Seguro] `iai-mcp cowork install` corrido: materializó el plugin
+  correctamente, pero no encontró ningún "Cowork home" donde engancharlo.
+  El mensaje del propio comando indica el paso que falta: *"rerun install
+  after the first Cowork session."*
+- Reportado en GitHub, dos issues abiertos hoy en
+  `CodeAbra/iai-personal-memory-engine`:
+  - `#113` — los tres bugs de Windows (ya resueltos en este fork) más dos
+    discrepancias de documentación (claim de Unix-socket-only falso en
+    Windows, tabla de `doctor` desactualizada: 27 documentados vs 30
+    reales).
+  - `#114` — específico de este hallazgo: `capture-hooks status` conflating
+    "MCP registrado en Desktop" con "hooks activos", cuando en realidad
+    solo Cowork tiene hooks reales y estaban INACTIVE.
 
 ## Conclusión
 
-El camino correcto sigue siendo terminar el port a Windows sobre el fork
-propio, no adoptar una herramienta externa (Valera Studio Harness, un
-wrapper de Claude Code CLI sin componente MCP, evaluado y descartado en
-este mismo hilo por no cubrir el caso de uso donde el MCP de iai-mcp ya
-funciona). Los dos bugs identificados con traceback en mano ya están
-corregidos y subidos. Queda por confirmar si eso basta para un boot limpio.
+No hay arreglo de configuración para captura ambiental en el Chat tab, es
+un límite estructural del producto. Cowork sí tiene el mecanismo correcto,
+solo falta activarlo con una sesión real.
 
 ## Próximo paso concreto
 
-En la máquina Windows: `git pull` sobre el fork, reinstalar
-(`pip install .` desde el checkout, o reemplazar el paquete en el venv ya
-activo), y repetir `iai-mcp daemon install` / arranque, con el mismo
-protocolo de diagnóstico de ayer (`Get-CimInstance` para confirmar
-proceso, revisar `task-stderr.log` y el log del daemon). Si vuelve a
-atascarse en el mismo punto (sin traceback, sin socket, CPU plana), el
-siguiente paso es leer `_ipc.py` y el arranque del `SocketServer` con el
-traceback real en mano, en vez de suponer.
+1. Confirmar que esta sesión de Cowork cuenta como "abrir Cowork por primera
+   vez" en esta máquina (o que ya existe un Cowork home previo).
+2. Correr `iai-mcp cowork install` de nuevo, ahora que el home debería
+   existir.
+3. Verificar con `iai-mcp cowork status` que pase de `INACTIVE` a `ACTIVE`.
+4. Prueba real, no solo status: después de un par de turnos en esta misma
+   sesión de Cowork, consultar `episodes_recent` (vía las tools MCP, o
+   `iai last` por CLI) y confirmar que aparece contenido nuevo de esta
+   conversación, sin haber llamado `memory_capture` a mano. Eso es lo único
+   que prueba que el hook realmente corrió y no solo que el plugin quedó
+   instalado.
+5. Si algo falla, capturar el error real (no asumir), de la misma forma
+   que se hizo esta semana con los bugs de Windows: traceback completo,
+   `iai-mcp doctor`, y el estado exacto de `cowork_settings.json` del home
+   correspondiente antes de tocar nada.
 
-## Destino Code
+## Destino Cowork
 
-- **Repo:** `oscampo/iai-personal-memory-engine` (fork de
-  `CodeAbra/iai-personal-memory-engine`), rama `main`.
-- **Módulos relevantes al problema de Windows:**
-  - `src/iai_mcp/daemon/__init__.py` — boot del daemon, FSM, señales
-    (ya parcheado en el punto de `SIGHUP`).
-  - `src/iai_mcp/_ipc.py` — capa de transporte multiplataforma (Unix
-    socket en POSIX, TCP loopback + token en Windows). Punto de partida
-    si el atascamiento persiste.
-  - `plugin/hooks/iai-mcp-turn-capture.sh` y
-    `src/iai_mcp/_deploy/hooks/iai-mcp-turn-capture.sh` — hooks de
-    captura ambiental (ya parcheados, mantener sincronizados a mano si se
-    tocan de nuevo).
-  - `src/iai_mcp/_flock.py` — el shim de locking POSIX/Windows ya
-    existente en el paquete, usado como referencia para el fix del hook
-    (el hook no pudo importarlo directamente porque corre bajo el Python
-    del sistema, no el venv).
-- **Resultado esperado de la siguiente sesión de Code:** correr el daemon
-  en Windows real, capturar el traceback o confirmar arranque limpio, y si
-  hace falta, localizar y corregir el siguiente punto de fallo en
-  `_ipc.py` o en el arranque de `SocketServer`.
+- **Objetivo de esta sesión:** activar y verificar hooks de captura
+  ambiental reales en Cowork (no solo confirmar que las tools MCP están
+  disponibles, eso ya se sabe que funciona).
+- **Comando clave:** `iai-mcp cowork install` /
+  `iai-mcp cowork status` (venv: `C:\Users\user\.iai-pme-venv\Scripts\`,
+  ya está en el `PATH` del usuario, no hace falta ruta completa en una
+  terminal nueva).
+- **Archivos relevantes:** el `cowork_settings.json` de cada Cowork home
+  (ruta exacta todavía no confirmada, la reporta el propio comando
+  `install` una vez que encuentra el home), y
+  `C:\Users\user\.iai-mcp\claude-plugin` (marketplace ya materializado).
+- **Resultado esperado:** `cowork status` → `ACTIVE`, y un `episodes_recent`
+  después de un par de turnos de esta sesión mostrando contenido capturado
+  solo, sin intervención manual.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,98 +1,109 @@
-# Handoff → Cowork
+# Handoff → Code
 
 ## Origen
 
-Conversación en Chat, sesión del 17 de agosto de 2026 (continuación de la
-sesión que ya resolvió el boot de Windows, ver commits `7e576682`,
-`c94e996f`, `b31a489b`, `1107640`, `23727ff`, todos en `main`, todos
-verificados end-to-end en la máquina real). Ese problema quedó cerrado.
-Este handoff es sobre uno nuevo, distinto: activar captura ambiental real
-en Claude Desktop.
+Sesión de Chat en Claude Desktop, 17-18 de agosto de 2026. Jornada larga:
+arrancó revisando un harness de terceros (descartado), siguió con el
+diagnóstico y fix de tres bugs reales de arranque en Windows, una
+verificación exhaustiva del propio README contra el comportamiento real,
+el diseño (a nivel conversación) de un sistema de memoria alternativo con
+Obsidian + LightRAG, y terminó investigando por qué la captura ambiental
+no llega a Cowork. Este handoff cubre el estado consolidado de todo lo que
+queda accionable sobre el fork en sí, no el diseño del sistema alternativo
+(ese vive solo en la conversación, no en código todavía).
 
 ## Contexto
 
-Se diseñó (todavía a nivel de conversación, sin implementar) un sistema
-para reemplazar el rol de "memoria de largo plazo portable" de iai-pme por
-un vault de Obsidian sincronizado por git + LightRAG, dejando iai-pme
-únicamente como motor de recall semántico en vivo dentro de una sesión.
-Ese rediseño no es el foco de este handoff, se retoma después.
+Tres bugs de arranque en Windows, diagnosticados con traceback real y
+`py-spy`, ya corregidos y **mergeados en `main`**: guard de `SIGHUP`
+(`daemon/__init__.py`), resolución de intérprete Python + guard de `fcntl`
+en el hook de captura (dos copias sincronizadas), y guard de
+`asyncio.start_unix_server` en `SocketServer.serve()` con un
+`done_callback` que ahora expone excepciones en vez de morir en silencio.
+Verificado end-to-end en la máquina real: `daemon status` limpio,
+`capture`/`recall` funcionando vía daemon.
 
-Durante la verificación se descubrió que `capture-hooks status` reporta
-`Claude Desktop: ... WIRED` de forma engañosa: eso solo confirma que
-`iai-mcp` está registrado como servidor MCP (`claude_desktop_config.json`),
-no que exista captura ambiental automática. Se probó en vivo: dos horas de
-conversación real en el Chat tab, cero registros nuevos en el store
-después. El Chat tab no tiene ningún mecanismo de hooks, estructuralmente,
-a diferencia de Claude Code.
-
-Se encontró que **Cowork sí tiene un mecanismo de hooks real**, vía el
-subcomando `iai-mcp cowork install/status`, que engancha
-`recall_hooks`/`capture_hooks` en el `cowork_settings.json` de cada
-"Cowork home". Se corrió `iai-mcp cowork install` en la máquina de casa:
-quedó el plugin "staged" en `~/.iai-mcp/claude-plugin`, pero no se pudo
-conectar porque **nunca se había abierto una sesión de Cowork en esta
-máquina** (`no Cowork homes found`).
+Aparte de eso, se hizo una verificación línea por línea del README contra
+el comportamiento real (no solo lectura), y se investigó a fondo por qué
+`iai-mcp cowork install` nunca logra activarse en esta instalación de
+Desktop. Ambas líneas produjeron hallazgos reportados como issues, algunos
+con trabajo de código pendiente, uno cerrado como no-accionable.
 
 ## Hallazgos verificados
 
-- [Seguro] `claude_desktop_config.json` solo contiene `mcpServers`
-  (`github`, `iai-mcp`), sin ninguna sección de hooks. Confirmado leyendo
-  el archivo completo.
-- [Seguro] `episodes_recent` tras una sesión larga de Chat tab: 0 registros
-  nuevos. Solo los de pruebas manuales anteriores seguían ahí.
-- [Seguro] `iai-mcp cowork status` inicial: `status: INACTIVE`, `Cowork
-  homes: none found (desktop app absent or Cowork unused)`.
-- [Seguro] `iai-mcp cowork install` corrido: materializó el plugin
-  correctamente, pero no encontró ningún "Cowork home" donde engancharlo.
-  El mensaje del propio comando indica el paso que falta: *"rerun install
-  after the first Cowork session."*
-- Reportado en GitHub, dos issues abiertos hoy en
-  `CodeAbra/iai-personal-memory-engine`:
-  - `#113` — los tres bugs de Windows (ya resueltos en este fork) más dos
-    discrepancias de documentación (claim de Unix-socket-only falso en
-    Windows, tabla de `doctor` desactualizada: 27 documentados vs 30
-    reales).
-  - `#114` — específico de este hallazgo: `capture-hooks status` conflating
-    "MCP registrado en Desktop" con "hooks activos", cuando en realidad
-    solo Cowork tiene hooks reales y estaban INACTIVE.
+- [Seguro] Los tres bugs de Windows están resueltos y mergeados: commits
+  `7e576682`, `c94e996f`, `b31a489b`, `1107640`, `23727ff`, todos en
+  `main`.
+- [Seguro] `doctor` corre **30 checks reales**, el README documenta solo
+  27: faltan `(ii) store embed identity`, `(aa) capture-state hygiene`,
+  `(bb) nightly insight mint` en la tabla.
+- [Seguro] La sección "Deployment surface" del README afirma "MCP
+  transport is a Unix domain socket. No TCP listener, no bind address, no
+  auth surface to misconfigure", lo cual es falso en Windows: hay TCP
+  loopback + token (`.daemon.port`, `.daemon.token`, implementado en
+  `_ipc.py`), sin que el README documente la excepción.
+- [Seguro] `capture-hooks status` reporta `Claude Desktop: ... WIRED` de
+  forma engañosa: solo confirma que `iai-mcp` está registrado como
+  servidor MCP en `claude_desktop_config.json`, no que haya captura
+  ambiental. Probado en vivo: una sesión larga en el Chat tab de Desktop
+  dejó **cero registros nuevos** en el store. El Chat tab no tiene ningún
+  mecanismo de hooks, estructuralmente.
+- [Seguro] Cowork sí tiene un mecanismo de hooks real y separado
+  (`iai-mcp cowork install/status`), pero `_looks_like_cowork_home()`
+  busca `cowork_settings.json`, `cowork_plugins/` o `.claude.json`, y
+  **ninguno de los tres existe** en esta versión de Desktop, confirmado
+  tras un ciclo completo de cierre + reapertura + sesión Cowork nueva.
+  `rpm/manifest.json` muestra que el mecanismo real de plugins en esta
+  versión es centralizado (marketplace con ID emitido por servidor), no
+  un archivo local.
+- [Seguro] La función manual de Desktop "Agregar marketplace → Agregar
+  desde un repositorio" falla con el mismo error tanto para el fork
+  (`oscampo/iai-personal-memory-engine`) como para el repo oficial
+  (`CodeAbra/iai-personal-memory-engine`, el que el propio README
+  documenta como camino canónico). Como el repo oficial falla igual,
+  **la causa no está en el código de este proyecto**, es un problema de
+  la propia función de Desktop, fuera del alcance de un fix aquí.
 
 ## Conclusión
 
-No hay arreglo de configuración para captura ambiental en el Chat tab, es
-un límite estructural del producto. Cowork sí tiene el mecanismo correcto,
-solo falta activarlo con una sesión real.
+Dos issues tienen trabajo de código concreto y ofrecido, listo para
+implementar. Uno quedó cerrado como no-accionable (documentado con
+evidencia, no requiere más trabajo de este lado).
 
 ## Próximo paso concreto
 
-1. Confirmar que esta sesión de Cowork cuenta como "abrir Cowork por primera
-   vez" en esta máquina (o que ya existe un Cowork home previo).
-2. Correr `iai-mcp cowork install` de nuevo, ahora que el home debería
-   existir.
-3. Verificar con `iai-mcp cowork status` que pase de `INACTIVE` a `ACTIVE`.
-4. Prueba real, no solo status: después de un par de turnos en esta misma
-   sesión de Cowork, consultar `episodes_recent` (vía las tools MCP, o
-   `iai last` por CLI) y confirmar que aparece contenido nuevo de esta
-   conversación, sin haber llamado `memory_capture` a mano. Eso es lo único
-   que prueba que el hook realmente corrió y no solo que el plugin quedó
-   instalado.
-5. Si algo falla, capturar el error real (no asumir), de la misma forma
-   que se hizo esta semana con los bugs de Windows: traceback completo,
-   `iai-mcp doctor`, y el estado exacto de `cowork_settings.json` del home
-   correspondiente antes de tocar nada.
+1. **Issue `#113`** (parte de documentación, los bugs de código ya están
+   resueltos): actualizar la tabla de `doctor` en el README para incluir
+   `(ii)`, `(aa)`, `(bb)`; corregir la sección "Deployment surface" para
+   aclarar que Windows usa TCP loopback + token, no Unix socket puro.
+2. **Issue `#114`**: dividir la línea `Claude Desktop: ... WIRED` de
+   `capture-hooks status` en dos, una para "MCP registrado" (Chat +
+   Cowork) y otra para "hooks de captura ambiental activos" (solo
+   Cowork, delegando a `cowork status`), y quitar "Desktop also wired"
+   del resumen `status: ACTIVE` salvo que Cowork esté realmente activo.
+3. **Issue `#119`**: sin trabajo de código. Ya documentado que la causa es
+   externa al proyecto (función de Desktop). Dejar como referencia para
+   quien llegue con el mismo síntoma.
+4. Considerar armar el PR de los puntos 1 y 2 contra `CodeAbra/main`
+   directamente (ambos issues ya ofrecieron mandar PR), no solo dejarlo en
+   el fork.
 
-## Destino Cowork
+## Destino Code
 
-- **Objetivo de esta sesión:** activar y verificar hooks de captura
-  ambiental reales en Cowork (no solo confirmar que las tools MCP están
-  disponibles, eso ya se sabe que funciona).
-- **Comando clave:** `iai-mcp cowork install` /
-  `iai-mcp cowork status` (venv: `C:\Users\user\.iai-pme-venv\Scripts\`,
-  ya está en el `PATH` del usuario, no hace falta ruta completa en una
-  terminal nueva).
-- **Archivos relevantes:** el `cowork_settings.json` de cada Cowork home
-  (ruta exacta todavía no confirmada, la reporta el propio comando
-  `install` una vez que encuentra el home), y
-  `C:\Users\user\.iai-mcp\claude-plugin` (marketplace ya materializado).
-- **Resultado esperado:** `cowork status` → `ACTIVE`, y un `episodes_recent`
-  después de un par de turnos de esta sesión mostrando contenido capturado
-  solo, sin intervención manual.
+- **Repo:** `oscampo/iai-personal-memory-engine` (fork de
+  `CodeAbra/iai-personal-memory-engine`), rama `main`, checkout local en
+  `C:\Users\user\source\iai-personal-memory-engine`.
+- **Issues relacionados:** `#113` (bugs de Windows resueltos + docs
+  pendientes), `#114` (wording de `capture-hooks status`), `#119`
+  (Cowork, cerrado como no-accionable, sin trabajo pendiente).
+- **Archivos relevantes para el trabajo pendiente:**
+  - `README.md` — sección `## Doctor` (tabla de checks) y
+    `### Deployment surface`, ambas necesitan corrección de texto.
+  - El módulo que arma el string de `capture-hooks status` (no
+    identificado por ruta exacta en esta sesión, localizarlo primero;
+    probablemente cerca de `_cowork.py` o `capture_hooks.py` bajo
+    `src/iai_mcp/cli/`).
+- **Resultado esperado de la siguiente sesión de Code:** los dos fixes de
+  documentación/wording implementados y, si tiene sentido, un PR armado
+  contra `CodeAbra/iai-personal-memory-engine` (no solo el fork), dado que
+  ambos issues ya ofrecieron ese camino.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -2,108 +2,68 @@
 
 ## Origen
 
-Sesión de Chat en Claude Desktop, 17-18 de agosto de 2026. Jornada larga:
-arrancó revisando un harness de terceros (descartado), siguió con el
-diagnóstico y fix de tres bugs reales de arranque en Windows, una
-verificación exhaustiva del propio README contra el comportamiento real,
-el diseño (a nivel conversación) de un sistema de memoria alternativo con
-Obsidian + LightRAG, y terminó investigando por qué la captura ambiental
-no llega a Cowork. Este handoff cubre el estado consolidado de todo lo que
-queda accionable sobre el fork en sí, no el diseño del sistema alternativo
-(ese vive solo en la conversación, no en código todavía).
+Sesión de Chat en Claude Desktop, 17-18 de agosto de 2026. Cierre de la
+jornada larga documentada en los handoffs anteriores (bugs de Windows,
+verificación del README, investigación de Cowork). Este handoff es
+deliberadamente corto: casi todo lo de esta jornada quedó cerrado.
 
 ## Contexto
 
-Tres bugs de arranque en Windows, diagnosticados con traceback real y
-`py-spy`, ya corregidos y **mergeados en `main`**: guard de `SIGHUP`
-(`daemon/__init__.py`), resolución de intérprete Python + guard de `fcntl`
-en el hook de captura (dos copias sincronizadas), y guard de
-`asyncio.start_unix_server` en `SocketServer.serve()` con un
-`done_callback` que ahora expone excepciones en vez de morir en silencio.
-Verificado end-to-end en la máquina real: `daemon status` limpio,
-`capture`/`recall` funcionando vía daemon.
-
-Aparte de eso, se hizo una verificación línea por línea del README contra
-el comportamiento real (no solo lectura), y se investigó a fondo por qué
-`iai-mcp cowork install` nunca logra activarse en esta instalación de
-Desktop. Ambas líneas produjeron hallazgos reportados como issues, algunos
-con trabajo de código pendiente, uno cerrado como no-accionable.
+Los issues `#113` (parte de documentación) y `#114` se implementaron en
+una sesión de Code anterior, en la rama `claude/handoff-context-8wd0k2`,
+sin poder correr el suite completo ahí (sandbox sin `numpy` ni el motor
+nativo). Esta sesión de Chat verificó ambos fixes en la máquina Windows
+real, con el entorno completo, y los mergeó.
 
 ## Hallazgos verificados
 
-- [Seguro] Los tres bugs de Windows están resueltos y mergeados: commits
-  `7e576682`, `c94e996f`, `b31a489b`, `1107640`, `23727ff`, todos en
-  `main`.
-- [Seguro] `doctor` corre **30 checks reales**, el README documenta solo
-  27: faltan `(ii) store embed identity`, `(aa) capture-state hygiene`,
-  `(bb) nightly insight mint` en la tabla.
-- [Seguro] La sección "Deployment surface" del README afirma "MCP
-  transport is a Unix domain socket. No TCP listener, no bind address, no
-  auth surface to misconfigure", lo cual es falso en Windows: hay TCP
-  loopback + token (`.daemon.port`, `.daemon.token`, implementado en
-  `_ipc.py`), sin que el README documente la excepción.
-- [Seguro] `capture-hooks status` reporta `Claude Desktop: ... WIRED` de
-  forma engañosa: solo confirma que `iai-mcp` está registrado como
-  servidor MCP en `claude_desktop_config.json`, no que haya captura
-  ambiental. Probado en vivo: una sesión larga en el Chat tab de Desktop
-  dejó **cero registros nuevos** en el store. El Chat tab no tiene ningún
-  mecanismo de hooks, estructuralmente.
-- [Seguro] Cowork sí tiene un mecanismo de hooks real y separado
-  (`iai-mcp cowork install/status`), pero `_looks_like_cowork_home()`
-  busca `cowork_settings.json`, `cowork_plugins/` o `.claude.json`, y
-  **ninguno de los tres existe** en esta versión de Desktop, confirmado
-  tras un ciclo completo de cierre + reapertura + sesión Cowork nueva.
-  `rpm/manifest.json` muestra que el mecanismo real de plugins en esta
-  versión es centralizado (marketplace con ID emitido por servidor), no
-  un archivo local.
-- [Seguro] La función manual de Desktop "Agregar marketplace → Agregar
-  desde un repositorio" falla con el mismo error tanto para el fork
-  (`oscampo/iai-personal-memory-engine`) como para el repo oficial
-  (`CodeAbra/iai-personal-memory-engine`, el que el propio README
-  documenta como camino canónico). Como el repo oficial falla igual,
-  **la causa no está en el código de este proyecto**, es un problema de
-  la propia función de Desktop, fuera del alcance de un fix aquí.
+- [Seguro] `#113` y `#114` verificados de punta a punta en la máquina
+  real: `iai-mcp doctor` corre 30 checks reales (coincide con el README
+  actualizado), `capture-hooks status` imprime las dos líneas separadas
+  correctamente (`MCP registered` / `ambient capture (Cowork)`), y
+  `pytest` sobre los tres archivos relevantes da 10 passed, 5 skipped, 0
+  failed (tras compilar `mcp-wrapper`, que no estaba buildeado en ese
+  checkout; los 4 fallos iniciales eran por eso, no por el fix).
+- [Seguro] Dos PRs abiertos como resultado:
+  - `oscampo/iai-personal-memory-engine` PR `#2` — **mergeado a `main`**
+    del fork.
+  - `CodeAbra/iai-personal-memory-engine` PR `#120` — **abierto, sin
+    mergear**, esperando decisión del mantenedor original (Areg).
+- [Seguro] `#119` (Cowork) sigue cerrado como no-accionable, causa externa
+  al proyecto, ya documentado con evidencia completa en el issue.
 
 ## Conclusión
 
-Dos issues tienen trabajo de código concreto y ofrecido, listo para
-implementar. Uno quedó cerrado como no-accionable (documentado con
-evidencia, no requiere más trabajo de este lado).
+No queda trabajo de código pendiente sobre `iai-pme` iniciado por esta
+jornada. El fork está limpio: los cinco fixes de Windows más los dos de
+documentación/wording, todos en `main`, todos verificados en la máquina
+real, no solo revisados en diff.
 
 ## Próximo paso concreto
 
-1. **Issue `#113`** (parte de documentación, los bugs de código ya están
-   resueltos): actualizar la tabla de `doctor` en el README para incluir
-   `(ii)`, `(aa)`, `(bb)`; corregir la sección "Deployment surface" para
-   aclarar que Windows usa TCP loopback + token, no Unix socket puro.
-2. **Issue `#114`**: dividir la línea `Claude Desktop: ... WIRED` de
-   `capture-hooks status` en dos, una para "MCP registrado" (Chat +
-   Cowork) y otra para "hooks de captura ambiental activos" (solo
-   Cowork, delegando a `cowork status`), y quitar "Desktop also wired"
-   del resumen `status: ACTIVE` salvo que Cowork esté realmente activo.
-3. **Issue `#119`**: sin trabajo de código. Ya documentado que la causa es
-   externa al proyecto (función de Desktop). Dejar como referencia para
-   quien llegue con el mismo síntoma.
-4. Considerar armar el PR de los puntos 1 y 2 contra `CodeAbra/main`
-   directamente (ambos issues ya ofrecieron mandar PR), no solo dejarlo en
-   el fork.
+1. **Nada urgente.** Si se retoma esta línea de trabajo, lo único
+   pendiente es reactivo: seguimiento del PR `#120` por si el mantenedor
+   de `CodeAbra` responde con comentarios o lo mergea.
+2. Si se quiere seguir contribuyendo al proyecto, dos áreas quedaron
+   identificadas pero sin issue abierto todavía:
+   - El editable install (`pip install -e .`) falla sin un compilador de
+     Rust configurado; el install normal (`pip install .` desde PyPI, wheel
+     prebuilt) no lo necesita. Podría documentarse mejor en el README o
+     detectarse con un mensaje de error más claro.
+   - El diseño de memoria alternativo (vault de Obsidian + LightRAG,
+     discutido en la conversación de Chat) sigue sin ningún código, solo
+     existe como decisión de arquitectura. Si se retoma, el punto de
+     partida ya identificado es enganchar la ingesta a
+     `oscampo/Research/Hechos/` en el mismo punto donde
+     `reflexion-diaria` hace commit.
 
 ## Destino Code
 
-- **Repo:** `oscampo/iai-personal-memory-engine` (fork de
-  `CodeAbra/iai-personal-memory-engine`), rama `main`, checkout local en
+- **Repo:** `oscampo/iai-personal-memory-engine`, rama `main` (limpia,
+  todo mergeado). Checkout local en
   `C:\Users\user\source\iai-personal-memory-engine`.
-- **Issues relacionados:** `#113` (bugs de Windows resueltos + docs
-  pendientes), `#114` (wording de `capture-hooks status`), `#119`
-  (Cowork, cerrado como no-accionable, sin trabajo pendiente).
-- **Archivos relevantes para el trabajo pendiente:**
-  - `README.md` — sección `## Doctor` (tabla de checks) y
-    `### Deployment surface`, ambas necesitan corrección de texto.
-  - El módulo que arma el string de `capture-hooks status` (no
-    identificado por ruta exacta en esta sesión, localizarlo primero;
-    probablemente cerca de `_cowork.py` o `capture_hooks.py` bajo
-    `src/iai_mcp/cli/`).
-- **Resultado esperado de la siguiente sesión de Code:** los dos fixes de
-  documentación/wording implementados y, si tiene sentido, un PR armado
-  contra `CodeAbra/iai-personal-memory-engine` (no solo el fork), dado que
-  ambos issues ya ofrecieron ese camino.
+- **Estado:** sin trabajo abierto. Este handoff es informativo, para que
+  la próxima sesión no repita verificaciones ya hechas ni reabra `#119`.
+- **Issues:** `#113` cerrado, `#114` cerrado, `#119` cerrado
+  (no-accionable). PR `#120` abierto en upstream, fuera de nuestro
+  control directo.

--- a/README.md
+++ b/README.md
@@ -456,11 +456,11 @@ iai-mcp    doctor · self-update · daemon {install,start,stop,restart,logs,paus
 
 `entity-backfill` derives `entity:` anchor tags from records captured before anchoring shipped, so names in old turns become matchable; `--refresh` recomputes the whole corpus. `blob-quarantine` tombstones machine-notification blobs that drown real records on any cue sharing their vocabulary. Both are dry-run by default and journal every change when applied.
 
-`doctor` runs 27 checks and repairs: `--apply` prompts before anything touching the store and renames corrupt state aside rather than deleting it; `--auto` is the unattended read-only subset your assistant invokes when the socket is unreachable 10s into a session. `self-update` upgrades the wheel, restarts the daemon and verifies by querying the running engine's version; it refuses source checkouts and leaves the running engine untouched if pip fails.
+`doctor` runs 30 checks and repairs: `--apply` prompts before anything touching the store and renames corrupt state aside rather than deleting it; `--auto` is the unattended read-only subset your assistant invokes when the socket is unreachable 10s into a session. `self-update` upgrades the wheel, restarts the daemon and verifies by querying the running engine's version; it refuses source checkouts and leaves the running engine untouched if pip fails.
 
 ### Deployment surface
 
-- MCP transport is a Unix domain socket. No TCP listener, no bind address, no auth surface to misconfigure.
+- MCP transport is a Unix domain socket on macOS and Linux — no TCP listener, no bind address, no auth surface to misconfigure. On Windows, where Unix domain sockets aren't available, it's TCP loopback (`127.0.0.1`, ephemeral port) with a random per-boot auth token: every connection must send the token as its first line, or it's closed immediately.
 - Store at `~/.iai-mcp/`, AES-256-GCM per record, key at `.crypto.key` mode `0600`, rotation and prior-key recovery supported.
 - Thirteen languages beyond English ship as an opt-in pack, one command to turn on (`iai lang add ru`) plus a re-embed. English-only is the default. See [Languages](#languages).
 - Embedder is swappable beyond that: `IAI_MCP_EMBED_PROVIDER=http` disables the native BGE model entirely (not constructed, not downloaded) and routes to a loopback endpoint, for a domain-specific model without a Python ML stack. Protocol in [`docs/EMBEDDERS.md`](docs/EMBEDDERS.md).
@@ -638,7 +638,7 @@ config file is something you can read.
 
 ## Doctor
 
-`iai-mcp doctor` runs 27 checks against the local engine, the store, the native engine, and the runtime state. Output is one line per check: PASS, WARN, or FAIL.
+`iai-mcp doctor` runs 30 checks against the local engine, the store, the native engine, and the runtime state. Output is one line per check: PASS, WARN, or FAIL.
 
 It also repairs what it finds. `--apply` walks the repairs it can make and asks before anything that touches your memory; corrupt state files and vector indexes are renamed aside so the engine rebuilds them, never deleted. `--auto` is the unattended subset — no prompts, no killed processes, no changes to the store — and your assistant runs it for you if the engine is still unreachable ten seconds into a session. In practice a stalled engine now fixes itself before you notice it stalled.
 
@@ -649,7 +649,7 @@ iai-mcp doctor
 ```
 
 <details>
-<summary><b>All 27 checks, one line each</b></summary>
+<summary><b>All 30 checks, one line each</b></summary>
 
 What it checks:
 
@@ -677,9 +677,12 @@ What it checks:
 | t | hippo_compacted freshness | Compaction has run recently |
 | u | recall centrality regression | Recall ranking hasn't regressed |
 | v | native Rust embedder | The Rust embedder is built and produces vectors |
+| ii | store embed identity | The store's vector-identity stamp matches the embedder the runtime would use |
 | w | no permanent-failed captures | No capture is stuck after exhausting its retries |
 | x | timestamps not collapsed | Record timestamps span a real range, not all-identical |
+| aa | capture-state hygiene | No stale or orphaned capture-queue state files |
 | y | RSS 24h plateau | Resident memory has settled rather than climbing across the last day |
+| bb | nightly insight mint | The nightly synthesis step is still producing insights |
 | z | AVX2 CPU support | CPU supports the instructions the native libs need |
 | + | update available | A newer release is on PyPI (checked once a day, silently skipped offline) |
 

--- a/plugin/hooks/iai-mcp-turn-capture.sh
+++ b/plugin/hooks/iai-mcp-turn-capture.sh
@@ -17,6 +17,25 @@
 set -u
 # Spool files must never be world-readable.
 umask 077
+
+# Locate a Python 3 interpreter. Prefer the one the MCP host was configured
+# with (IAI_MCP_PYTHON, matching the venv iai-pme installed into); fall back
+# to whatever python3/python resolves on PATH. /usr/bin/python3 does not
+# exist on every platform this hook runs on (e.g. Git Bash on Windows), so
+# it must never be hardcoded. Fail-safe: no interpreter found -> exit 0,
+# same as any other capture failure.
+PYBIN=""
+if [ -n "${IAI_MCP_PYTHON:-}" ] && [ -x "${IAI_MCP_PYTHON:-}" ]; then
+  PYBIN="$IAI_MCP_PYTHON"
+elif command -v python3 >/dev/null 2>&1; then
+  PYBIN="python3"
+elif command -v python >/dev/null 2>&1; then
+  PYBIN="python"
+fi
+if [ -z "$PYBIN" ]; then
+  exit 0
+fi
+
 input=$(cat 2>/dev/null || true)
 
 # Extract session_id and transcript_path in a single subprocess call.
@@ -24,7 +43,7 @@ _extract_tmp=$(mktemp 2>/dev/null || echo "/tmp/iai-mcp-turn-extract-$$.tmp")
 if command -v jq >/dev/null 2>&1; then
   printf '%s' "$input" | jq -r '(.session_id // "") + "\t" + (.transcript_path // "")' >"$_extract_tmp" 2>/dev/null
 else
-  printf '%s' "$input" | /usr/bin/python3 -c "
+  printf '%s' "$input" | "$PYBIN" -c "
 import json, sys
 try:
     d = json.load(sys.stdin)
@@ -54,7 +73,6 @@ case "$session_id" in
 esac
 
 PY_SCRIPT='
-import fcntl
 import hashlib
 import json
 import os
@@ -62,6 +80,30 @@ import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+
+try:
+    from fcntl import LOCK_EX, LOCK_NB, flock
+except ImportError:  # Windows: msvcrt shim, mirrors iai_mcp._flock.
+    # Self-contained on purpose: this script runs under whatever python3
+    # resolves on PATH, which is not guaranteed to be the venv iai-pme is
+    # installed into, so importing the package here is not reliable.
+    import errno as _errno
+    import msvcrt as _msvcrt
+
+    LOCK_EX = 0x2
+    LOCK_NB = 0x4
+
+    def flock(fd, operation):
+        _pos = os.lseek(fd, 0, os.SEEK_CUR)
+        os.lseek(fd, 0, os.SEEK_SET)
+        try:
+            mode = _msvcrt.LK_NBLCK if operation & LOCK_NB else _msvcrt.LK_LOCK
+            try:
+                _msvcrt.locking(fd, mode, 1)
+            except OSError as exc:
+                raise OSError(_errno.EAGAIN, "lock held (msvcrt)") from exc
+        finally:
+            os.lseek(fd, _pos, os.SEEK_SET)
 
 MAX_TURNS = 100_000
 
@@ -127,7 +169,7 @@ _lock_fd = os.open(
     os.O_WRONLY | os.O_CREAT, 0o600,
 )
 try:
-    fcntl.flock(_lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    flock(_lock_fd, LOCK_EX | LOCK_NB)
 except OSError:
     # Another carrier is draining this session right now; its walk covers
     # these lines.
@@ -697,11 +739,11 @@ except Exception:
 '
 
 if command -v timeout >/dev/null 2>&1; then
-  timeout 5 /usr/bin/python3 -c "$PY_SCRIPT" "$session_id" "$transcript_path" 2>/dev/null
+  timeout 5 "$PYBIN" -c "$PY_SCRIPT" "$session_id" "$transcript_path" 2>/dev/null
 elif command -v gtimeout >/dev/null 2>&1; then
-  gtimeout 5 /usr/bin/python3 -c "$PY_SCRIPT" "$session_id" "$transcript_path" 2>/dev/null
+  gtimeout 5 "$PYBIN" -c "$PY_SCRIPT" "$session_id" "$transcript_path" 2>/dev/null
 else
-  /usr/bin/python3 -c "$PY_SCRIPT" "$session_id" "$transcript_path" 2>/dev/null
+  "$PYBIN" -c "$PY_SCRIPT" "$session_id" "$transcript_path" 2>/dev/null
 fi
 rc=$?
 

--- a/src/iai_mcp/_deploy/hooks/iai-mcp-turn-capture.sh
+++ b/src/iai_mcp/_deploy/hooks/iai-mcp-turn-capture.sh
@@ -17,6 +17,25 @@
 set -u
 # Spool files must never be world-readable.
 umask 077
+
+# Locate a Python 3 interpreter. Prefer the one the MCP host was configured
+# with (IAI_MCP_PYTHON, matching the venv iai-pme installed into); fall back
+# to whatever python3/python resolves on PATH. /usr/bin/python3 does not
+# exist on every platform this hook runs on (e.g. Git Bash on Windows), so
+# it must never be hardcoded. Fail-safe: no interpreter found -> exit 0,
+# same as any other capture failure.
+PYBIN=""
+if [ -n "${IAI_MCP_PYTHON:-}" ] && [ -x "${IAI_MCP_PYTHON:-}" ]; then
+  PYBIN="$IAI_MCP_PYTHON"
+elif command -v python3 >/dev/null 2>&1; then
+  PYBIN="python3"
+elif command -v python >/dev/null 2>&1; then
+  PYBIN="python"
+fi
+if [ -z "$PYBIN" ]; then
+  exit 0
+fi
+
 input=$(cat 2>/dev/null || true)
 
 # Extract session_id and transcript_path in a single subprocess call.
@@ -24,7 +43,7 @@ _extract_tmp=$(mktemp 2>/dev/null || echo "/tmp/iai-mcp-turn-extract-$$.tmp")
 if command -v jq >/dev/null 2>&1; then
   printf '%s' "$input" | jq -r '(.session_id // "") + "\t" + (.transcript_path // "")' >"$_extract_tmp" 2>/dev/null
 else
-  printf '%s' "$input" | /usr/bin/python3 -c "
+  printf '%s' "$input" | "$PYBIN" -c "
 import json, sys
 try:
     d = json.load(sys.stdin)
@@ -54,7 +73,6 @@ case "$session_id" in
 esac
 
 PY_SCRIPT='
-import fcntl
 import hashlib
 import json
 import os
@@ -62,6 +80,30 @@ import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+
+try:
+    from fcntl import LOCK_EX, LOCK_NB, flock
+except ImportError:  # Windows: msvcrt shim, mirrors iai_mcp._flock.
+    # Self-contained on purpose: this script runs under whatever python3
+    # resolves on PATH, which is not guaranteed to be the venv iai-pme is
+    # installed into, so importing the package here is not reliable.
+    import errno as _errno
+    import msvcrt as _msvcrt
+
+    LOCK_EX = 0x2
+    LOCK_NB = 0x4
+
+    def flock(fd, operation):
+        _pos = os.lseek(fd, 0, os.SEEK_CUR)
+        os.lseek(fd, 0, os.SEEK_SET)
+        try:
+            mode = _msvcrt.LK_NBLCK if operation & LOCK_NB else _msvcrt.LK_LOCK
+            try:
+                _msvcrt.locking(fd, mode, 1)
+            except OSError as exc:
+                raise OSError(_errno.EAGAIN, "lock held (msvcrt)") from exc
+        finally:
+            os.lseek(fd, _pos, os.SEEK_SET)
 
 MAX_TURNS = 100_000
 
@@ -127,7 +169,7 @@ _lock_fd = os.open(
     os.O_WRONLY | os.O_CREAT, 0o600,
 )
 try:
-    fcntl.flock(_lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    flock(_lock_fd, LOCK_EX | LOCK_NB)
 except OSError:
     # Another carrier is draining this session right now; its walk covers
     # these lines.
@@ -697,11 +739,11 @@ except Exception:
 '
 
 if command -v timeout >/dev/null 2>&1; then
-  timeout 5 /usr/bin/python3 -c "$PY_SCRIPT" "$session_id" "$transcript_path" 2>/dev/null
+  timeout 5 "$PYBIN" -c "$PY_SCRIPT" "$session_id" "$transcript_path" 2>/dev/null
 elif command -v gtimeout >/dev/null 2>&1; then
-  gtimeout 5 /usr/bin/python3 -c "$PY_SCRIPT" "$session_id" "$transcript_path" 2>/dev/null
+  gtimeout 5 "$PYBIN" -c "$PY_SCRIPT" "$session_id" "$transcript_path" 2>/dev/null
 else
-  /usr/bin/python3 -c "$PY_SCRIPT" "$session_id" "$transcript_path" 2>/dev/null
+  "$PYBIN" -c "$PY_SCRIPT" "$session_id" "$transcript_path" 2>/dev/null
 fi
 rc=$?
 

--- a/src/iai_mcp/cli/_capture.py
+++ b/src/iai_mcp/cli/_capture.py
@@ -1073,22 +1073,46 @@ def cmd_capture_hooks_status(args: argparse.Namespace) -> int:
     print(f"Claude Code settings.json SessionStart:     {settings}  {'WIRED' if recall_wired else 'NOT WIRED'}")
     print(f"Claude Code settings.json per-turn recall:  {settings}  {'WIRED' if pt_wired else 'NOT WIRED'}")
 
+    # "MCP registered" (this section) is NOT the same thing as "ambient
+    # capture active": registering iai-mcp as an MCP server in
+    # claude_desktop_config.json makes it reachable from the Chat tab, which
+    # has no hook mechanism at all and produces zero ambient captures no
+    # matter how long a session runs. Real ambient capture in Desktop only
+    # exists in Cowork sessions, wired separately via `iai-mcp cowork
+    # install` — checked below, delegating to `cowork status`'s own logic.
     desktop_cfg = _cli._claude_desktop_config_path()
     if desktop_cfg is None:
-        desktop_line = "Claude Desktop: not installed"
-        desktop_wired = False
+        desktop_line = "Claude Desktop MCP registered:   not installed"
+        desktop_mcp_registered = False
     elif not desktop_cfg.exists():
-        desktop_line = f"Claude Desktop: {desktop_cfg} MISSING"
-        desktop_wired = False
+        desktop_line = f"Claude Desktop MCP registered:   {desktop_cfg} MISSING"
+        desktop_mcp_registered = False
     else:
         try:
             d = _json.loads(desktop_cfg.read_text(encoding="utf-8"))
-            desktop_wired = "iai-mcp" in d.get("mcpServers", {})
-            desktop_line = f"Claude Desktop: {desktop_cfg}  {'WIRED' if desktop_wired else 'NOT WIRED'}"
+            desktop_mcp_registered = "iai-mcp" in d.get("mcpServers", {})
+            desktop_line = (
+                f"Claude Desktop MCP registered:   {desktop_cfg}  "
+                f"{'WIRED' if desktop_mcp_registered else 'NOT WIRED'}"
+            )
         except (OSError, ValueError):
-            desktop_line = f"Claude Desktop: {desktop_cfg} (unreadable)"
-            desktop_wired = False
+            desktop_line = f"Claude Desktop MCP registered:   {desktop_cfg} (unreadable)"
+            desktop_mcp_registered = False
     print(desktop_line)
+
+    from iai_mcp.cli._cowork import _discover_cowork_homes, _home_wired
+
+    cowork_homes = _discover_cowork_homes()
+    cowork_ambient_active = bool(cowork_homes) and any(
+        _home_wired(home) for home in cowork_homes
+    )
+    if not cowork_homes:
+        print("Claude Desktop ambient capture (Cowork): no Cowork homes found — skipped")
+    else:
+        print(
+            "Claude Desktop ambient capture (Cowork): "
+            f"{'ACTIVE' if cowork_ambient_active else 'NOT WIRED'} — details: iai-mcp cowork status"
+        )
 
     ok = (
         dst.exists() and wired
@@ -1096,11 +1120,13 @@ def cmd_capture_hooks_status(args: argparse.Namespace) -> int:
         and dst_recall.exists() and recall_wired
         and pt_dst.exists() and pt_wired
     )
-    desktop_problem = desktop_cfg is not None and desktop_cfg.exists() and not desktop_wired
+    desktop_problem = (
+        desktop_cfg is not None and desktop_cfg.exists() and not desktop_mcp_registered
+    )
 
     if ok and not desktop_problem:
         print(f"\nstatus: ACTIVE — Stop + UserPromptSubmit + SessionStart + per-turn hooks wired "
-              f"(Claude Code{'; Desktop also wired' if desktop_wired else ''})")
+              f"(Claude Code{'; Desktop Cowork ambient capture also active' if cowork_ambient_active else ''})")
         return 0
     msg = []
     if not ok:

--- a/src/iai_mcp/daemon/__init__.py
+++ b/src/iai_mcp/daemon/__init__.py
@@ -1550,7 +1550,11 @@ def _install_boot_signal_trace() -> None:
         except Exception:  # noqa: BLE001 -- re-raise is best-effort
             os._exit(128 + int(signum))
 
-    for _sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+    _trace_signals = [signal.SIGTERM, signal.SIGINT]
+    _trace_sighup = getattr(signal, "SIGHUP", None)
+    if _trace_sighup is not None:
+        _trace_signals.append(_trace_sighup)
+    for _sig in _trace_signals:
         try:
             signal.signal(_sig, _trace)
         except (AttributeError, ValueError, OSError):

--- a/src/iai_mcp/daemon/__init__.py
+++ b/src/iai_mcp/daemon/__init__.py
@@ -1904,6 +1904,27 @@ async def main() -> int:
         # served during the boot window.
         _boot_socket_activity_mono: list[float] = [mcp_socket.last_activity_ts]
         mcp_socket_task = asyncio.create_task(mcp_socket.serve())
+
+        def _on_mcp_socket_task_done(task: "asyncio.Task") -> None:
+            # serve() is fire-and-forget: nothing else awaits this task, and
+            # main() otherwise only observes it at shutdown.wait() -- which
+            # never fires on its own. A serve() failure (like the Windows
+            # AttributeError on asyncio.start_unix_server, previously fixed)
+            # died completely silently: the rest of the daemon kept running,
+            # `daemon status` just said "not running", no traceback anywhere.
+            # Surface it loudly and trigger the normal shutdown path instead
+            # of leaving the process looking alive with no socket forever.
+            if task.cancelled():
+                return
+            exc = task.exception()
+            if exc is not None:
+                log.error(
+                    "mcp socket server task died unexpectedly; shutting down",
+                    exc_info=exc,
+                )
+                shutdown.set()
+
+        mcp_socket_task.add_done_callback(_on_mcp_socket_task_done)
         await asyncio.sleep(0.05)
 
         # The socket is live before any model construction: liveness must

--- a/src/iai_mcp/socket_server.py
+++ b/src/iai_mcp/socket_server.py
@@ -267,8 +267,17 @@ class SocketServer:
             env_path = os.environ.get("IAI_DAEMON_SOCKET_PATH")
             socket_path = Path(env_path) if env_path else SOCKET_PATH
 
-        sig = inspect.signature(asyncio.start_unix_server)
-        supports_cleanup_socket = "cleanup_socket" in sig.parameters
+        try:
+            sig = inspect.signature(asyncio.start_unix_server)
+            supports_cleanup_socket = "cleanup_socket" in sig.parameters
+        except AttributeError:
+            # asyncio.start_unix_server does not exist on Windows; the
+            # daemon boot silently swallowed this because serve() runs
+            # as an un-awaited asyncio.create_task(), so the socket
+            # never opened and no traceback ever surfaced. Confirmed
+            # with py-spy dump: MainThread was idle inside run_forever,
+            # not stuck in serve() at all -- the task had already died.
+            supports_cleanup_socket = False
 
         # One JSON-RPC request is one line; a relayed document upload
         # (base64, ≤25 MB raw) must fit the StreamReader line buffer.


### PR DESCRIPTION
## Qué arregla

Closes #113 (the doc portion — the three Windows boot bugs from that issue were already fixed upstream via #111, this closes the remaining README gaps) and closes #114.

1. **README**: the `doctor` table documented 27 checks, the command runs 30. Added `(ii) store embed identity`, `(aa) capture-state hygiene`, `(bb) nightly insight mint` in their actual `run_diagnosis()` order, updated the count in all three places that cited "27 checks". The "Deployment surface" section stated the transport is always a Unix domain socket with no exception; it now documents that Windows uses TCP loopback with a per-boot random auth token (`_ipc.py`) instead of contradicting the daemon's own behavior there.
2. **`capture-hooks status`**: the single `Claude Desktop: ... WIRED` line conflated "MCP registered in `claude_desktop_config.json`" with "ambient capture active" — the Chat tab has the former but never the latter (confirmed live: a long real session produced zero new captures, since Chat has no hook mechanism at all). Now prints two separate lines, with the capture-status one delegating to the same Cowork-home discovery `cowork status` already uses, so it reflects real hook wiring rather than just MCP-entry presence. The `status: ACTIVE` summary no longer claims "Desktop also wired" unless Cowork ambient capture is actually active.

## Verification

Ran on the real target Windows machine, not just reviewed in diff:

- `iai-mcp doctor`: 30 real checks, `(ii)`/`(aa)`/`(bb)` present and functioning.
- `iai-mcp capture-hooks status`: both new lines print correctly; since that machine currently has no discoverable Cowork home (a separate, Desktop-app-side issue, not something this project can fix — see #119 for the full investigation, including a control test against this exact repo), it correctly reports "no Cowork homes found — skipped" and the summary no longer overclaims about Desktop.
- `pytest tests/test_capture_hooks_install_registers_turn_hook.py tests/test_capture_hooks_install_registers_per_turn_recall.py tests/test_cowork_install.py`: 10 passed, 5 skipped, 0 failed.