### PR TITLE
Drain idle socket handlers so daemon shutdown cannot hang

### DIFF
--- a/src/iai_mcp/socket_server.py
+++ b/src/iai_mcp/socket_server.py
@@ -77,6 +77,7 @@ class SocketServer:
         self.last_activity_ts: float = time.monotonic()
         self.active_connections: int = 0
         self.shutdown_event: asyncio.Event = asyncio.Event()
+        self._handler_tasks: set[asyncio.Task[Any]] = set()
         self._state = state
 
     async def handle(
@@ -85,6 +86,9 @@ class SocketServer:
         writer: asyncio.StreamWriter,
     ) -> None:
         self.active_connections += 1
+        handler_task = asyncio.current_task()
+        if handler_task is not None:
+            self._handler_tasks.add(handler_task)
         try:
             while not reader.at_eof():
                 line = await reader.readline()
@@ -255,12 +259,30 @@ class SocketServer:
             pass
         finally:
             self.active_connections -= 1
+            if handler_task is not None:
+                self._handler_tasks.discard(handler_task)
             try:
                 writer.close()
                 await writer.wait_closed()
             except (OSError, ConnectionError):  # noqa: BLE001 -- cleanup is best-effort
                 pass
 
+
+    async def _drain_handler_tasks(self) -> None:
+        """Cancel live connection handlers and wait for them to unwind.
+
+        ``Server.wait_closed()`` returns only once every active connection has
+        been dropped (CPython 3.12.1+; before that it returned immediately even
+        with connections open). A handler parked on ``reader.readline()`` for an
+        idle client never drops on its own, so without this the shutdown blocks
+        until the supervisor's stop timeout and the daemon dies by SIGKILL.
+        """
+        handlers = [t for t in self._handler_tasks if not t.done()]
+        if not handlers:
+            return
+        for task in handlers:
+            task.cancel()
+        await asyncio.gather(*handlers, return_exceptions=True)
 
     async def serve(self, socket_path: Path | None = None) -> None:
         if socket_path is None:
@@ -279,9 +301,11 @@ class SocketServer:
                 self.handle, socket_path, limit=_line_limit,
             )
             try:
-                async with server:
+                try:
                     await self.shutdown_event.wait()
+                finally:
                     server.close()
+                    await self._drain_handler_tasks()
                     await server.wait_closed()
             finally:
                 shutdown_ipc()
@@ -311,9 +335,15 @@ class SocketServer:
                 pass
 
         try:
-            async with server:
+            try:
                 await self.shutdown_event.wait()
+            finally:
+                # Not `async with server:`. On cancellation the body is skipped
+                # and __aexit__ runs close()+wait_closed() with handlers still
+                # parked on readline(), which never returns. A finally runs the
+                # same teardown but drains the handlers first.
                 server.close()
+                await self._drain_handler_tasks()
                 await server.wait_closed()
         finally:
             if inherited is None and not supports_cleanup_socket:

--- a/tests/test_socket_shutdown_drains_idle_handlers.py
+++ b/tests/test_socket_shutdown_drains_idle_handlers.py
@@ -1,0 +1,81 @@
+"""Cancelling serve() must not hang on connections parked in readline().
+
+Regression test for the shutdown hang: with an idle client attached, the
+daemon took the full systemd stop timeout and died by SIGKILL on every stop.
+
+The mechanism is a CPython behaviour change. ``Server.wait_closed()`` returns
+only once every active connection has been dropped (3.12.1+; before that it
+returned immediately even with connections open). A handler parked on
+``reader.readline()`` for a client that sends nothing never drops on its own,
+so the teardown blocked there forever.
+
+Cancellation is the part that makes this subtle, and the reason this test
+cancels rather than setting ``shutdown_event``. ``daemon.main()`` sets the
+event and then immediately cancels the serve task, so the cancellation lands
+while ``serve`` is still parked on ``shutdown_event.wait()``. Any cleanup
+written in the body of an ``async with server:`` is skipped in that case, and
+``__aexit__`` runs ``close()`` + ``wait_closed()`` with the handlers still
+live. A fix that drains handlers in the body passes a test that only sets the
+event, and still hangs in production.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+if sys.platform == "win32":  # pragma: no cover -- POSIX socket path only
+    pytest.skip("unix socket path", allow_module_level=True)
+
+
+def test_cancelled_serve_drains_idle_connection() -> None:
+    from iai_mcp.socket_server import SocketServer
+
+    async def _drive() -> None:
+        with tempfile.TemporaryDirectory() as td:
+            sock_path = Path(td) / "d.sock"
+            srv = SocketServer(store=None, idle_secs=99999, state={"fsm_state": "WAKE"})
+            server_task = asyncio.create_task(srv.serve(socket_path=sock_path))
+
+            for _ in range(500):
+                if sock_path.exists():
+                    break
+                await asyncio.sleep(0.01)
+            assert sock_path.exists(), "socket never bound"
+
+            # Connect and send nothing: this is what parks handle() forever.
+            client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            client.connect(str(sock_path))
+            try:
+                for _ in range(500):
+                    if srv.active_connections > 0:
+                        break
+                    await asyncio.sleep(0.01)
+                assert srv.active_connections > 0, "handler never started"
+
+                # Exactly what daemon.main() does at teardown.
+                srv.shutdown_event.set()
+                server_task.cancel()
+
+                # Ten seconds is far below the 60s stop timeout that exposed
+                # this, and far above the ~0s a correct teardown needs.
+                try:
+                    await asyncio.wait_for(
+                        asyncio.gather(server_task, return_exceptions=True),
+                        timeout=10,
+                    )
+                except asyncio.TimeoutError:  # pragma: no cover -- the bug
+                    pytest.fail(
+                        "serve() did not finish within 10s of cancellation: the "
+                        "idle connection's handler was never drained, so "
+                        "wait_closed() blocked"
+                    )
+            finally:
+                client.close()
+
+    asyncio.run(_drive())


### PR DESCRIPTION
Fixes the shutdown hang reported in #158 (finding 3 there).

With any MCP client connected and idle, `systemctl --user stop iai-mcp-daemon` takes the full `TimeoutStopSec` and the daemon dies by SIGKILL. Every time, never cleanly. A SIGKILLed daemon cannot checkpoint or close its WAL, so this may also bear on the other findings in that issue, though I would not assume it.

## Cause

`Server.wait_closed()` returns only once every active connection has been dropped. From the CPython 3.12.3 stdlib source:

> Wait until server is closed and all connections are dropped. If the server is not closed, wait. If it is closed, but there are still active connections, wait.
>
> Historical note: In 3.11 and before, this was broken, returning immediately if the server was already closed, even if there were still active connections.

A `SocketServer.handle` task parked on `await reader.readline()` for an idle client never drops on its own, and nothing tracked or cancelled those tasks. On 3.11 and earlier that did not matter, because `wait_closed()` returned immediately. On 3.12.1+ it became load-bearing, which is why this can appear without any code change on your side. Worth checking against your CI matrix: a suite that runs on 3.11 would not catch it.

## Fix

Track the per-connection handler tasks on the `SocketServer` and cancel them before `wait_closed()`.

The `async with server:` had to go, and this is the part I would most like a second opinion on. `daemon.main()` sets `shutdown_event` and then immediately cancels the serve task (`daemon/__init__.py:3265` then `:3284`). The cancellation lands while `serve` is still parked on `shutdown_event.wait()`, which skips the `with` body entirely and runs `__aexit__` — calling `close()` and `wait_closed()` with the handlers still live. Draining in the body looks correct and still hangs in production. An explicit `try/finally` runs the same teardown on the path cancellation actually takes.

I kept the change to the socket server rather than bounding the `gather` in `daemon.main()` with a timeout, since that would cap the damage without addressing why the handlers never finish. Happy to reshape this if the intended connection lifecycle is different from what I assumed.

## Evidence

Measured on Ubuntu (LXC on Proxmox), Python 3.12.3, one idle client attached for the whole run, same daemon and store each time:

| Build | Idle client | Stop time | Outcome |
| --- | --- | --- | --- |
| stock 3.0.8 | attached | 60s | SIGKILL |
| drain inside the `with` body | attached | 60s | SIGKILL |
| drain in a `finally` (this PR) | attached | 0s | clean |

With no client attached, stock already stops cleanly in about 2s, which is what made this look intermittent at first.

The asyncio task dump during the hang, showing all four live tasks:

```
===== task dump 2026-09-02T08:21:44 shutdown_set=True =====
--- Task-1 done=False ---   coro: 'main'
  daemon/__init__.py:3285   await asyncio.gather(*_cancel_targets, return_exceptions=True)
--- Task-7 done=False ---   coro: 'SocketServer.serve'
  socket_server.py:314      async with server:
--- Task-147 done=False --- coro: 'SocketServer.handle'
  socket_server.py:90       line = await reader.readline()
--- Task-2299 done=False -- coro: 'SocketServer.handle'
  socket_server.py:90       line = await reader.readline()
```

`shutdown_set=True`, so the signal handler and `shutdown.wait()` both work correctly; the teardown is running and stuck five lines in. Two dumps 30s apart are identical, so it is wedged rather than slow. Note `serve` sits on line 314, the `async with`, not on the `wait_closed()` below it — that is what showed the body-drain version could not work.

## Tests

Added `tests/test_socket_shutdown_drains_idle_handlers.py`. It fails on stock (10s timeout, no completion) and passes with the fix.

The test cancels the serve task rather than only setting `shutdown_event`, deliberately: a test that only sets the event passes against the broken body-drain version. That distinction is in a comment so a future refactor does not quietly weaken it.

Existing socket suite on this branch: `tests/test_socket_server_dispatch.py`, `test_socket_concurrent_clients.py`, `test_socket_disconnect_reconnect.py`, `test_socket_activity_excludes_health_probe.py` all pass. `test_socket_fail_loud.py` has 2 failures ("daemon never bound socket within 30s") that reproduce identically on unpatched `main` in my environment, so they look environmental here rather than related to this change.

## Reproducing

Start the daemon, connect a client and send nothing, then stop it:

```python
import socket, os, time
s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
s.connect(os.path.expanduser("~/.iai-mcp/.daemon.sock"))
time.sleep(600)
```

Stock hangs for the full stop timeout; with this change it exits immediately.