### PR TITLE
Release 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1] - 2026-09-08
+
+### Fixed
+- The transcript sweeper no longer errors when two sweeps run concurrently on
+  the same session. `_write_sweep_state` now writes to a unique per-process
+  temp file, so running `transcript-sweep run` back to back no longer races on
+  a shared temp path and raises a spurious `FileNotFoundError` (surfaced as
+  `files_failed`). No data was lost — content is staged before the state write —
+  but the errors were alarming on a first run. (#165)
+
 ## [3.2.0] - 2026-09-08
 
 ### Added

--- a/mcp-wrapper/package.json
+++ b/mcp-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iai-mcp-wrapper",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "TypeScript MCP wrapper for IAI-MCP Python core",
   "author": "Areg Noya",
   "type": "module",

--- a/mcp-wrapper/src/index.ts
+++ b/mcp-wrapper/src/index.ts
@@ -78,7 +78,7 @@ export function buildServer(
   const server = new Server(
     {
       name: "iai-mcp",
-      version: "3.2.0",
+      version: "3.2.1",
     },
     {
       capabilities: { tools: {} },

--- a/mcp-wrapper/src/lifecycle.ts
+++ b/mcp-wrapper/src/lifecycle.ts
@@ -26,7 +26,7 @@ export const SOCKET_PROBE_DELAY_MS = 2_000;
 
 export const HEARTBEAT_SCHEMA_VERSION = 1;
 
-export const WRAPPER_VERSION = "3.2.0";
+export const WRAPPER_VERSION = "3.2.1";
 
 const LAUNCHCTL_BIN = "/bin/launchctl";
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "iai-memory",
   "displayName": "iai-pme — personal memory engine",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Persistent local memory for your assistant: every turn captured verbatim, relevant memory injected at session start and before each turn, and fourteen memory tools over MCP. Requires the iai-pme package (pip install iai-pme).",
   "author": {
     "name": "Areg Aramovich Noya",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iai-pme"
-version = "3.2.0"
+version = "3.2.1"
 description = "MCP server giving Claude persistent autistic-style memory + learning"
 authors = [{ name = "Areg Noya" }]
 requires-python = ">=3.11,<3.13"

--- a/src/iai_mcp/transcript_sweep.py
+++ b/src/iai_mcp/transcript_sweep.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 import re
+import secrets
 import sys
 import time
 from dataclasses import dataclass
@@ -204,15 +205,23 @@ def _write_sweep_state(session_id: str, state: "_SweepState") -> None:
     state_dir = capture_state_dir()
     state_dir.mkdir(parents=True, exist_ok=True)
     path = _sweep_state_path(session_id)
-    tmp_path = path.with_name(path.name + ".tmp")
+    # Unique per writer: two concurrent sweeps on the same session id must
+    # never share a tmp name, or the second os.replace loses the race and
+    # raises FileNotFoundError on the first one's already-consumed tmp file.
+    # Digits only (no dots/hex letters) so the name still matches the
+    # stale-tmp GC regex `\.tmp\d*$` in capture.py.
+    tmp_path = path.with_name(f"{path.name}.tmp{os.getpid()}{secrets.randbelow(1 << 64)}")
     payload = {
         "mtime_ns": state.mtime_ns,
         "size": state.size,
         "lines_swept": state.lines_swept,
         "pending_tools": list(state.pending_tools),
     }
-    tmp_path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
-    os.replace(tmp_path, path)
+    try:
+        tmp_path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+        os.replace(tmp_path, path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
 
 
 def _should_sweep(path: Path, prior: "_SweepState | None", *, now: float) -> bool:

--- a/tests/test_anticipation_economy.py
+++ b/tests/test_anticipation_economy.py
@@ -178,11 +178,11 @@ def _serve_one_recall_reply(sock_path: str, reply_obj: dict):
         srv.bind(sock_path)
         srv.listen(1)
         listening.set()
-        srv.settimeout(2.0)
+        srv.settimeout(30.0)
         try:
             conn, _ = srv.accept()
             try:
-                conn.settimeout(2.0)
+                conn.settimeout(30.0)
                 buf = b""
                 while b"\n" not in buf:
                     chunk = conn.recv(4096)
@@ -199,7 +199,7 @@ def _serve_one_recall_reply(sock_path: str, reply_obj: dict):
             accept_done.set()
 
     threading.Thread(target=_listener, daemon=True).start()
-    listening.wait(timeout=2.0)
+    listening.wait(timeout=30.0)
     return accept_done
 
 
@@ -241,7 +241,7 @@ def test_socket_recall_fires_by_default_without_the_env_var():
             [str(hook)], input='{"prompt":"remind me about alice"}',
             capture_output=True, text=True, env=env, timeout=10,
         )
-        done.wait(timeout=2)
+        done.wait(timeout=30)
         assert proc.returncode == 0
         assert "<iai-mcp-recall>" in proc.stdout
         assert "alice prefers dark mode" in proc.stdout

--- a/tests/test_iai_cli_version.py
+++ b/tests/test_iai_cli_version.py
@@ -6,7 +6,7 @@ from contextlib import redirect_stdout
 
 import pytest
 
-EXPECTED_VERSION = "3.2.0"
+EXPECTED_VERSION = "3.2.1"
 
 
 def test_canonical_version_is_expected():

--- a/tests/test_spread_activation_transfer.py
+++ b/tests/test_spread_activation_transfer.py
@@ -179,12 +179,12 @@ class TestTransferTerm:
         self, linked_setup, monkeypatch
     ):
         store, graph, assignment, *_ = linked_setup
+        monkeypatch.setattr("iai_mcp.pipeline._age_penalty", lambda created_at: 0.0)
         base = _recall(store, graph, assignment)
         monkeypatch.setenv("IAI_MCP_W_SPREAD_ACT", "0")
         off = _recall(store, graph, assignment)
         assert [h.record_id for h in base.hits] == [h.record_id for h in off.hits]
-        # The age penalty ticks with wall-clock between the two calls, so
-        # scores match only approximately.
+        # Recency term frozen so both recall calls compare at the same instant.
         for hb, ho in zip(base.hits, off.hits):
             assert ho.score == pytest.approx(hb.score, abs=1e-4)
 
@@ -192,6 +192,7 @@ class TestTransferTerm:
         self, linked_setup, monkeypatch
     ):
         store, graph, assignment, seed, linked, off = linked_setup
+        monkeypatch.setattr("iai_mcp.pipeline._age_penalty", lambda created_at: 0.0)
         base = _recall(store, graph, assignment)
         monkeypatch.setenv("IAI_MCP_W_SPREAD_ACT", "0.3")
         boosted = _recall(store, graph, assignment)
@@ -199,8 +200,7 @@ class TestTransferTerm:
         base_linked = _score_of(base, linked.id)
         boosted_linked = _score_of(boosted, linked.id)
         assert base_linked is not None and boosted_linked is not None
-        # Seed cosine 1.0, one hop: transfer = 0.3 * 1.0 * 0.6. The age
-        # penalty drifts a hair between calls, hence the loose tolerance.
+        # Seed cosine 1.0, one hop: transfer = 0.3 * 1.0 * 0.6.
         assert boosted_linked - base_linked == pytest.approx(0.18, abs=1e-4)
 
         for rid in (seed.id, off.id):

--- a/tests/test_transcript_sweep.py
+++ b/tests/test_transcript_sweep.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import json
+import threading
 import time
 from contextlib import redirect_stdout
 from datetime import datetime, timezone
@@ -636,3 +637,62 @@ def test_sweep_state_suffix_excluded_from_time_based_gc():
     end_idx = source.index(")", idx)
     tuple_block = source[idx:end_idx]
     assert ".transcript-sweep" not in tuple_block
+
+
+def test_write_sweep_state_concurrent_writers_same_session_do_not_race(iai_home, monkeypatch):
+    import os
+    import re
+    import iai_mcp.transcript_sweep as mod
+
+    session_id = "concurrent-writer-session"
+    real_replace = os.replace
+    barrier = threading.Barrier(2)
+    tmp_names: "list[str]" = []
+    tmp_names_lock = threading.Lock()
+
+    def barrier_replace(src, dst):
+        # Both writers must have finished their own tmp-file write before
+        # either is allowed to replace -- this forces the exact interleaving
+        # a real race requires, deterministically, instead of hoping for it.
+        with tmp_names_lock:
+            tmp_names.append(Path(src).name)
+        barrier.wait(timeout=5)
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(mod.os, "replace", barrier_replace)
+
+    errors: "list[BaseException]" = []
+    errors_lock = threading.Lock()
+
+    def writer(lines_swept: int) -> None:
+        try:
+            mod._write_sweep_state(
+                session_id,
+                mod._SweepState(mtime_ns=lines_swept, size=lines_swept, lines_swept=lines_swept),
+            )
+        except BaseException as exc:  # noqa: BLE001 -- collected and asserted below
+            with errors_lock:
+                errors.append(exc)
+
+    t1 = threading.Thread(target=writer, args=(1,))
+    t2 = threading.Thread(target=writer, args=(2,))
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert not t1.is_alive() and not t2.is_alive(), "a writer thread never finished"
+    assert errors == [], f"concurrent writers on the same session id raised: {errors!r}"
+
+    state_path = mod._sweep_state_path(session_id)
+    raw = json.loads(state_path.read_text(encoding="utf-8"))
+    assert set(raw) == {"mtime_ns", "size", "lines_swept", "pending_tools"}
+    assert raw["lines_swept"] in (1, 2)
+
+    # Regression guard: the stale-tmp GC in capture.py reaps orphans by
+    # matching `\.tmp\d*$` on the tmp basename. A tmp name that drifts from
+    # this shape (e.g. dots or hex letters) silently escapes that GC.
+    assert len(tmp_names) == 2
+    gc_pattern = re.compile(r"\.tmp\d*$")
+    for name in tmp_names:
+        assert gc_pattern.search(name), f"tmp name {name!r} would escape the stale-tmp GC"


### PR DESCRIPTION
Fixes a transcript-sweep concurrency race: two sweeps on the same session no longer collide on the state temp file (#165 follow-up, thanks @mbusch-regis). Also hardens two load-sensitive tests so the correctness gate stops flaking under CI contention. No API or storage change.

Platform: developed and tested on macOS; Linux and Windows are contributor-supported.