### PR TITLE
Fix three Windows daemon-boot defects (silent serve() wedge, SIGHUP crash, elevation-requiring task XML)

### DIFF
--- a/src/iai_mcp/_deploy/windows/iai-mcp-daemon.xml
+++ b/src/iai_mcp/_deploy/windows/iai-mcp-daemon.xml
@@ -7,10 +7,12 @@
   <Triggers>
     <LogonTrigger>
       <Enabled>true</Enabled>
+      <UserId>{USER_ID}</UserId>
     </LogonTrigger>
   </Triggers>
   <Principals>
     <Principal id="Author">
+      <UserId>{USER_ID}</UserId>
       <LogonType>InteractiveToken</LogonType>
       <RunLevel>LeastPrivilege</RunLevel>
     </Principal>

--- a/src/iai_mcp/cli/_daemon.py
+++ b/src/iai_mcp/cli/_daemon.py
@@ -210,12 +210,30 @@ def _render_systemd_unit() -> str:
     return text
 
 
+def _windows_task_user_id() -> str:
+    r"""DOMAIN\user for the account registering the task.
+
+    The template pins both the logon trigger and the principal to this
+    account. Without an explicit <UserId>, Task Scheduler reads the
+    trigger as "at logon of ANY user" -- a machine-wide registration
+    that requires elevation, so schtasks /Create fails with
+    "Access is denied" from the normal unelevated shell the installer
+    runs in.
+    """
+    import getpass
+    import os as _os
+    user = _os.environ.get("USERNAME") or getpass.getuser()
+    domain = _os.environ.get("USERDOMAIN")
+    return f"{domain}\\{user}" if domain else user
+
+
 def _render_windows_task_xml() -> str:
     from iai_mcp import cli as _cli
     tmpl = _res.files("iai_mcp") / "_deploy" / "windows" / "iai-mcp-daemon.xml"
     text = tmpl.read_text(encoding="utf-8")
     text = text.replace("{START_CMD}", str(_cli.WINDOWS_START_CMD))
     text = text.replace("{WORK_DIR}", str(Path.home() / ".iai-mcp"))
+    text = text.replace("{USER_ID}", _windows_task_user_id())
     return text
 
 

--- a/src/iai_mcp/daemon/__init__.py
+++ b/src/iai_mcp/daemon/__init__.py
@@ -1558,7 +1558,14 @@ def _install_boot_signal_trace() -> None:
         except Exception:  # noqa: BLE001 -- re-raise is best-effort
             os._exit(128 + int(signum))
 
-    for _sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+    # SIGHUP resolved lazily: absent on Windows, where naming it in the
+    # tuple raises AttributeError before the per-signal guard below can
+    # catch it (the tuple is built before the loop body runs).
+    for _sig in (
+        _s
+        for _s in (signal.SIGTERM, signal.SIGINT, getattr(signal, "SIGHUP", None))
+        if _s is not None
+    ):
         try:
             signal.signal(_sig, _trace)
         except (AttributeError, ValueError, OSError):

--- a/src/iai_mcp/socket_server.py
+++ b/src/iai_mcp/socket_server.py
@@ -267,9 +267,6 @@ class SocketServer:
             env_path = os.environ.get("IAI_DAEMON_SOCKET_PATH")
             socket_path = Path(env_path) if env_path else SOCKET_PATH
 
-        sig = inspect.signature(asyncio.start_unix_server)
-        supports_cleanup_socket = "cleanup_socket" in sig.parameters
-
         # One JSON-RPC request is one line; a relayed document upload
         # (base64, ≤25 MB raw) must fit the StreamReader line buffer.
         _line_limit = 64 * 1024 * 1024
@@ -286,6 +283,17 @@ class SocketServer:
             finally:
                 shutdown_ipc()
             return
+
+        # POSIX only, and it MUST stay below the Windows return: asyncio
+        # exposes start_unix_server only on platforms with AF_UNIX, so
+        # probing it above the branch raises AttributeError on Windows
+        # before the loopback path can bind. serve() runs as a
+        # fire-and-forget task, so the failure is silent: the daemon
+        # boots, warms, and ticks its FSM while serving nothing, the
+        # port file is never written, and the watchdog kills the
+        # process as wedged when the cold-start grace expires.
+        sig = inspect.signature(asyncio.start_unix_server)
+        supports_cleanup_socket = "cleanup_socket" in sig.parameters
         inherited = _inherit_activated_socket()
         if inherited is not None:
             server = await asyncio.start_unix_server(

--- a/tests/test_daemon_boot_signal_trace.py
+++ b/tests/test_daemon_boot_signal_trace.py
@@ -32,9 +32,13 @@ def test_daemon_boot_window_signal_breadcrumb(monkeypatch, tmp_path):
     _install_boot_signal_trace()
 
     registered_sigs = {sig for sig, _handler in registered}
-    assert registered_sigs == {signal.SIGTERM, signal.SIGINT, signal.SIGHUP}
+    # SIGHUP exists only on POSIX; Windows registers the other two.
+    expected = {signal.SIGTERM, signal.SIGINT}
+    if hasattr(signal, "SIGHUP"):
+        expected.add(signal.SIGHUP)
+    assert registered_sigs == expected
     handlers = {handler for _sig, handler in registered}
-    assert len(handlers) == 1, "all three signals must map to the same handler"
+    assert len(handlers) == 1, "every signal must map to the same handler"
     trace = registered[0][1]
 
     # Guard: a failed monkeypatch would otherwise write the breadcrumb to
@@ -80,6 +84,7 @@ def test_daemon_boot_window_signal_breadcrumb(monkeypatch, tmp_path):
     assert kill_calls == [(os.getpid(), signal.SIGTERM)]
 
     # ordering: the SIG_DFL restore was recorded before the kill call.
+    # (one registration per available signal, plus the restore)
     state_at_kill = signal_state_at_kill[0]
-    assert len(state_at_kill) == 4
+    assert len(state_at_kill) == len(expected) + 1
     assert state_at_kill[-1] == (signal.SIGTERM, signal.SIG_DFL)

--- a/tests/test_windows_daemon_boot_regressions.py
+++ b/tests/test_windows_daemon_boot_regressions.py
@@ -1,0 +1,121 @@
+"""Regression witnesses for the three Windows daemon-boot defects fixed in
+fix/windows-daemon-boot. All platform-neutral: the Windows conditions are
+simulated (SIGHUP deleted, start_unix_server deleted, IS_WINDOWS forced), so
+the suite exercises them on POSIX CI too.
+
+The original failure chain on a real Windows 11 host, in order:
+
+1. ``_install_boot_signal_trace`` named ``signal.SIGHUP`` inside a tuple --
+   built before the loop body, so the per-signal AttributeError guard never
+   ran and the daemon died at boot, before anything else.
+2. ``SocketServer.serve`` probed ``asyncio.start_unix_server`` above its
+   ``IS_WINDOWS`` branch. asyncio exposes that symbol only where AF_UNIX
+   exists, so the probe raised before the loopback bind. serve() runs as a
+   fire-and-forget task, so the failure was SILENT: the daemon booted,
+   warmed, and ticked its FSM while serving nothing; the port file was never
+   written, every client reported "daemon not running", and the watchdog
+   killed the process as wedged when the cold-start grace expired -- on
+   every boot.
+3. The Task Scheduler XML had no <UserId> in its LogonTrigger or Principal,
+   which Windows reads as "at logon of ANY user" -- a machine-wide
+   registration needing elevation, so ``schtasks /Create`` failed with
+   "Access is denied" from the unelevated shell the installer runs in.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import signal
+
+
+def test_boot_signal_trace_survives_missing_sighup(monkeypatch, tmp_path):
+    """Windows has no signal.SIGHUP: installing the boot trace must skip it
+    rather than raise while building the signal tuple."""
+    from iai_mcp.daemon import _install_boot_signal_trace
+
+    monkeypatch.setattr(
+        "iai_mcp.daemon._watchdog._watchdog_log_path",
+        lambda: tmp_path / "watchdog.log",
+    )
+    monkeypatch.delattr("signal.SIGHUP", raising=False)
+
+    registered: list[int] = []
+    monkeypatch.setattr(
+        "signal.signal", lambda sig, handler: registered.append(sig)
+    )
+
+    _install_boot_signal_trace()  # must not raise
+
+    assert set(registered) == {signal.SIGTERM, signal.SIGINT}
+
+
+def test_serve_windows_path_never_touches_start_unix_server(monkeypatch):
+    """The POSIX capability probe must sit below the Windows return: on a
+    platform without asyncio.start_unix_server the loopback path has to bind
+    without evaluating the symbol at all."""
+    from iai_mcp.socket_server import SocketServer
+
+    monkeypatch.delattr("asyncio.start_unix_server", raising=False)
+    monkeypatch.setattr("iai_mcp._ipc.IS_WINDOWS", True)
+
+    served: list[bool] = []
+
+    class _FakeServer:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        def close(self):
+            pass
+
+        async def wait_closed(self):
+            pass
+
+    async def fake_start_ipc_server(handler, addr=None, *, limit=None):
+        served.append(True)
+        return _FakeServer(), ("127.0.0.1", 12345), True
+
+    monkeypatch.setattr("iai_mcp._ipc.start_ipc_server", fake_start_ipc_server)
+    monkeypatch.setattr("iai_mcp._ipc.shutdown_ipc", lambda addr=None: None)
+
+    server = SocketServer.__new__(SocketServer)
+    server.shutdown_event = asyncio.Event()
+    server.handle = None
+    server.shutdown_event.set()  # serve() should bind, observe shutdown, exit
+
+    asyncio.run(server.serve())  # AttributeError here is the regression
+
+    assert served == [True], "the Windows branch must reach the loopback bind"
+
+
+def test_windows_task_xml_pins_trigger_and_principal_to_user(monkeypatch):
+    """Without an explicit <UserId>, Task Scheduler treats the logon trigger
+    as any-user and demands elevation; the rendered XML must pin both the
+    trigger and the principal to the installing account."""
+    import defusedxml.ElementTree as ET
+
+    from iai_mcp.cli import _daemon
+
+    monkeypatch.setattr(_daemon, "_windows_task_user_id", lambda: "DOM\\alice")
+    rendered = _daemon._render_windows_task_xml()
+    assert "{USER_ID}" not in rendered
+
+    root = ET.fromstring(rendered)
+    ns = "{http://schemas.microsoft.com/windows/2004/02/mit/task}"
+    trigger_user = root.find(f"{ns}Triggers/{ns}LogonTrigger/{ns}UserId")
+    principal_user = root.find(f"{ns}Principals/{ns}Principal/{ns}UserId")
+    assert trigger_user is not None and trigger_user.text == "DOM\\alice"
+    assert principal_user is not None and principal_user.text == "DOM\\alice"
+
+
+def test_windows_task_user_id_resolves_from_environment(monkeypatch):
+    from iai_mcp.cli import _daemon
+
+    monkeypatch.setenv("USERNAME", "alice")
+    monkeypatch.setenv("USERDOMAIN", "DOM")
+    assert _daemon._windows_task_user_id() == "DOM\\alice"
+
+    monkeypatch.delenv("USERDOMAIN")
+    assert _daemon._windows_task_user_id() == "alice"


### PR DESCRIPTION
Windows install of 3.0.4 (manual path, per the README) produced a daemon that died or wedged on every boot. Three root causes, fixed in dependency order — found and verified live on Windows 11, Python 3.11, `cp311-win_amd64` wheel.

## 1. `signal.SIGHUP` in the boot signal trace (instant death)

`_install_boot_signal_trace` iterates `(signal.SIGTERM, signal.SIGINT, signal.SIGHUP)`. The tuple is built before the loop body runs, so the per-signal `except AttributeError` guard never fires — on Windows the daemon died at boot with:

```
AttributeError: module 'signal' has no attribute 'SIGHUP'
```

Fixed with the same `getattr(signal, "SIGHUP", None)` idiom the graceful-handler site in the same file already uses.

## 2. `asyncio.start_unix_server` probed above the `IS_WINDOWS` branch (silent wedge — the bad one)

`SocketServer.serve` ran

```python
sig = inspect.signature(asyncio.start_unix_server)
```

before its `if IS_WINDOWS:` branch. asyncio exposes `start_unix_server` only on platforms with AF_UNIX, so on Windows this raised `AttributeError` before the loopback bind. Because `serve()` is scheduled fire-and-forget, the failure was **silent**: the daemon booted, warmed the embedder, ran boot-warmup (110 ms), and ticked its FSM — while serving nothing. `.daemon.port` was never written, every client reported "daemon not running", `iai recall` quietly degraded to the bank fallback, and the watchdog killed the process as `reason=wedge` when the 600 s cold-start grace expired. Every boot, indefinitely.

Fix: move the POSIX capability probe below the Windows `return`.

## 3. Task XML registers machine-wide, so `schtasks /Create` needs elevation

The rendered task XML has no `<UserId>` in its `<LogonTrigger>` or `<Principal>`. Task Scheduler reads that as "at logon of ANY user" — a machine-wide registration requiring elevation — so `iai-mcp daemon install` fails with `ERROR: Access is denied` from the normal unelevated shell. Fixed by adding a `{USER_ID}` placeholder to both elements, rendered as `DOMAIN\user` of the installing account. Registration now succeeds unelevated; the task still runs as the same interactive user at `LeastPrivilege`.

## Tests

- New `tests/test_windows_daemon_boot_regressions.py` covers all three. The Windows conditions are simulated (SIGHUP deleted, `start_unix_server` deleted + `IS_WINDOWS` forced, user id stubbed), so they run red on the old code and green on this branch **on POSIX CI too**.
- `tests/test_daemon_boot_signal_trace.py` hardcoded the three-signal set and the 3+1 `signal.signal` call count; it now derives both from the platform — one more test that passes on Windows.

Verified on the Windows 11 host that hit this: with the three fixes the daemon binds in ~10 s, `iai-mcp doctor` goes 32/32, and recall serves semantic hits through the daemon.

```
tests/test_windows_daemon_boot_regressions.py  4 passed  (4 failed against unfixed src)
tests/test_daemon_boot_signal_trace.py         1 passed
tests/test_cli_daemon_install_windows.py       5 passed
tests/test_ipc_transport.py                    3 passed, 2 skipped
```

(`tests/test_iai_recall_fail_fast.py` has 2 failures on Windows both before and after this branch — pre-existing suite-port gap, untouched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
