### PR TITLE
feat: capture per-model attribution

### DIFF
--- a/src/iai_mcp/capture.py
+++ b/src/iai_mcp/capture.py
@@ -406,6 +406,45 @@ def _is_episodic_conversational(tier: str, role: str) -> bool:
     return tier == "episodic" and role in {"user", "assistant"}
 
 
+def _normalize_model(model: object) -> str | None:
+    """Return a bounded printable model label, or ``None`` for unknown input."""
+    if not isinstance(model, str):
+        return None
+    normalized = "".join(
+        char for char in model if char.isalnum() or char in " ._:/+-"
+    )
+    normalized = " ".join(normalized.split())
+    if not normalized:
+        return None
+    return normalized[:80]
+
+
+class _TranscriptModelText(str):
+    """A text value that preserves explicit transcript metadata for old callers."""
+
+    def __new__(cls, value: str, model: object) -> "_TranscriptModelText":
+        instance = super().__new__(cls, value)
+        instance.model = model
+        return instance
+
+
+def _with_transcript_model(text: str, model: object) -> str:
+    if model is None:
+        return text
+    return _TranscriptModelText(text, model)
+
+
+def _transcript_model(text: object) -> object | None:
+    return getattr(text, "model", None)
+
+
+def _event_model(*containers: object) -> object | None:
+    for container in containers:
+        if isinstance(container, dict) and "model" in container:
+            return container["model"]
+    return None
+
+
 def capture_turn(
     store: MemoryStore,
     *,
@@ -416,6 +455,7 @@ def capture_turn(
     role: str = "user",
     ts: str | None = None,
     source_uuid: str | None = None,
+    model: str | None = None,
     provenance_extra: dict | None = None,
     extra_tags: "list[str] | None" = None,
     near_dup_gate: bool = False,
@@ -433,6 +473,8 @@ def capture_turn(
     # would otherwise insert near-duplicates at cos 0.95+.
     if tier not in TIER_ENUM:
         return {"status": "skipped", "record_id": None, "reason": f"invalid tier {tier!r}"}
+
+    model = _normalize_model(model)
 
     text = (text or "").strip()
     # A durable working-tier result is stored byte-identical even below the
@@ -594,10 +636,15 @@ def capture_turn(
             ts_iso = now.isoformat()
             tags.append(_idem_tag(session_id, role, ts_iso, text, source_uuid=source_uuid))
 
-        provenance_list: list[dict] = [
-            {"ts": now.isoformat(), "cue": cue or "(auto-capture)",
-             "session_id": session_id, "role": role}
-        ]
+        provenance = {
+            "ts": now.isoformat(),
+            "cue": cue or "(auto-capture)",
+            "session_id": session_id,
+            "role": role,
+        }
+        if model is not None:
+            provenance["model"] = model
+        provenance_list: list[dict] = [provenance]
         if provenance_extra:
             provenance_list.append(dict(provenance_extra))
 
@@ -690,6 +737,7 @@ def _drain_write_pending(
     role: str = "user",
     ts: str | None = None,
     source_uuid: str | None = None,
+    model: str | None = None,
     provenance_extra: dict | None = None,
 ) -> dict[str, Any]:
     """Write a captured turn as a pending (un-embedded) row.
@@ -712,6 +760,7 @@ def _drain_write_pending(
     if tier not in TIER_ENUM:
         return {"status": "skipped", "record_id": None, "reason": f"invalid tier {tier!r}"}
 
+    model = _normalize_model(model)
     text = (text or "").strip()
     if len(text) < MIN_CAPTURE_LEN:
         return {"status": "skipped", "record_id": None, "reason": "too short"}
@@ -758,10 +807,15 @@ def _drain_write_pending(
                 _idem_tag(session_id, role, ts_iso, text, source_uuid=source_uuid)
             )
 
-        provenance_list: list[dict] = [
-            {"ts": now.isoformat(), "cue": cue or "(auto-capture)",
-             "session_id": session_id, "role": role}
-        ]
+        provenance = {
+            "ts": now.isoformat(),
+            "cue": cue or "(auto-capture)",
+            "session_id": session_id,
+            "role": role,
+        }
+        if model is not None:
+            provenance["model"] = model
+        provenance_list: list[dict] = [provenance]
         if provenance_extra:
             provenance_list.append(dict(provenance_extra))
 
@@ -869,6 +923,7 @@ def capture_transcript(
                 role=role,
                 ts=ts,
                 source_uuid=src_uuid,
+                model=_transcript_model(text),
             )
             status = result.get("status", "skipped")
             if status in counts:
@@ -1036,11 +1091,14 @@ class _ToolTrailerState:
                 self._pending = []
             return None
         role, text, src_uuid, ts = parsed
+        model = _transcript_model(text)
         if role == "assistant":
             # Floor on the BARE text: the trailer must never turn an
             # otherwise-skipped stub into a record.
             if len(text.strip()) >= MIN_CAPTURE_LEN:
-                text = text + _tools_trailer(self._pending + tools)
+                text = _with_transcript_model(
+                    text + _tools_trailer(self._pending + tools), model
+                )
                 self._pending = []
             else:
                 self._pending.extend(tools)
@@ -1086,7 +1144,15 @@ def _parse_transcript_obj(
             return None
         if _is_noise(text):
             return None
-        return role, text, payload.get("id") or obj.get("uuid"), obj.get("timestamp")
+        return (
+            role,
+            _with_transcript_model(
+                text,
+                _event_model(payload, obj),
+            ),
+            payload.get("id") or obj.get("uuid"),
+            obj.get("timestamp"),
+        )
     if "step_index" in obj and "source" in obj:
         # Antigravity transcript_full lines: conversational turns only —
         # tool views, history replays, and system steps are not dialogue.
@@ -1100,7 +1166,12 @@ def _parse_transcript_obj(
         text = str(obj.get("content") or "").strip()
         if not text or _is_noise(text):
             return None
-        return role, text, None, obj.get("created_at")
+        return (
+            role,
+            _with_transcript_model(text, _event_model(obj)),
+            None,
+            obj.get("created_at"),
+        )
     msg = obj.get("message") if isinstance(obj.get("message"), dict) else obj
     # Claude puts the role in top-level "type", Cursor in top-level "role"
     # with the content nested under "message".
@@ -1128,7 +1199,12 @@ def _parse_transcript_obj(
     # per-line uuid — assistant lines of one prompt share promptId, so
     # keying them by it would collapse a whole response into one idem.
     src_uuid = (obj.get("promptId") if role == "user" else None) or obj.get("uuid")
-    return role, text, src_uuid, obj.get("timestamp")
+    return (
+        role,
+        _with_transcript_model(text, _event_model(msg, obj)),
+        src_uuid,
+        obj.get("timestamp"),
+    )
 
 
 # Spool lines are AES-GCM-encrypted with the store's key FILE only — never
@@ -1313,6 +1389,7 @@ def write_deferred_event(
     cwd: str | None = None,
     ts: str | None = None,
     source_uuid: str | None = None,
+    model: str | None = None,
 ) -> Path:
     deferred_dir = deferred_captures_dir()
     deferred_dir.mkdir(parents=True, exist_ok=True)
@@ -1354,6 +1431,11 @@ def write_deferred_event(
         }
         if source_uuid:
             event["source_uuid"] = source_uuid
+        normalized_model = _normalize_model(
+            model if model is not None else _transcript_model(text)
+        )
+        if normalized_model is not None:
+            event["model"] = normalized_model
         fh.write(_encode_spool_line(event) + "\n")
         fh.flush()
         try:
@@ -1651,6 +1733,9 @@ def write_deferred_captures(
                     }
                     if src_uuid:
                         event["source_uuid"] = src_uuid
+                    model = _normalize_model(_transcript_model(text))
+                    if model is not None:
+                        event["model"] = model
                     fh.write(_encode_spool_line(event) + "\n")
         fh.flush()
         try:
@@ -2110,6 +2195,7 @@ def _drain_deferred_captures_locked(
                         role=role,
                         ts=ev.get("ts"),
                         source_uuid=ev.get("source_uuid"),
+                        model=ev.get("model"),
                         provenance_extra=(
                             {"cwd": header_cwd} if header_cwd else None
                         ),
@@ -2403,6 +2489,7 @@ def drain_permanent_failed_files(
                         role=role,
                         ts=ev.get("ts"),
                         source_uuid=ev.get("source_uuid"),
+                        model=ev.get("model"),
                     )
                     if result.get("status") in ("inserted", "reinforced"):
                         file_inserted += 1
@@ -2442,6 +2529,7 @@ def drain_permanent_failed_files(
                         role=role,
                         ts=src_ts,
                         source_uuid=src_uuid,
+                        model=_transcript_model(text),
                     )
                     if result.get("status") in ("inserted", "reinforced"):
                         file_inserted += 1
@@ -2590,6 +2678,7 @@ def _drain_active_live_captures_locked(
                 role=ev.get("role", "user"),
                 ts=ev.get("ts"),
                 source_uuid=ev.get("source_uuid"),
+                model=ev.get("model"),
             )
             status = result.get("status", "skipped")
             reason = str(result.get("reason", ""))

--- a/src/iai_mcp/session.py
+++ b/src/iai_mcp/session.py
@@ -265,10 +265,28 @@ def _candidate_session_id(rec: object) -> str:
         return ""
 
 
+def _model_label(rec: object) -> str:
+    try:
+        for entry in getattr(rec, "provenance", None) or []:
+            value = entry.get("model") if isinstance(entry, dict) else None
+            if not isinstance(value, str):
+                continue
+            model = " ".join(value.split())
+            model = "".join(
+                char for char in model if char.isalnum() or char in " ._:/+-"
+            )[:64]
+            if model:
+                return f"[model:{model}] "
+    except Exception:  # noqa: BLE001 -- attribution must never break the payload
+        pass
+    return ""
+
+
 def _origin_label(rec: object) -> str:
     # Ambient feeds mix every session and project; an unlabeled line reads as
     # "my recent work" and a parallel session's thread gets adopted as this
     # one's. The label names the origin so the model can attribute, not guess.
+    model_label = _model_label(rec)
     try:
         prov = getattr(rec, "provenance", None) or []
         cwd = ""
@@ -279,7 +297,7 @@ def _origin_label(rec: object) -> str:
         if cwd:
             import os as _os
 
-            return f"[{_os.path.basename(cwd.rstrip('/')) or cwd}] "
+            return f"[{_os.path.basename(cwd.rstrip('/')) or cwd}] {model_label}"
         sid = ""
         for entry in prov:
             if isinstance(entry, dict) and entry.get("session_id"):
@@ -288,10 +306,10 @@ def _origin_label(rec: object) -> str:
         if not sid:
             sid = str(getattr(rec, "session_id", "") or "")
         if sid and sid != "-":
-            return f"[s:{sid[:6]}] "
+            return f"[s:{sid[:6]}] {model_label}"
     except Exception:  # noqa: BLE001 -- labels must never break the payload
         pass
-    return ""
+    return model_label
 
 
 def _recent_thread_segment(

--- a/src/iai_mcp/working_tier.py
+++ b/src/iai_mcp/working_tier.py
@@ -103,6 +103,23 @@ def _cache_path(store: Any = None, session_id: str = "-") -> Path:
     return base / f".working-tier.{_sanitize_session_id(session_id)}.cached.md"
 
 
+def _model_label(record: Any) -> str:
+    try:
+        for entry in getattr(record, "provenance", None) or []:
+            value = entry.get("model") if isinstance(entry, dict) else None
+            if not isinstance(value, str):
+                continue
+            model = " ".join(value.split())
+            model = "".join(
+                char for char in model if char.isalnum() or char in " ._:/+-"
+            )[:64]
+            if model:
+                return f"[model:{model}] "
+    except Exception:  # noqa: BLE001 -- capture feed must remain fail-soft
+        pass
+    return ""
+
+
 def _render_snapshot(entry: WorkingSetEntry) -> str:
     lines = [
         "# Working tier — active task",
@@ -580,7 +597,7 @@ def update_from_record(record: Any, *, store: Any = None) -> None:
             text = _literal_surface_of(record)
             if text:
                 _bounded_append(
-                    entry.raw_sensory, text,
+                    entry.raw_sensory, f"{_model_label(record)}{text}",
                     max_slots=WORKING_TIER_MAX_SLOTS, allow_evict=True,
                 )
             # Advance the idle clock monotonically. The async write-queue flush

--- a/tests/test_model_attribution_capture.py
+++ b/tests/test_model_attribution_capture.py
@@ -1,0 +1,410 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="POSIX paths + UNIX socket semantics",
+)
+
+
+SESSION_ID = "model-attribution-session"
+TURN_TEXT = "A direct captured turn keeps its explicit model attribution."
+
+
+@pytest.fixture
+def iai_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("PYTHON_KEYRING_BACKEND", "keyring.backends.fail.Keyring")
+    monkeypatch.setenv("IAI_MCP_CRYPTO_PASSPHRASE", "model-attribution-test-passphrase")
+    monkeypatch.setenv("IAI_MCP_STORE", str(tmp_path / ".iai-mcp"))
+    monkeypatch.setenv("IAI_MCP_PATSEP_DRY_RUN", "false")
+    import keyring.core
+
+    keyring.core._keyring_backend = None
+    yield tmp_path
+    keyring.core._keyring_backend = None
+
+
+def _open_store():
+    from iai_mcp.store import MemoryStore
+
+    return MemoryStore()
+
+
+def test_explicit_model_survives_direct_capture_and_replay(iai_home):
+    from iai_mcp import session, working_tier
+    from iai_mcp.capture import capture_turn
+
+    store = _open_store()
+    source_uuid = "abababab-1111-2222-3333-444444444444"
+    ts = datetime.now(timezone.utc).isoformat()
+
+    inserted = capture_turn(
+        store,
+        cue="direct attribution test",
+        text=TURN_TEXT,
+        session_id=SESSION_ID,
+        role="user",
+        ts=ts,
+        source_uuid=source_uuid,
+        model="  gpt-5.6   terra  ",
+    )
+    replayed = capture_turn(
+        store,
+        cue="direct attribution replay",
+        text=TURN_TEXT,
+        session_id=SESSION_ID,
+        role="user",
+        ts=datetime.now(timezone.utc).isoformat(),
+        source_uuid=source_uuid,
+        model="different-model",
+    )
+
+    assert inserted["status"] == "inserted"
+    assert replayed["status"] == "reinforced"
+    assert replayed["record_id"] == inserted["record_id"]
+
+    record = store.get(UUID(inserted["record_id"]))
+    assert record is not None
+    assert record.provenance[0]["model"] == "gpt-5.6 terra"
+    assert session._recent_thread_segment(store, max_records=5).count(
+        "[model:gpt-5.6 terra]"
+    ) == 1
+
+    entry = working_tier.read_task(session_id=SESSION_ID)
+    assert entry is not None
+    assert working_tier._render_snapshot(entry).count(
+        "[model:gpt-5.6 terra]"
+    ) == 1
+
+    store.close()
+    reopened = _open_store()
+    persisted = reopened.get(UUID(inserted["record_id"]))
+    assert persisted is not None
+    assert persisted.provenance[0]["model"] == "gpt-5.6 terra"
+
+
+def test_missing_or_malformed_model_has_no_display_label(iai_home):
+    from iai_mcp import session
+    from iai_mcp.capture import capture_turn
+
+    store = _open_store()
+    outcome = capture_turn(
+        store,
+        cue="missing attribution test",
+        text="A turn without a model keeps legacy attribution behavior.",
+        session_id="missing-model-session",
+        role="user",
+        ts=datetime.now(timezone.utc).isoformat(),
+        source_uuid="cdcdcdcd-1111-2222-3333-444444444444",
+    )
+
+    assert outcome["status"] == "inserted"
+    record = store.get(UUID(outcome["record_id"]))
+    assert record is not None
+    assert "model" not in record.provenance[0]
+    assert "[model:" not in session._origin_label(record)
+
+    malformed = SimpleNamespace(provenance=[{"model": ["not", "a", "label"]}])
+    assert "[model:" not in session._origin_label(malformed)
+
+    sanitized = capture_turn(
+        store,
+        cue="sanitized attribution test",
+        text="A model label must not persist control or display delimiters.",
+        session_id="sanitized-model-session",
+        role="user",
+        ts=datetime.now(timezone.utc).isoformat(),
+        source_uuid="dededede-1111-2222-3333-444444444444",
+        model="model\x00[label]",
+    )
+    sanitized_record = store.get(UUID(sanitized["record_id"]))
+    assert sanitized_record is not None
+    assert sanitized_record.provenance[0]["model"] == "modellabel"
+
+
+def test_deferred_event_preserves_its_own_model_on_replay(iai_home):
+    from iai_mcp.capture import (
+        capture_turn,
+        drain_active_live_captures,
+        write_deferred_event,
+    )
+
+    store = _open_store()
+    session_id = "deferred-model-session"
+    model_text = "A deferred event preserves the model from its own envelope."
+    missing_text = "A neighboring deferred event has no explicit model value."
+    source_uuid = "efefefef-1111-2222-3333-444444444444"
+
+    capture_turn(
+        store,
+        cue="surrounding model",
+        text="A surrounding turn has a distinct explicit model attribution.",
+        session_id=session_id,
+        role="user",
+        ts=datetime.now(timezone.utc).isoformat(),
+        source_uuid="fefefefe-1111-2222-3333-444444444444",
+        model="surrounding-model",
+    )
+    write_deferred_event(
+        session_id,
+        "user",
+        model_text,
+        ts=datetime.now(timezone.utc).isoformat(),
+        source_uuid=source_uuid,
+        model="deferred-model",
+    )
+    drain_active_live_captures(store, exclude_session_id="-")
+
+    write_deferred_event(
+        session_id,
+        "user",
+        model_text,
+        ts=datetime.now(timezone.utc).isoformat(),
+        source_uuid=source_uuid,
+        model="replacement-model",
+    )
+    write_deferred_event(
+        session_id,
+        "user",
+        missing_text,
+        ts=datetime.now(timezone.utc).isoformat(),
+        source_uuid="abababab-9999-2222-3333-444444444444",
+    )
+    drain_active_live_captures(store, exclude_session_id="-")
+
+    records = store.recent_user_turns(n=20, session_id=session_id)
+    attributed = [record for record in records if record.literal_surface == model_text]
+    assert len(attributed) == 1
+    assert attributed[0].provenance[0]["model"] == "deferred-model"
+
+    unattributed = [record for record in records if record.literal_surface == missing_text]
+    assert len(unattributed) == 1
+    assert "model" not in unattributed[0].provenance[0]
+
+
+def test_standard_deferred_drain_preserves_model_through_retry_and_replay(
+    iai_home, monkeypatch
+):
+    from iai_mcp import capture
+
+    store = _open_store()
+    session_id = "standard-deferred-model-session"
+    source_uuid = "aaaaaaaa-2222-3333-4444-555555555555"
+    text = "A standard deferred drain retains its explicit model attribution."
+
+    first_live_path = capture.write_deferred_event(
+        session_id,
+        "user",
+        text,
+        ts=datetime.now(timezone.utc).isoformat(),
+        source_uuid=source_uuid,
+        model="standard-deferred-model",
+    )
+    first_live_path.rename(first_live_path.with_name("standard-deferred.jsonl"))
+
+    first_counts = capture.drain_deferred_captures(store)
+    assert first_counts["events_inserted"] == 1
+
+    retry_live_path = capture.write_deferred_event(
+        "retryable-deferred-model-session",
+        "user",
+        "A retryable deferred drain retains its explicit model attribution.",
+        ts=datetime.now(timezone.utc).isoformat(),
+        source_uuid="bbbbbbbb-2222-3333-4444-555555555555",
+        model="retryable-deferred-model",
+    )
+    retry_live_path.rename(retry_live_path.with_name("retryable-deferred.jsonl"))
+
+    original_write_pending = capture._drain_write_pending
+
+    def fail_retryable_write_pending(*args, **kwargs):
+        if kwargs.get("source_uuid") == "bbbbbbbb-2222-3333-4444-555555555555":
+            return {"status": "skipped", "reason": "insert-failed: transient"}
+        return original_write_pending(*args, **kwargs)
+
+    monkeypatch.setattr(capture, "_drain_write_pending", fail_retryable_write_pending)
+    failed_counts = capture.drain_deferred_captures(store)
+    assert failed_counts["events_skipped_insert_failed"] == 1
+    assert failed_counts["files_failed"] == 1
+
+    monkeypatch.setattr(capture, "_drain_write_pending", original_write_pending)
+    retry_path = next(
+        capture.deferred_captures_dir().glob("*.failed-*-attempt-1.jsonl")
+    )
+    os.utime(retry_path, (0, 0))
+
+    retry_counts = capture.drain_deferred_captures(store)
+    assert retry_counts["events_inserted"] == 1
+
+    replay_live_path = capture.write_deferred_event(
+        session_id,
+        "user",
+        text,
+        ts=datetime.now(timezone.utc).isoformat(),
+        source_uuid=source_uuid,
+        model="replacement-model",
+    )
+    replay_live_path.rename(replay_live_path.with_name("standard-deferred-replay.jsonl"))
+
+    replay_counts = capture.drain_deferred_captures(store)
+    assert replay_counts["events_reinforced"] == 1
+
+    standard_idem_tag = capture._idem_tag(
+        session_id,
+        "user",
+        "-",
+        text,
+        source_uuid=source_uuid,
+    )
+    retry_idem_tag = capture._idem_tag(
+        "retryable-deferred-model-session",
+        "user",
+        "-",
+        "A retryable deferred drain retains its explicit model attribution.",
+        source_uuid="bbbbbbbb-2222-3333-4444-555555555555",
+    )
+    standard_records = [
+        record for record in store.all_records() if standard_idem_tag in record.tags
+    ]
+    retry_records = [
+        record for record in store.all_records() if retry_idem_tag in record.tags
+    ]
+    assert len(standard_records) == 1
+    assert standard_records[0].provenance[0]["model"] == "standard-deferred-model"
+    assert len(retry_records) == 1
+    assert retry_records[0].provenance[0]["model"] == "retryable-deferred-model"
+
+
+def test_permanent_failed_recovery_preserves_model_and_first_attribution(iai_home):
+    from iai_mcp import capture
+
+    store = _open_store()
+    session_id = "permanent-recovery-model-session"
+    source_uuid = "cccccccc-2222-3333-4444-555555555555"
+    text = "A permanent failed recovery retains its explicit model attribution."
+
+    first_live_path = capture.write_deferred_event(
+        session_id,
+        "user",
+        text,
+        ts=datetime.now(timezone.utc).isoformat(),
+        source_uuid=source_uuid,
+        model="permanent-recovery-model",
+    )
+    first_live_path.rename(
+        first_live_path.with_name("permanent-recovery.permanent-failed-1.jsonl")
+    )
+
+    first_recovery = capture.drain_permanent_failed_files(store)
+    assert first_recovery["inserted"] == 1
+
+    replay_live_path = capture.write_deferred_event(
+        session_id,
+        "user",
+        text,
+        ts=datetime.now(timezone.utc).isoformat(),
+        source_uuid=source_uuid,
+        model="replacement-model",
+    )
+    replay_live_path.rename(
+        replay_live_path.with_name(
+            "permanent-recovery-replay.permanent-failed-1.jsonl"
+        )
+    )
+
+    replay_recovery = capture.drain_permanent_failed_files(store)
+    assert replay_recovery["inserted"] == 1
+
+    idem_tag = capture._idem_tag(
+        session_id,
+        "user",
+        "-",
+        text,
+        source_uuid=source_uuid,
+    )
+    records = [record for record in store.all_records() if idem_tag in record.tags]
+    assert len(records) == 1
+    assert records[0].provenance[0]["model"] == "permanent-recovery-model"
+
+
+def test_transcript_and_stop_hook_preserve_explicit_model(iai_home):
+    from iai_mcp.capture import capture_transcript, drain_active_live_captures
+    from iai_mcp.cli import cmd_capture_turn_deferred
+
+    transcript = iai_home / "model-attribution-transcript.jsonl"
+    explicit_text = "A transcript turn carries its own explicit model value."
+    unknown_text = "A transcript turn without a model remains unattributed."
+    transcript.write_text(
+        "\n".join(
+            json.dumps(item)
+            for item in (
+                {
+                    "type": "assistant",
+                    "uuid": "10101010-1111-2222-3333-444444444444",
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "message": {
+                        "role": "assistant",
+                        "content": explicit_text,
+                        "model": "transcript-model",
+                    },
+                },
+                {
+                    "type": "assistant",
+                    "uuid": "20202020-1111-2222-3333-444444444444",
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "message": {"role": "assistant", "content": unknown_text},
+                },
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    store = _open_store()
+    captured = capture_transcript(
+        store,
+        transcript,
+        session_id="transcript-model-session",
+    )
+    assert captured["inserted"] == 2
+
+    rc = cmd_capture_turn_deferred(
+        argparse.Namespace(
+            session_id="stop-hook-model-session",
+            transcript_path=str(transcript),
+            max_turns_per_call=10,
+        )
+    )
+    assert rc == 0
+    drain_active_live_captures(store, exclude_session_id="-")
+
+    records = store.all_records()
+    transcript_records = [
+        record
+        for record in records
+        if record.provenance[0].get("session_id") == "transcript-model-session"
+    ]
+    stop_hook_records = [
+        record
+        for record in records
+        if record.provenance[0].get("session_id") == "stop-hook-model-session"
+    ]
+    assert next(
+        record for record in transcript_records if record.literal_surface == explicit_text
+    ).provenance[0]["model"] == "transcript-model"
+    assert "model" not in next(
+        record for record in transcript_records if record.literal_surface == unknown_text
+    ).provenance[0]
+    assert next(
+        record for record in stop_hook_records if record.literal_surface == explicit_text
+    ).provenance[0]["model"] == "transcript-model"


### PR DESCRIPTION
## Summary

- capture optional explicit per-event model attribution without inferring missing values
- preserve attribution through transcript, Stop-hook, deferred drain/retry, and permanent-failed recovery paths
- keep working-tier records model-neutral while rendering a bounded provenance label when present

## Validation

- `pytest tests/test_model_attribution_capture.py -x` — 6 passed
- GSD goal verification — 5/5 must-haves passed
- GSD code review — clean (0 critical, 0 warnings, 0 info)
- one commit, exactly four implementation/test files

## Integration boundary

Host and sub-agent integrations that do not expose a stable explicit model remain unattributed; this change does not infer or discover model identity.

Draft only; intentionally unmerged.